### PR TITLE
ci: publish releases to PyPI with Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pypi:
+    name: PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/factory-droid-openai
+    permissions:
+      # Trusted Publishing mints a short-lived OIDC token per run, so no
+      # long-lived PyPI credential is stored in the repository.
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.21"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Build distributions
+        run: uv build
+
+      # The built filename carries the version, so a tag that disagrees with
+      # pyproject.toml fails here instead of publishing the wrong artifact.
+      - name: Verify the build matches the release tag
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          test -f "dist/factory_droid_openai-${version}-py3-none-any.whl"
+          test -f "dist/factory_droid_openai-${version}.tar.gz"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/README.md
+++ b/README.md
@@ -158,23 +158,38 @@ Run Droid normally once if authentication or first-time setup is required.
 
 ## Installation
 
+Released versions are published to
+[PyPI](https://pypi.org/project/factory-droid-openai/).
+
 ### uv
+
+```bash
+uv tool install factory-droid-openai
+factory-droid-openai
+```
+
+### pipx
+
+```bash
+pipx install factory-droid-openai
+factory-droid-openai
+```
+
+### pip
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install factory-droid-openai
+.venv/bin/factory-droid-openai
+```
+
+### From source
 
 ```bash
 git clone https://github.com/mrwogu/factory-droid-openai.git
 cd factory-droid-openai
 uv sync
 uv run factory-droid-openai
-```
-
-### pip
-
-```bash
-git clone https://github.com/mrwogu/factory-droid-openai.git
-cd factory-droid-openai
-python3 -m venv .venv
-.venv/bin/python -m pip install .
-.venv/bin/factory-droid-openai
 ```
 
 The default address is `http://127.0.0.1:8787`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "mrwogu" }]
 keywords = ["factory", "droid", "openai", "llm", "api", "bridge"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Framework :: FastAPI",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",


### PR DESCRIPTION
Publishes the built distributions to PyPI when a GitHub release is published - the event release-please already emits after its PR is merged.

Uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), so no PyPI token is stored in the repository; the run mints a short-lived OIDC token instead.

## Before this can work

A pending publisher has to be created once on PyPI, since the project does not exist there yet:
https://pypi.org/manage/account/publishing/

| Field | Value |
|---|---|
| PyPI project name | `factory-droid-openai` |
| Owner | `mrwogu` |
| Repository name | `factory-droid-openai` |
| Workflow name | `publish.yml` |
| Environment name | `pypi` |

Once that exists, re-running this workflow against the `v1.0.0` release publishes 1.0.0; every later release publishes on merge of its release PR.