### PR TITLE
feat: add guarded Droid RPC integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.env
 .code-review-graph/
 .mypy_cache/
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl --fail http://127.0.0.1:8787/v1/chat/completions \
   }'
 ```
 
-Use an ID listed under `Available Models` by `droid exec --help`. The bridge
+Use an ID returned by `GET /v1/models`. The bridge
 forwards every model value except its `factory-droid` alias directly to Droid.
 The alias requests the Droid CLI's configured default instead of selecting a
 model explicitly. Examples below use explicit `gpt-5.4` and
@@ -52,7 +52,7 @@ model explicitly. Examples below use explicit `gpt-5.4` and
 
 | OpenAI capability | Status | Bridge behavior |
 |---|---|---|
-| Text chat completions | ✅ | Returns one assistant choice |
+| Text chat completions | ✅ | Returns one or more assistant choices |
 | System and developer messages | ✅ | Serialized with the complete transcript |
 | Non-streaming responses | ✅ | OpenAI-compatible JSON completion |
 | Streaming responses | ✅ | SSE chunks followed by `[DONE]` |
@@ -63,9 +63,9 @@ model explicitly. Examples below use explicit `gpt-5.4` and
 | Stop sequences | ✅ | `stop` truncates the reply and interrupts the Droid turn |
 | Reasoning output | ✅ | Emitted as `reasoning` and `reasoning_content` |
 | Token usage | ✅ | Includes cache read and write token details |
-| Model selection | ✅ | Alias uses the Droid default; other IDs are forwarded |
+| Model selection | ✅ | `/v1/models` discovers the authenticated account's current catalog |
 | Multimodal content | ⚠️ | Inline image and file data URIs use SDK attachments; remote URLs are rejected |
-| Structured outputs | ❌ | `response_format` and JSON schema enforcement are ignored |
+| Structured outputs | ✅ | `json_schema` and `json_object` are enforced by Droid and validated by the bridge |
 | Sampling controls | ❌ | `temperature`, `top_p`, penalties, and `seed` are ignored |
 | Multiple choices | ✅ | `n` runs that many Droid turns sequentially and returns `n` choices |
 | Log probabilities | ❌ | `logprobs` and `top_logprobs` are ignored |
@@ -92,7 +92,7 @@ model explicitly. Examples below use explicit `gpt-5.4` and
 ## Features
 
 - OpenAI-compatible `POST /v1/chat/completions`
-- OpenAI-compatible `GET /v1/models`
+- Dynamic OpenAI-compatible `GET /v1/models`
 - Non-streaming JSON responses
 - Streaming server-sent events with `[DONE]` termination
 - System, developer, user, assistant, and tool message mapping
@@ -104,10 +104,11 @@ model explicitly. Examples below use explicit `gpt-5.4` and
 - Inline image and document attachments over the native SDK channel
 - Stop sequences, `n` choices, and multiple tool calls per turn
 - Optional Droid session continuity across requests
+- Guarded context, compaction, fork, rename, and close session extensions
 - Client disconnect cancellation
-- Factory-native tool blocking
+- Discoverable, verified Factory-native tool disabling
 - Versioned and externally validated OpenAPI 3.1 contract
-- Strict typing, locked dependencies, and 97% test coverage
+- Strict typing, locked dependencies, and at least 95% branch coverage
 
 ## How it works
 
@@ -146,7 +147,7 @@ result in the next request.
 
 - Python 3.11 or newer
 - Installed Factory `droid` CLI
-- Authenticated Droid session
+- Authenticated Droid session or `FACTORY_API_KEY`
 
 Verify the CLI before starting the bridge:
 
@@ -155,6 +156,8 @@ droid --version
 ```
 
 Run Droid normally once if authentication or first-time setup is required.
+For service-account execution, export `FACTORY_API_KEY`; the Droid subprocess
+inherits it directly. The bridge does not rename or copy that credential.
 
 ## Installation
 
@@ -243,6 +246,37 @@ response = client.chat.completions.create(
 
 print(response.choices[0].message.content)
 ```
+
+### Structured output
+
+Use OpenAI `response_format` with either `json_schema` or `json_object`:
+
+```python
+response = client.chat.completions.create(
+    model="gpt-5.4",
+    messages=[{"role": "user", "content": "Pick an integer from 1 to 10."}],
+    response_format={
+        "type": "json_schema",
+        "json_schema": {
+            "name": "answer",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "integer"}},
+                "required": ["answer"],
+                "additionalProperties": False,
+            },
+        },
+    },
+)
+```
+
+The bridge sends the schema through Droid's native `outputFormat` RPC field,
+then independently parses and validates the completed JSON. Invalid JSON,
+duplicate keys, non-finite numbers, schema violations, and trailing output
+fail closed. Remote JSON Schema references are rejected. `response_format`
+cannot be combined with bridge text tools or `stop`. Structured streaming
+buffers the JSON until it validates, then emits it in one content chunk.
 
 ### Streaming
 
@@ -424,8 +458,13 @@ attachments, and parallel tool calls remain unsupported by this bridge.
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/health` | Process health check |
-| `GET` | `/v1/models` | Configured bridge model alias |
+| `GET` | `/v1/models` | Bridge alias and dynamically discovered Droid models |
 | `POST` | `/v1/chat/completions` | Chat completions and streaming |
+| `GET` | `/v1/factory/sessions/{id}/context` | Context statistics and breakdown |
+| `POST` | `/v1/factory/sessions/{id}/compact` | Compact history into a new session |
+| `POST` | `/v1/factory/sessions/{id}/fork` | Fork a session with context preserved |
+| `PATCH` | `/v1/factory/sessions/{id}` | Rename a session |
+| `DELETE` | `/v1/factory/sessions/{id}` | Close a session |
 | `GET` | `/metrics` | Prometheus-style bridge metrics |
 | `GET` | `/openapi.json` | OpenAPI 3.1 contract |
 | `GET` | `/docs` | Interactive Swagger UI |
@@ -469,7 +508,7 @@ tool calls through the official `openai` Python client.
 | `timeout` | Yes | Per-request value capped by server timeout |
 | `temperature`, `top_p`, penalties, `seed` | No | Accepted but ignored |
 | `max_tokens`, `max_completion_tokens` | No | Accepted but ignored |
-| `response_format` | No | Accepted but not enforced |
+| `response_format` | Yes | `json_schema` and `json_object`; validated again before completion |
 | `functions`, `function_call` | No | Legacy function-calling fields are ignored |
 | `modalities`, `audio` | No | Accepted but ignored |
 | `logprobs`, `top_logprobs`, `logit_bias` | No | Accepted but ignored |
@@ -505,8 +544,11 @@ client.chat.completions.create(
 )
 ```
 
-Run `droid exec --help` to list model IDs available in the installed Droid CLI.
-Availability also depends on the authenticated Factory account.
+Call `GET /v1/models` to list the bridge alias and the models currently
+available to the authenticated Droid CLI. Factory-specific metadata includes
+the display name, reasoning efforts, and image and PDF support. If discovery
+cannot start or authenticate Droid, the endpoint preserves compatibility by
+returning the bridge alias alone.
 
 ### Reasoning
 
@@ -580,6 +622,34 @@ Only sessions this bridge process created can be continued. Session IDs
 stored by the local Droid CLI - including your own interactive sessions - are
 rejected with HTTP `404`, so a client cannot read back conversations it does
 not own. Restarting the bridge clears the set of continuable sessions.
+
+The same guard applies to the Factory session extension endpoints. They are
+available only when continuity is enabled and only for IDs created by the
+current bridge process:
+
+```bash
+curl http://127.0.0.1:8787/v1/factory/sessions/$SESSION_ID/context
+
+curl -X POST \
+  http://127.0.0.1:8787/v1/factory/sessions/$SESSION_ID/compact \
+  -H 'Content-Type: application/json' \
+  -d '{"custom_instructions":"Keep API decisions."}'
+
+curl -X POST \
+  http://127.0.0.1:8787/v1/factory/sessions/$SESSION_ID/fork
+
+curl -X PATCH \
+  http://127.0.0.1:8787/v1/factory/sessions/$SESSION_ID \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"API design"}'
+
+curl -X DELETE \
+  http://127.0.0.1:8787/v1/factory/sessions/$SESSION_ID
+```
+
+Compaction and fork return a new `session_id`, which the bridge registers for
+later continuation. Context responses contain aggregate token categories, not
+message or prompt content.
 
 ### Droid status events
 
@@ -737,17 +807,19 @@ The OpenAI client, not Factory Droid, owns tool execution.
 
 For every Droid session, the bridge:
 
-1. Sets Droid autonomy to `off`.
-2. Cancels permission requests.
-3. Cancels interactive questions.
-4. Passes no additional enabled tool IDs.
-5. Rejects any Factory-native tool event.
-6. Validates generated tool names against the request schema.
-7. Requires tool arguments to be a JSON object with unique keys.
-8. Caps the number of tool calls accepted in one turn.
-9. Rejects any non-whitespace output between or after tool calls.
-10. Refuses to fetch remote attachment URLs.
-11. Only continues Droid sessions this bridge process created.
+1. Selects normal interaction mode with autonomy `off`.
+2. Requests no additional MCP servers from the SDK.
+3. Cancels permission requests and interactive questions.
+4. Gives configured MCP servers a bounded initialization window.
+5. Discovers the complete native and MCP tool catalog through `droid.list_tools`.
+6. Disables every discovered tool ID and verifies no unexpected tool remains.
+7. Rejects any Factory-native tool event as a second line of defense.
+8. Validates generated tool names against the request schema.
+9. Requires tool arguments to be a JSON object with unique keys.
+10. Caps the number of tool calls accepted in one turn.
+11. Rejects any non-whitespace output between or after tool calls.
+12. Refuses to fetch remote attachment URLs.
+13. Only continues Droid sessions this bridge process created.
 
 Set `FACTORY_DROID_OPENAI_WORKDIR` to the smallest directory required by your
 workflow.
@@ -761,6 +833,7 @@ This is a compatibility bridge, not a native OpenAI inference implementation.
 | No native SDK chat-history input | History is serialized into one prompt unless session continuity is enabled |
 | No native SDK external-tool schemas | Tool definitions are serialized into the prompt |
 | No native SDK tool-result continuation | Each request creates a new Droid session |
+| Python SDK protocol drift | A small isolated compatibility shim supplies structured output, tool controls, and session RPCs |
 | Session-per-request execution | Prompt caching differs from a native inference endpoint |
 | Strict tool marker protocol | Invalid generated tool payloads fail closed |
 | Sequential tool calls only | Calls arrive one after another, never concurrently |

--- a/README.md
+++ b/README.md
@@ -276,7 +276,10 @@ then independently parses and validates the completed JSON. Invalid JSON,
 duplicate keys, non-finite numbers, schema violations, and trailing output
 fail closed. Remote JSON Schema references are rejected. `response_format`
 cannot be combined with bridge text tools or `stop`. Structured streaming
-buffers the JSON until it validates, then emits it in one content chunk.
+buffers the JSON until it validates, then emits it in one content chunk, so no
+content chunks arrive while the model is generating. Buffered output is capped
+by `FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES`, and a schema larger than
+`FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES` is rejected with `413`.
 
 ### Streaming
 
@@ -546,9 +549,15 @@ client.chat.completions.create(
 
 Call `GET /v1/models` to list the bridge alias and the models currently
 available to the authenticated Droid CLI. Factory-specific metadata includes
-the display name, reasoning efforts, and image and PDF support. If discovery
-cannot start or authenticate Droid, the endpoint preserves compatibility by
-returning the bridge alias alone.
+the display name, reasoning efforts, and image and PDF support.
+
+Discovery starts a short-lived Droid session, so the catalog is cached for
+`FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS` and concurrent callers share a
+single discovery attempt. If discovery cannot start or authenticate Droid, the
+endpoint preserves compatibility by serving the last known catalog, or the
+bridge alias alone, and marks the response with the
+`x-factory-droid-model-discovery: degraded` header while incrementing
+`factory_droid_openai_model_discovery_failures_total`.
 
 ### Reasoning
 
@@ -649,7 +658,9 @@ curl -X DELETE \
 
 Compaction and fork return a new `session_id`, which the bridge registers for
 later continuation. Context responses contain aggregate token categories, not
-message or prompt content.
+message or prompt content. Context, fork, rename, and close run no model turn,
+so they leave the session's tool settings untouched; compaction runs a turn and
+therefore disables the tool catalog first.
 
 ### Droid status events
 
@@ -714,6 +725,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_MAX_TOOLS` | `128` | Tool schemas accepted per request |
 | `FACTORY_DROID_OPENAI_MAX_TRANSCRIPT_BYTES` | `4194304` | Serialized transcript size limit |
 | `FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES` | `1048576` | Serialized tool schema size limit |
+| `FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES` | `1048576` | Buffered structured output size limit |
 | `FACTORY_DROID_OPENAI_MAX_JSON_DEPTH` | `32` | Request JSON nesting limit |
 | `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` | `1` | Wait before killing a Droid process |
 | `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` | `4` | Total budget for session cleanup |
@@ -729,6 +741,8 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_WORKTREE` | unset | Run Droid in a git worktree |
 | `FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE` | unset | File appended to the Droid system prompt |
 | `FACTORY_DROID_OPENAI_MODEL_ALIAS` | `factory-droid` | Alias using Droid default model |
+| `FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS` | `300` | `GET /v1/models` catalog cache lifetime |
+| `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` | `0` | MCP initialization window before tool discovery |
 
 Command-line options:
 
@@ -749,7 +763,9 @@ Every request passes two gates before a Droid process is involved.
 Size limits are enforced while the body is still arriving, so an oversized
 payload is rejected with `413` instead of being buffered in full. Body bytes,
 message count, tool count, serialized transcript size, tool schema size, and
-JSON nesting depth each have their own bound.
+JSON nesting depth each have their own bound. Body size, nesting depth, the
+body timeout, and request metrics cover every HTTP route, including
+`GET /v1/models` and the `/v1/factory/sessions` endpoints.
 
 Admission control then bounds how many requests reach Droid. Requests beyond
 `FACTORY_DROID_OPENAI_MAX_CONCURRENCY` wait in a queue of at most
@@ -772,6 +788,7 @@ surface.
 | `factory_droid_openai_overload_rejections_total` | Requests rejected with `429` |
 | `factory_droid_openai_payload_rejections_total` | Requests rejected with `413` |
 | `factory_droid_openai_forced_kills_total` | Droid processes that needed a kill |
+| `factory_droid_openai_model_discovery_failures_total` | Failed Droid model discovery attempts |
 
 `forced_kills_total` counts any process that did not exit within its grace
 period, so treat it as an upper bound on genuinely stuck processes.
@@ -807,12 +824,16 @@ The OpenAI client, not Factory Droid, owns tool execution.
 
 For every Droid session, the bridge:
 
-1. Selects normal interaction mode with autonomy `off`.
+1. Selects Droid's `auto` interaction mode with autonomy `off`.
 2. Requests no additional MCP servers from the SDK.
 3. Cancels permission requests and interactive questions.
-4. Gives configured MCP servers a bounded initialization window.
-5. Discovers the complete native and MCP tool catalog through `droid.list_tools`.
+4. Optionally waits `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` for configured MCP
+   servers, which only widens the verification snapshot and is off by default.
+5. Discovers the native and MCP tool catalog known at that moment through
+   `droid.list_tools`.
 6. Disables every discovered tool ID and verifies no unexpected tool remains.
+   Tools that appear after this point stay denied, because Droid defaults to
+   deny once a disabled set has been sent.
 7. Rejects any Factory-native tool event as a second line of defense.
 8. Validates generated tool names against the request schema.
 9. Requires tool arguments to be a JSON object with unique keys.

--- a/openapi.json
+++ b/openapi.json
@@ -132,7 +132,7 @@
           },
           "n": {
             "default": 1,
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "N",
             "type": "integer"
           },
@@ -151,6 +151,31 @@
               }
             ],
             "title": "Reasoning Effort"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "json_object": "#/components/schemas/JsonObjectResponseFormat",
+                    "json_schema": "#/components/schemas/JsonSchemaResponseFormat"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/JsonSchemaResponseFormat"
+                  },
+                  {
+                    "$ref": "#/components/schemas/JsonObjectResponseFormat"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Format"
           },
           "stop": {
             "anyOf": [
@@ -187,7 +212,7 @@
           "timeout": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
@@ -370,6 +395,139 @@
         "title": "ChatMessage",
         "type": "object"
       },
+      "CompactSessionRequest": {
+        "properties": {
+          "custom_instructions": {
+            "anyOf": [
+              {
+                "maxLength": 16384,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Instructions"
+          }
+        },
+        "title": "CompactSessionRequest",
+        "type": "object"
+      },
+      "CompactSessionResponse": {
+        "properties": {
+          "removed_count": {
+            "title": "Removed Count",
+            "type": "integer"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "removed_count"
+        ],
+        "title": "CompactSessionResponse",
+        "type": "object"
+      },
+      "ContextBreakdownResponse": {
+        "properties": {
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/ContextCategoryResponse"
+            },
+            "title": "Categories",
+            "type": "array"
+          },
+          "context_budget": {
+            "title": "Context Budget",
+            "type": "integer"
+          },
+          "free_tokens": {
+            "title": "Free Tokens",
+            "type": "integer"
+          },
+          "model_display_name": {
+            "title": "Model Display Name",
+            "type": "string"
+          },
+          "model_id": {
+            "title": "Model Id",
+            "type": "string"
+          },
+          "used_tokens": {
+            "title": "Used Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "model_id",
+          "model_display_name",
+          "context_budget",
+          "used_tokens",
+          "free_tokens",
+          "categories"
+        ],
+        "title": "ContextBreakdownResponse",
+        "type": "object"
+      },
+      "ContextCategoryResponse": {
+        "properties": {
+          "color_key": {
+            "title": "Color Key",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "tokens": {
+            "title": "Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "tokens",
+          "color_key"
+        ],
+        "title": "ContextCategoryResponse",
+        "type": "object"
+      },
+      "ContextStatsResponse": {
+        "properties": {
+          "accuracy": {
+            "title": "Accuracy",
+            "type": "string"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "remaining": {
+            "title": "Remaining",
+            "type": "integer"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "used": {
+            "title": "Used",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "used",
+          "remaining",
+          "limit",
+          "accuracy",
+          "updated_at"
+        ],
+        "title": "ContextStatsResponse",
+        "type": "object"
+      },
       "ErrorDetail": {
         "properties": {
           "code": {
@@ -422,6 +580,19 @@
         "title": "ErrorResponse",
         "type": "object"
       },
+      "ForkSessionResponse": {
+        "properties": {
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "ForkSessionResponse",
+        "type": "object"
+      },
       "FunctionCall": {
         "properties": {
           "arguments": {
@@ -454,11 +625,148 @@
         "title": "HealthResponse",
         "type": "object"
       },
+      "JsonObjectResponseFormat": {
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "const": "json_object",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "JsonObjectResponseFormat",
+        "type": "object"
+      },
+      "JsonSchemaDefinition": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "title": "Name",
+            "type": "string"
+          },
+          "schema": {
+            "additionalProperties": true,
+            "title": "Schema",
+            "type": "object"
+          },
+          "strict": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strict"
+          }
+        },
+        "required": [
+          "name",
+          "schema"
+        ],
+        "title": "JsonSchemaDefinition",
+        "type": "object"
+      },
+      "JsonSchemaResponseFormat": {
+        "additionalProperties": false,
+        "properties": {
+          "json_schema": {
+            "$ref": "#/components/schemas/JsonSchemaDefinition"
+          },
+          "type": {
+            "const": "json_schema",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "json_schema"
+        ],
+        "title": "JsonSchemaResponseFormat",
+        "type": "object"
+      },
       "ModelInfo": {
         "properties": {
           "created": {
             "title": "Created",
             "type": "integer"
+          },
+          "factory_droid_default_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Droid Default Reasoning Effort"
+          },
+          "factory_droid_display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Droid Display Name"
+          },
+          "factory_droid_supported_reasoning_efforts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Droid Supported Reasoning Efforts"
+          },
+          "factory_droid_supports_images": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Droid Supports Images"
+          },
+          "factory_droid_supports_pdfs": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Droid Supports Pdfs"
           },
           "id": {
             "title": "Id",
@@ -503,6 +811,64 @@
           "data"
         ],
         "title": "ModelListResponse",
+        "type": "object"
+      },
+      "RenameSessionRequest": {
+        "properties": {
+          "title": {
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "title": "RenameSessionRequest",
+        "type": "object"
+      },
+      "SessionContextResponse": {
+        "properties": {
+          "breakdown": {
+            "$ref": "#/components/schemas/ContextBreakdownResponse"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/ContextStatsResponse"
+          }
+        },
+        "required": [
+          "session_id",
+          "stats",
+          "breakdown"
+        ],
+        "title": "SessionContextResponse",
+        "type": "object"
+      },
+      "SessionOperationResponse": {
+        "properties": {
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "renamed",
+              "closed"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id",
+          "status"
+        ],
+        "title": "SessionOperationResponse",
         "type": "object"
       },
       "StreamOptions": {
@@ -721,6 +1087,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -750,16 +1126,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -770,6 +1136,549 @@
         "summary": "Create a chat completion",
         "tags": [
           "OpenAI compatibility"
+        ]
+      }
+    },
+    "/v1/factory/sessions/{session_id}": {
+      "delete": {
+        "operationId": "close_session_v1_factory_sessions__session_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionOperationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is unknown to this bridge."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Close a Factory Droid session",
+        "tags": [
+          "Factory extensions"
+        ]
+      },
+      "patch": {
+        "operationId": "rename_session_v1_factory_sessions__session_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionOperationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is unknown to this bridge."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Rename a Factory Droid session",
+        "tags": [
+          "Factory extensions"
+        ]
+      }
+    },
+    "/v1/factory/sessions/{session_id}/compact": {
+      "post": {
+        "operationId": "compact_session_v1_factory_sessions__session_id__compact_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompactSessionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompactSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is unknown to this bridge."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Compact a Factory Droid session",
+        "tags": [
+          "Factory extensions"
+        ]
+      }
+    },
+    "/v1/factory/sessions/{session_id}/context": {
+      "get": {
+        "operationId": "session_context_v1_factory_sessions__session_id__context_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionContextResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is unknown to this bridge."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Read Factory Droid context utilization",
+        "tags": [
+          "Factory extensions"
+        ]
+      }
+    },
+    "/v1/factory/sessions/{session_id}/fork": {
+      "post": {
+        "operationId": "fork_session_v1_factory_sessions__session_id__fork_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForkSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is unknown to this bridge."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Fork a Factory Droid session",
+        "tags": [
+          "Factory extensions"
         ]
       }
     },
@@ -787,6 +1696,24 @@
             },
             "description": "Successful Response"
           },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
           "4XX": {
             "content": {
               "application/json": {
@@ -795,7 +1722,37 @@
                 }
               }
             },
-            "description": "Bearer authentication failure."
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
           }
         },
         "security": [
@@ -803,7 +1760,7 @@
             "HTTPBearer": []
           }
         ],
-        "summary": "List the bridge model alias",
+        "summary": "List available Factory Droid models",
         "tags": [
           "OpenAI compatibility"
         ]
@@ -818,6 +1775,10 @@
     {
       "description": "OpenAI-compatible model and chat endpoints.",
       "name": "OpenAI compatibility"
+    },
+    {
+      "description": "Guarded operations for bridge-created Droid sessions.",
+      "name": "Factory extensions"
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1694,7 +1694,15 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "The bridge alias and the discovered Droid model catalog.",
+            "headers": {
+              "x-factory-droid-model-discovery": {
+                "description": "Set to 'degraded' when discovery failed and the bridge served the last known catalog, or the alias alone.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "content": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
   "droid-sdk==0.1.2",
   "fastapi>=0.133.1,<1",
+  "jsonschema>=4.26.0,<5",
   "pydantic>=2.13.4,<3",
   "uvicorn>=0.41.0,<1",
 ]
@@ -42,6 +43,7 @@ dev = [
   "pytest-asyncio>=1.3.0,<2",
   "pytest-cov>=7.1.0,<8",
   "ruff>=0.15.10,<1",
+  "types-jsonschema>=4.26.0,<5",
 ]
 
 [project.urls]

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -8,10 +8,11 @@ import secrets
 import time
 import uuid
 from collections import OrderedDict, deque
-from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import TYPE_CHECKING, Annotated, Any
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar
 
-from fastapi import Depends, FastAPI, Request, Security
+from fastapi import Depends, FastAPI, Request, Response, Security
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -20,6 +21,7 @@ from jsonschema.exceptions import SchemaError
 from jsonschema.validators import validator_for
 
 from factory_droid_openai.config import Settings
+from factory_droid_openai.droid_rpc import DroidRpcExtension
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.models import (
     ChatCompletionRequest,
@@ -47,6 +49,7 @@ from factory_droid_openai.protocol import (
     ToolCallEmission,
     ToolCallStreamParser,
     build_prompt,
+    parse_strict_json,
 )
 from factory_droid_openai.runner import (
     DroidModel,
@@ -64,6 +67,7 @@ from factory_droid_openai.runner import (
 )
 
 if TYPE_CHECKING:
+    from jsonschema.protocols import Validator
     from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 RunnerFactory = Callable[[], DroidRunner]
@@ -133,13 +137,105 @@ FACTORY_OPERATION_RESPONSES: dict[int | str, dict[str, Any]] = {
     503: CHAT_COMPLETION_RESPONSES[503],
     504: CHAT_COMPLETION_RESPONSES[504],
 }
-MODEL_LIST_RESPONSES = {
-    status: response for status, response in FACTORY_OPERATION_RESPONSES.items() if status != 404
+MODEL_LIST_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        "model": ModelListResponse,
+        "description": "The bridge alias and the discovered Droid model catalog.",
+        "headers": {
+            "x-factory-droid-model-discovery": {
+                "description": (
+                    "Set to 'degraded' when discovery failed and the bridge served the "
+                    "last known catalog, or the alias alone."
+                ),
+                "schema": {"type": "string"},
+            }
+        },
+    },
+    **{
+        status: response
+        for status, response in FACTORY_OPERATION_RESPONSES.items()
+        if status != 404
+    },
 }
+
+
+FactoryOperationResult = TypeVar("FactoryOperationResult")
 
 
 class AdmissionRejectedError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True, slots=True)
+class StructuredOutput:
+    """A validated ``response_format`` request, compiled once per completion."""
+
+    payload: dict[str, Any]
+    validator: Validator
+    max_bytes: int
+
+
+class StructuredOutputBuffer:
+    """Collects structured completion text until it can be validated.
+
+    Structured output is only useful once the whole JSON document is present,
+    so the bridge holds it back instead of streaming partial JSON. The byte
+    cap keeps a runaway generation from growing the buffer without bound.
+    """
+
+    def __init__(self, max_bytes: int) -> None:
+        self._max_bytes = max_bytes
+        self._parts: list[str] = []
+        self._bytes = 0
+
+    def append(self, text: str) -> None:
+        self._bytes += len(text.encode("utf-8"))
+        if self._bytes > self._max_bytes:
+            raise ProtocolError(
+                f"Factory Droid structured output exceeds maximum of {self._max_bytes} bytes"
+            )
+        self._parts.append(text)
+
+    def text(self) -> str:
+        return "".join(self._parts)
+
+
+class ModelCatalog:
+    """Caches discovered Droid models behind a single-flight lock.
+
+    Model discovery starts a Droid process and takes an admission slot, so an
+    uncached endpoint would let routine ``GET /v1/models`` polling stall chat
+    traffic. Concurrent callers share one discovery; a failed discovery serves
+    the last known catalog instead of replacing it.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float,
+        load: Callable[[], Awaitable[tuple[DroidModel, ...]]],
+    ) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._load = load
+        self._lock = asyncio.Lock()
+        self._models: tuple[DroidModel, ...] | None = None
+        self._expires_at = 0.0
+
+    async def get(self) -> tuple[tuple[DroidModel, ...], bool]:
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            cached = self._models
+            if cached is not None and loop.time() < self._expires_at:
+                return cached, False
+            try:
+                models = await self._load()
+            except BridgeHTTPError as exc:
+                if exc.status_code not in {502, 503, 504}:
+                    raise
+                return cached or (), True
+            self._models = models
+            self._expires_at = loop.time() + self._ttl_seconds
+            return models, False
 
 
 class SessionRegistry:
@@ -357,7 +453,10 @@ class RequestSizeLimitMiddleware:
         receive: Receive,
         send: Send,
     ) -> None:
-        if scope["type"] != "http" or scope.get("path") != "/v1/chat/completions":
+        # Every HTTP route is covered, not only chat completions: the session
+        # extensions accept request bodies too, and FastAPI buffers a body
+        # before authentication runs.
+        if scope["type"] != "http":
             await self._app(scope, receive, send)
             return
 
@@ -472,8 +571,12 @@ def create_app(
             metrics=metrics,
             worktree=resolved_settings.worktree,
             append_system_prompt_file=resolved_settings.append_system_prompt_file,
+            rpc_extension=DroidRpcExtension(
+                mcp_settle_seconds=resolved_settings.mcp_settle_seconds,
+            ),
         )
     )
+    bridge_created = int(time.time())
     sessions = SessionRegistry(resolved_settings.max_tracked_sessions)
     admission = AdmissionController(
         max_concurrency=resolved_settings.max_concurrency,
@@ -553,10 +656,10 @@ def create_app(
         )
 
     async def run_factory_operation(
-        operation: Callable[[DroidRunner, float], Awaitable[Any]],
+        operation: Callable[[DroidRunner, float], Awaitable[FactoryOperationResult]],
         *,
         timeout_seconds: float | None = None,
-    ) -> Any:
+    ) -> FactoryOperationResult:
         timeout = min(
             timeout_seconds or resolved_settings.timeout_seconds,
             resolved_settings.timeout_seconds,
@@ -581,13 +684,9 @@ def create_app(
 
         async with lease:
             try:
+                # A budget already spent in the queue is forwarded as-is; the
+                # runner's own timeout turns it into a 504.
                 remaining = deadline - asyncio.get_running_loop().time()
-                if remaining <= 0:
-                    raise BridgeHTTPError(
-                        f"Factory Droid timed out after {timeout:.1f} seconds.",
-                        status_code=504,
-                        error_type="factory_droid_timeout",
-                    )
                 runner = resolved_runner_factory()
                 return await operation(runner, remaining)
             except RunnerError as exc:
@@ -596,6 +695,14 @@ def create_app(
                     status_code=exc.status_code,
                     error_type=exc.error_type,
                 ) from exc
+
+    model_catalog = ModelCatalog(
+        ttl_seconds=resolved_settings.model_cache_seconds,
+        load=lambda: run_factory_operation(
+            lambda runner, remaining: runner.list_models(timeout_seconds=remaining),
+            timeout_seconds=min(30.0, resolved_settings.timeout_seconds),
+        ),
+    )
 
     def require_known_session(session_id: str) -> None:
         if not resolved_settings.session_continuity:
@@ -637,20 +744,16 @@ def create_app(
         tags=["OpenAI compatibility"],
         summary="List available Factory Droid models",
     )
-    async def models() -> ModelListResponse:
-        try:
-            discovered = await run_factory_operation(
-                lambda runner, remaining: runner.list_models(timeout_seconds=remaining),
-                timeout_seconds=min(30.0, resolved_settings.timeout_seconds),
-            )
-        except BridgeHTTPError as exc:
-            if exc.status_code not in {502, 503, 504}:
-                raise
-            discovered = ()
+    async def models(response: Response) -> ModelListResponse:
+        discovered, degraded = await model_catalog.get()
+        if degraded:
+            metrics.increment_model_discovery_failures()
+            response.headers["x-factory-droid-model-discovery"] = "degraded"
         return ModelListResponse(
             data=_model_list(
                 resolved_settings.model_alias,
                 discovered,
+                created=bridge_created,
             )
         )
 
@@ -823,9 +926,10 @@ def create_app(
             session_id = payload.factory_droid_session_id
 
         try:
-            output_format = _prepare_output_format(
+            structured = _prepare_output_format(
                 payload,
                 max_schema_bytes=resolved_settings.max_tool_schema_bytes,
+                max_output_bytes=resolved_settings.max_structured_output_bytes,
             )
             plan = build_prompt(
                 payload,
@@ -865,7 +969,7 @@ def create_app(
             images=tuple(image.to_sdk() for image in plan.attachments.images),
             documents=tuple(document.to_sdk() for document in plan.attachments.documents),
             session_id=session_id,
-            output_format=output_format,
+            output_format=structured.payload if structured is not None else None,
         )
 
         try:
@@ -919,7 +1023,7 @@ def create_app(
                 emit_status=payload.factory_droid_status,
                 session_callback=sessions.remember,
                 expose_session=resolved_settings.session_continuity,
-                output_format=output_format,
+                structured=structured,
             )
             return FinalizingStreamingResponse(
                 event_stream,
@@ -971,8 +1075,8 @@ def create_app(
                     if result.session_id is not None:
                         sessions.remember(result.session_id)
                         started_session = result.session_id
-                    if output_format is not None:
-                        _validate_structured_output(result.text, output_format)
+                    if structured is not None:
+                        _validate_structured_output(result.text, structured)
                     total_usage = _add_usage(total_usage, result.usage)
                     choices.append(_choice_dict(result, index))
         except ProtocolError as exc:
@@ -1148,7 +1252,7 @@ async def _stream_completion(
     emit_status: bool = False,
     session_callback: Callable[[str], None] | None = None,
     expose_session: bool = False,
-    output_format: dict[str, Any] | None = None,
+    structured: StructuredOutput | None = None,
 ) -> AsyncIterator[str]:
     usage = Usage()
     completed = False
@@ -1157,7 +1261,23 @@ async def _stream_completion(
     outcome = "success"
     stop_buffer = StopSequenceBuffer(stop_sequences)
     tool_call_index = 0
-    structured_parts: list[str] = []
+    structured_buffer = (
+        StructuredOutputBuffer(structured.max_bytes) if structured is not None else None
+    )
+
+    def text_chunk(text: str) -> str | None:
+        if structured_buffer is not None:
+            structured_buffer.append(text)
+            return None
+        return _sse(
+            _chunk_for_emission(
+                request_id,
+                created,
+                model,
+                TextEmission(text),
+                include_usage=include_usage,
+            )
+        )
 
     async with lease:
         yield _sse(
@@ -1194,18 +1314,9 @@ async def _stream_completion(
                                 continue
                             text = stop_buffer.feed(emission.text)
                             if text:
-                                if output_format is not None:
-                                    structured_parts.append(text)
-                                else:
-                                    yield _sse(
-                                        _chunk_for_emission(
-                                            request_id,
-                                            created,
-                                            model,
-                                            TextEmission(text),
-                                            include_usage=include_usage,
-                                        )
-                                    )
+                                chunk_payload = text_chunk(text)
+                                if chunk_payload is not None:
+                                    yield chunk_payload
                         if stop_buffer.triggered:
                             # Closing the runner generator interrupts the Droid
                             # turn instead of draining output nobody will read.
@@ -1266,50 +1377,19 @@ async def _stream_completion(
                 )
             if not stop_buffer.triggered:
                 for emission in parser.finish():
-                    if isinstance(emission, ToolCallEmission):
-                        saw_tool_call = True
-                        chunk = _chunk_for_emission(
-                            request_id,
-                            created,
-                            model,
-                            emission,
-                            include_usage=include_usage,
-                            tool_call_index=tool_call_index,
-                        )
-                        tool_call_index += 1
-                        yield _sse(chunk)
-                        continue
                     text = stop_buffer.feed(emission.text)
                     if text:
-                        if output_format is not None:
-                            structured_parts.append(text)
-                        else:
-                            yield _sse(
-                                _chunk_for_emission(
-                                    request_id,
-                                    created,
-                                    model,
-                                    TextEmission(text),
-                                    include_usage=include_usage,
-                                )
-                            )
+                        chunk_payload = text_chunk(text)
+                        if chunk_payload is not None:
+                            yield chunk_payload
                 held = stop_buffer.flush()
                 if held:
-                    if output_format is not None:
-                        structured_parts.append(held)
-                    else:
-                        yield _sse(
-                            _chunk_for_emission(
-                                request_id,
-                                created,
-                                model,
-                                TextEmission(held),
-                                include_usage=include_usage,
-                            )
-                        )
-            if output_format is not None:
-                structured_text = "".join(structured_parts)
-                _validate_structured_output(structured_text, output_format)
+                    chunk_payload = text_chunk(held)
+                    if chunk_payload is not None:
+                        yield chunk_payload
+            if structured is not None and structured_buffer is not None:
+                structured_text = structured_buffer.text()
+                _validate_structured_output(structured_text, structured)
                 yield _sse(
                     _chunk_for_emission(
                         request_id,
@@ -1363,7 +1443,7 @@ async def _finalize_stream(
 
 def _apply_emissions(
     result: CollectedCompletion,
-    emissions: list[ProtocolEmission],
+    emissions: Sequence[ProtocolEmission],
     stop_buffer: StopSequenceBuffer | None = None,
 ) -> None:
     for emission in emissions:
@@ -1498,11 +1578,16 @@ def _validate_options(
     return None
 
 
-def _model_list(alias: str, discovered: tuple[DroidModel, ...]) -> list[ModelInfo]:
+def _model_list(
+    alias: str,
+    discovered: tuple[DroidModel, ...],
+    *,
+    created: int,
+) -> list[ModelInfo]:
     models = [
         ModelInfo(
             id=alias,
-            created=0,
+            created=created,
             owned_by="factory",
         )
     ]
@@ -1514,7 +1599,7 @@ def _model_list(alias: str, discovered: tuple[DroidModel, ...]) -> list[ModelInf
         models.append(
             ModelInfo(
                 id=model.id,
-                created=0,
+                created=created,
                 owned_by=model.provider,
                 factory_droid_display_name=model.display_name,
                 factory_droid_supported_reasoning_efforts=list(model.supported_reasoning_efforts),
@@ -1530,7 +1615,8 @@ def _prepare_output_format(
     payload: ChatCompletionRequest,
     *,
     max_schema_bytes: int,
-) -> dict[str, Any] | None:
+    max_output_bytes: int,
+) -> StructuredOutput | None:
     response_format = payload.response_format
     if response_format is None:
         return None
@@ -1554,50 +1640,35 @@ def _prepare_output_format(
             f"response_format schema exceeds maximum of {max_schema_bytes} bytes"
         )
     _reject_remote_schema_refs(schema)
-    validator = validator_for(schema)
+    validator_class = validator_for(schema)
     try:
-        validator.check_schema(schema)
+        validator_class.check_schema(schema)
     except SchemaError as exc:
         raise ProtocolError(
             f"response_format contains an invalid JSON schema: {exc.message}"
         ) from exc
-    return {"type": "json_schema", "schema": schema}
+    return StructuredOutput(
+        payload={"type": "json_schema", "schema": schema},
+        validator=validator_class(schema),
+        max_bytes=max_output_bytes,
+    )
 
 
-def _validate_structured_output(
-    text: str,
-    output_format: dict[str, Any],
-) -> None:
-    try:
-        value = json.loads(
-            text,
-            object_pairs_hook=_reject_duplicate_json_keys,
-            parse_constant=_reject_non_json_constant,
+def _validate_structured_output(text: str, structured: StructuredOutput) -> None:
+    if len(text.encode("utf-8")) > structured.max_bytes:
+        raise ProtocolError(
+            f"Factory Droid structured output exceeds maximum of {structured.max_bytes} bytes"
         )
+    try:
+        value = parse_strict_json(text)
     except (TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ProtocolError("Factory Droid returned invalid structured JSON output") from exc
-    schema = output_format.get("schema")
-    if not isinstance(schema, dict):
-        raise ProtocolError("Factory Droid structured output schema is malformed")
     try:
-        validator_for(schema)(schema).validate(value)
+        structured.validator.validate(value)
     except JsonSchemaValidationError as exc:
         raise ProtocolError(
             f"Factory Droid structured output violated the requested schema: {exc.message}"
         ) from exc
-
-
-def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ValueError(f"duplicate key '{key}'")
-        result[key] = value
-    return result
-
-
-def _reject_non_json_constant(value: str) -> None:
-    raise ValueError(f"non-JSON numeric constant '{value}'")
 
 
 def _reject_remote_schema_refs(value: Any) -> None:

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -15,16 +15,28 @@ from fastapi import Depends, FastAPI, Request, Security
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jsonschema import ValidationError as JsonSchemaValidationError
+from jsonschema.exceptions import SchemaError
+from jsonschema.validators import validator_for
 
 from factory_droid_openai.config import Settings
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
+    CompactSessionRequest,
+    CompactSessionResponse,
+    ContextBreakdownResponse,
+    ContextCategoryResponse,
+    ContextStatsResponse,
     ErrorResponse,
+    ForkSessionResponse,
     HealthResponse,
     ModelInfo,
     ModelListResponse,
+    RenameSessionRequest,
+    SessionContextResponse,
+    SessionOperationResponse,
 )
 from factory_droid_openai.protocol import (
     ProtocolEmission,
@@ -37,6 +49,7 @@ from factory_droid_openai.protocol import (
     build_prompt,
 )
 from factory_droid_openai.runner import (
+    DroidModel,
     DroidRunner,
     ReasoningDelta,
     RunComplete,
@@ -106,6 +119,24 @@ CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     },
 }
 
+FACTORY_OPERATION_RESPONSES: dict[int | str, dict[str, Any]] = {
+    "4XX": {
+        "model": ErrorResponse,
+        "description": "Invalid request or bearer authentication failure.",
+    },
+    404: {
+        "model": ErrorResponse,
+        "description": "The requested Factory Droid session is unknown to this bridge.",
+    },
+    429: CHAT_COMPLETION_RESPONSES[429],
+    502: CHAT_COMPLETION_RESPONSES[502],
+    503: CHAT_COMPLETION_RESPONSES[503],
+    504: CHAT_COMPLETION_RESPONSES[504],
+}
+MODEL_LIST_RESPONSES = {
+    status: response for status, response in FACTORY_OPERATION_RESPONSES.items() if status != 404
+}
+
 
 class AdmissionRejectedError(RuntimeError):
     pass
@@ -135,6 +166,9 @@ class SessionRegistry:
             return False
         self._sessions.move_to_end(session_id)
         return True
+
+    def forget(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
 
 
 class AdmissionLease:
@@ -467,6 +501,10 @@ def create_app(
                 "name": "OpenAI compatibility",
                 "description": "OpenAI-compatible model and chat endpoints.",
             },
+            {
+                "name": "Factory extensions",
+                "description": "Guarded operations for bridge-created Droid sessions.",
+            },
         ],
     )
     application.add_middleware(
@@ -496,7 +534,12 @@ def create_app(
 
     @application.exception_handler(BridgeHTTPError)
     async def handle_bridge_error(_request: Request, exc: BridgeHTTPError) -> JSONResponse:
-        return _error_response(exc.message, exc.status_code, exc.error_type)
+        return _error_response(
+            exc.message,
+            exc.status_code,
+            exc.error_type,
+            headers=exc.headers,
+        )
 
     @application.exception_handler(RequestValidationError)
     async def handle_validation_error(
@@ -508,6 +551,66 @@ def create_app(
             400,
             "invalid_request_error",
         )
+
+    async def run_factory_operation(
+        operation: Callable[[DroidRunner, float], Awaitable[Any]],
+        *,
+        timeout_seconds: float | None = None,
+    ) -> Any:
+        timeout = min(
+            timeout_seconds or resolved_settings.timeout_seconds,
+            resolved_settings.timeout_seconds,
+        )
+        deadline = asyncio.get_running_loop().time() + timeout
+        try:
+            lease = await admission.acquire(deadline)
+        except AdmissionRejectedError as exc:
+            metrics.increment_overload_rejections()
+            raise BridgeHTTPError(
+                "Factory Droid request queue is full.",
+                status_code=429,
+                error_type="rate_limit_error",
+                headers={"Retry-After": str(resolved_settings.retry_after_seconds)},
+            ) from exc
+        except TimeoutError as exc:
+            raise BridgeHTTPError(
+                f"Factory Droid timed out after {timeout:.1f} seconds.",
+                status_code=504,
+                error_type="factory_droid_timeout",
+            ) from exc
+
+        async with lease:
+            try:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise BridgeHTTPError(
+                        f"Factory Droid timed out after {timeout:.1f} seconds.",
+                        status_code=504,
+                        error_type="factory_droid_timeout",
+                    )
+                runner = resolved_runner_factory()
+                return await operation(runner, remaining)
+            except RunnerError as exc:
+                raise BridgeHTTPError(
+                    str(exc),
+                    status_code=exc.status_code,
+                    error_type=exc.error_type,
+                ) from exc
+
+    def require_known_session(session_id: str) -> None:
+        if not resolved_settings.session_continuity:
+            raise BridgeHTTPError(
+                "Session continuity is disabled on this bridge.",
+                status_code=400,
+                error_type="invalid_request_error",
+            )
+        if not sessions.knows(session_id):
+            raise BridgeHTTPError(
+                "Unknown Factory Droid session. Only sessions created by this "
+                "bridge process can be managed.",
+                status_code=404,
+                error_type="session_not_found",
+            )
 
     @application.get(
         "/health",
@@ -528,26 +631,156 @@ def create_app(
     @application.get(
         "/v1/models",
         response_model=ModelListResponse,
+        response_model_exclude_none=True,
         dependencies=[Depends(require_auth)],
-        responses={
-            "4XX": {
-                "model": ErrorResponse,
-                "description": "Bearer authentication failure.",
-            }
-        },
+        responses=MODEL_LIST_RESPONSES,
         tags=["OpenAI compatibility"],
-        summary="List the bridge model alias",
+        summary="List available Factory Droid models",
     )
     async def models() -> ModelListResponse:
+        try:
+            discovered = await run_factory_operation(
+                lambda runner, remaining: runner.list_models(timeout_seconds=remaining),
+                timeout_seconds=min(30.0, resolved_settings.timeout_seconds),
+            )
+        except BridgeHTTPError as exc:
+            if exc.status_code not in {502, 503, 504}:
+                raise
+            discovered = ()
         return ModelListResponse(
-            data=[
-                ModelInfo(
-                    id=resolved_settings.model_alias,
-                    created=0,
-                    owned_by="factory",
-                )
-            ]
+            data=_model_list(
+                resolved_settings.model_alias,
+                discovered,
+            )
         )
+
+    @application.get(
+        "/v1/factory/sessions/{session_id}/context",
+        response_model=SessionContextResponse,
+        dependencies=[Depends(require_auth)],
+        responses=FACTORY_OPERATION_RESPONSES,
+        tags=["Factory extensions"],
+        summary="Read Factory Droid context utilization",
+    )
+    async def session_context(session_id: str) -> SessionContextResponse:
+        require_known_session(session_id)
+        stats, breakdown = await run_factory_operation(
+            lambda runner, remaining: runner.get_context(
+                session_id,
+                timeout_seconds=remaining,
+            )
+        )
+        return SessionContextResponse(
+            session_id=session_id,
+            stats=ContextStatsResponse(
+                used=stats.used,
+                remaining=stats.remaining,
+                limit=stats.limit,
+                accuracy=stats.accuracy,
+                updated_at=stats.updated_at,
+            ),
+            breakdown=ContextBreakdownResponse(
+                model_id=breakdown.model_id,
+                model_display_name=breakdown.model_display_name,
+                context_budget=breakdown.context_budget,
+                used_tokens=breakdown.used_tokens,
+                free_tokens=breakdown.free_tokens,
+                categories=[
+                    ContextCategoryResponse(
+                        name=category.name,
+                        tokens=category.tokens,
+                        color_key=category.color_key,
+                    )
+                    for category in breakdown.categories
+                ],
+            ),
+        )
+
+    @application.post(
+        "/v1/factory/sessions/{session_id}/compact",
+        response_model=CompactSessionResponse,
+        dependencies=[Depends(require_auth)],
+        responses=FACTORY_OPERATION_RESPONSES,
+        tags=["Factory extensions"],
+        summary="Compact a Factory Droid session",
+    )
+    async def compact_session(
+        session_id: str,
+        payload: CompactSessionRequest,
+    ) -> CompactSessionResponse:
+        require_known_session(session_id)
+        result = await run_factory_operation(
+            lambda runner, remaining: runner.compact_session(
+                session_id,
+                custom_instructions=payload.custom_instructions,
+                timeout_seconds=remaining,
+            )
+        )
+        sessions.remember(result.new_session_id)
+        return CompactSessionResponse(
+            session_id=result.new_session_id,
+            removed_count=result.removed_count,
+        )
+
+    @application.post(
+        "/v1/factory/sessions/{session_id}/fork",
+        response_model=ForkSessionResponse,
+        dependencies=[Depends(require_auth)],
+        responses=FACTORY_OPERATION_RESPONSES,
+        tags=["Factory extensions"],
+        summary="Fork a Factory Droid session",
+    )
+    async def fork_session(session_id: str) -> ForkSessionResponse:
+        require_known_session(session_id)
+        new_session_id = await run_factory_operation(
+            lambda runner, remaining: runner.fork_session(
+                session_id,
+                timeout_seconds=remaining,
+            )
+        )
+        sessions.remember(new_session_id)
+        return ForkSessionResponse(session_id=new_session_id)
+
+    @application.patch(
+        "/v1/factory/sessions/{session_id}",
+        response_model=SessionOperationResponse,
+        dependencies=[Depends(require_auth)],
+        responses=FACTORY_OPERATION_RESPONSES,
+        tags=["Factory extensions"],
+        summary="Rename a Factory Droid session",
+    )
+    async def rename_session(
+        session_id: str,
+        payload: RenameSessionRequest,
+    ) -> SessionOperationResponse:
+        require_known_session(session_id)
+        await run_factory_operation(
+            lambda runner, remaining: runner.rename_session(
+                session_id,
+                title=payload.title,
+                timeout_seconds=remaining,
+            )
+        )
+        return SessionOperationResponse(session_id=session_id, status="renamed")
+
+    @application.delete(
+        "/v1/factory/sessions/{session_id}",
+        response_model=SessionOperationResponse,
+        dependencies=[Depends(require_auth)],
+        responses=FACTORY_OPERATION_RESPONSES,
+        tags=["Factory extensions"],
+        summary="Close a Factory Droid session",
+    )
+    async def close_session(session_id: str) -> SessionOperationResponse:
+        require_known_session(session_id)
+        await run_factory_operation(
+            lambda runner, remaining: runner.close_session(
+                session_id,
+                timeout_seconds=remaining,
+            )
+        )
+        sessions.forget(session_id)
+        return SessionOperationResponse(session_id=session_id, status="closed")
 
     @application.post(
         "/v1/chat/completions",
@@ -590,6 +823,10 @@ def create_app(
             session_id = payload.factory_droid_session_id
 
         try:
+            output_format = _prepare_output_format(
+                payload,
+                max_schema_bytes=resolved_settings.max_tool_schema_bytes,
+            )
             plan = build_prompt(
                 payload,
                 max_messages=resolved_settings.max_messages,
@@ -628,6 +865,7 @@ def create_app(
             images=tuple(image.to_sdk() for image in plan.attachments.images),
             documents=tuple(document.to_sdk() for document in plan.attachments.documents),
             session_id=session_id,
+            output_format=output_format,
         )
 
         try:
@@ -681,6 +919,7 @@ def create_app(
                 emit_status=payload.factory_droid_status,
                 session_callback=sessions.remember,
                 expose_session=resolved_settings.session_continuity,
+                output_format=output_format,
             )
             return FinalizingStreamingResponse(
                 event_stream,
@@ -732,6 +971,8 @@ def create_app(
                     if result.session_id is not None:
                         sessions.remember(result.session_id)
                         started_session = result.session_id
+                    if output_format is not None:
+                        _validate_structured_output(result.text, output_format)
                     total_usage = _add_usage(total_usage, result.usage)
                     choices.append(_choice_dict(result, index))
         except ProtocolError as exc:
@@ -758,11 +999,19 @@ def create_app(
 
 
 class BridgeHTTPError(Exception):
-    def __init__(self, message: str, *, status_code: int, error_type: str) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        error_type: str,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         super().__init__(message)
         self.message = message
         self.status_code = status_code
         self.error_type = error_type
+        self.headers = headers
 
 
 class CollectedCompletion:
@@ -899,6 +1148,7 @@ async def _stream_completion(
     emit_status: bool = False,
     session_callback: Callable[[str], None] | None = None,
     expose_session: bool = False,
+    output_format: dict[str, Any] | None = None,
 ) -> AsyncIterator[str]:
     usage = Usage()
     completed = False
@@ -907,6 +1157,7 @@ async def _stream_completion(
     outcome = "success"
     stop_buffer = StopSequenceBuffer(stop_sequences)
     tool_call_index = 0
+    structured_parts: list[str] = []
 
     async with lease:
         yield _sse(
@@ -943,15 +1194,18 @@ async def _stream_completion(
                                 continue
                             text = stop_buffer.feed(emission.text)
                             if text:
-                                yield _sse(
-                                    _chunk_for_emission(
-                                        request_id,
-                                        created,
-                                        model,
-                                        TextEmission(text),
-                                        include_usage=include_usage,
+                                if output_format is not None:
+                                    structured_parts.append(text)
+                                else:
+                                    yield _sse(
+                                        _chunk_for_emission(
+                                            request_id,
+                                            created,
+                                            model,
+                                            TextEmission(text),
+                                            include_usage=include_usage,
+                                        )
                                     )
-                                )
                         if stop_buffer.triggered:
                             # Closing the runner generator interrupts the Droid
                             # turn instead of draining output nobody will read.
@@ -1027,26 +1281,44 @@ async def _stream_completion(
                         continue
                     text = stop_buffer.feed(emission.text)
                     if text:
+                        if output_format is not None:
+                            structured_parts.append(text)
+                        else:
+                            yield _sse(
+                                _chunk_for_emission(
+                                    request_id,
+                                    created,
+                                    model,
+                                    TextEmission(text),
+                                    include_usage=include_usage,
+                                )
+                            )
+                held = stop_buffer.flush()
+                if held:
+                    if output_format is not None:
+                        structured_parts.append(held)
+                    else:
                         yield _sse(
                             _chunk_for_emission(
                                 request_id,
                                 created,
                                 model,
-                                TextEmission(text),
+                                TextEmission(held),
                                 include_usage=include_usage,
                             )
                         )
-                held = stop_buffer.flush()
-                if held:
-                    yield _sse(
-                        _chunk_for_emission(
-                            request_id,
-                            created,
-                            model,
-                            TextEmission(held),
-                            include_usage=include_usage,
-                        )
+            if output_format is not None:
+                structured_text = "".join(structured_parts)
+                _validate_structured_output(structured_text, output_format)
+                yield _sse(
+                    _chunk_for_emission(
+                        request_id,
+                        created,
+                        model,
+                        TextEmission(structured_text),
+                        include_usage=include_usage,
                     )
+                )
             yield _sse(
                 _chunk(
                     request_id,
@@ -1211,7 +1483,134 @@ def _validate_options(
             400,
             "invalid_request_error",
         )
+    if payload.response_format is not None and payload.stop_sequences:
+        return _error_response(
+            "stop is not supported together with response_format.",
+            400,
+            "invalid_request_error",
+        )
+    if payload.response_format is not None and payload.tools and payload.tool_choice != "none":
+        return _error_response(
+            "tools are not supported together with response_format on this bridge.",
+            400,
+            "invalid_request_error",
+        )
     return None
+
+
+def _model_list(alias: str, discovered: tuple[DroidModel, ...]) -> list[ModelInfo]:
+    models = [
+        ModelInfo(
+            id=alias,
+            created=0,
+            owned_by="factory",
+        )
+    ]
+    seen = {alias}
+    for model in discovered:
+        if model.id in seen:
+            continue
+        seen.add(model.id)
+        models.append(
+            ModelInfo(
+                id=model.id,
+                created=0,
+                owned_by=model.provider,
+                factory_droid_display_name=model.display_name,
+                factory_droid_supported_reasoning_efforts=list(model.supported_reasoning_efforts),
+                factory_droid_default_reasoning_effort=model.default_reasoning_effort,
+                factory_droid_supports_images=model.supports_images,
+                factory_droid_supports_pdfs=model.supports_pdfs,
+            )
+        )
+    return models
+
+
+def _prepare_output_format(
+    payload: ChatCompletionRequest,
+    *,
+    max_schema_bytes: int,
+) -> dict[str, Any] | None:
+    response_format = payload.response_format
+    if response_format is None:
+        return None
+    if response_format.type == "json_object":
+        schema: dict[str, Any] = {
+            "type": "object",
+            "additionalProperties": True,
+        }
+    else:
+        schema = response_format.json_schema.schema_
+        if schema.get("type") != "object":
+            raise ProtocolError("response_format JSON schema must have type 'object'")
+    serialized = json.dumps(
+        schema,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    )
+    if len(serialized.encode("utf-8")) > max_schema_bytes:
+        raise RequestTooLargeError(
+            f"response_format schema exceeds maximum of {max_schema_bytes} bytes"
+        )
+    _reject_remote_schema_refs(schema)
+    validator = validator_for(schema)
+    try:
+        validator.check_schema(schema)
+    except SchemaError as exc:
+        raise ProtocolError(
+            f"response_format contains an invalid JSON schema: {exc.message}"
+        ) from exc
+    return {"type": "json_schema", "schema": schema}
+
+
+def _validate_structured_output(
+    text: str,
+    output_format: dict[str, Any],
+) -> None:
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_non_json_constant,
+        )
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ProtocolError("Factory Droid returned invalid structured JSON output") from exc
+    schema = output_format.get("schema")
+    if not isinstance(schema, dict):
+        raise ProtocolError("Factory Droid structured output schema is malformed")
+    try:
+        validator_for(schema)(schema).validate(value)
+    except JsonSchemaValidationError as exc:
+        raise ProtocolError(
+            f"Factory Droid structured output violated the requested schema: {exc.message}"
+        ) from exc
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key '{key}'")
+        result[key] = value
+    return result
+
+
+def _reject_non_json_constant(value: str) -> None:
+    raise ValueError(f"non-JSON numeric constant '{value}'")
+
+
+def _reject_remote_schema_refs(value: Any) -> None:
+    if isinstance(value, dict):
+        for keyword in ("$ref", "$dynamicRef", "$recursiveRef"):
+            reference = value.get(keyword)
+            if isinstance(reference, str) and not reference.startswith("#"):
+                raise ProtocolError("response_format does not allow remote JSON schema references")
+        for item in value.values():
+            _reject_remote_schema_refs(item)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_remote_schema_refs(item)
 
 
 def _choice_dict(result: CollectedCompletion, index: int) -> dict[str, Any]:

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -22,6 +22,7 @@ class Settings:
     max_tools: int = 128
     max_transcript_bytes: int = 4_194_304
     max_tool_schema_bytes: int = 1_048_576
+    max_structured_output_bytes: int = 1_048_576
     max_json_depth: int = 32
     retry_after_seconds: int = 1
     process_grace_seconds: float = 1.0
@@ -35,6 +36,8 @@ class Settings:
     max_stop_sequences: int = 4
     session_continuity: bool = False
     max_tracked_sessions: int = 256
+    mcp_settle_seconds: float = 0.0
+    model_cache_seconds: float = 300.0
     worktree: str | None = None
     append_system_prompt_file: Path | None = None
     model_alias: str = "factory-droid"
@@ -79,6 +82,10 @@ class Settings:
         )
         max_tool_schema_bytes = _positive_int(
             "FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES",
+            default=1_048_576,
+        )
+        max_structured_output_bytes = _positive_int(
+            "FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES",
             default=1_048_576,
         )
         max_json_depth = _positive_int(
@@ -140,6 +147,14 @@ class Settings:
             "FACTORY_DROID_OPENAI_MAX_TRACKED_SESSIONS",
             default=256,
         )
+        mcp_settle_seconds = _non_negative_float(
+            "FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS",
+            default=0.0,
+        )
+        model_cache_seconds = _non_negative_float(
+            "FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS",
+            default=300.0,
+        )
         worktree = os.getenv("FACTORY_DROID_OPENAI_WORKTREE") or None
         append_system_prompt_file = _optional_file(
             "FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE",
@@ -162,6 +177,7 @@ class Settings:
             max_tools=max_tools,
             max_transcript_bytes=max_transcript_bytes,
             max_tool_schema_bytes=max_tool_schema_bytes,
+            max_structured_output_bytes=max_structured_output_bytes,
             max_json_depth=max_json_depth,
             retry_after_seconds=retry_after_seconds,
             process_grace_seconds=process_grace_seconds,
@@ -175,6 +191,8 @@ class Settings:
             max_stop_sequences=max_stop_sequences,
             session_continuity=session_continuity,
             max_tracked_sessions=max_tracked_sessions,
+            mcp_settle_seconds=mcp_settle_seconds,
+            model_cache_seconds=model_cache_seconds,
             worktree=worktree,
             append_system_prompt_file=append_system_prompt_file,
             model_alias=os.getenv("FACTORY_DROID_OPENAI_MODEL_ALIAS", "factory-droid"),
@@ -189,6 +207,17 @@ def _positive_float(name: str, *, default: float) -> float:
         raise ValueError(f"{name} must be a number") from exc
     if not math.isfinite(value) or value <= 0:
         raise ValueError(f"{name} must be greater than zero and finite")
+    return value
+
+
+def _non_negative_float(name: str, *, default: float) -> float:
+    raw = os.getenv(name)
+    try:
+        value = float(raw) if raw is not None else default
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a number") from exc
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be zero or greater and finite")
     return value
 
 

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -5,13 +5,19 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from droid_sdk.errors import DroidClientError
+from droid_sdk.schemas.enums import (
+    AutonomyLevel,
+    DroidInteractionMode,
+    DroidServerMethod,
+)
 
 if TYPE_CHECKING:
     from droid_sdk import DroidClient
 
 _RPC_TIMEOUT_SECONDS = 30.0
+# Compaction runs a full model turn, so it needs a far larger budget than the
+# metadata RPCs. The caller's own timeout still bounds the operation.
 _COMPACTION_TIMEOUT_SECONDS = 300.0
-_MCP_SETTLE_SECONDS = 3.0
 _MCP_POLL_SECONDS = 0.1
 _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
 
@@ -61,6 +67,9 @@ class CompactionResult:
 class DroidRpcExtension:
     """Compatibility shim for RPCs not yet exposed by droid-sdk-python."""
 
+    def __init__(self, *, mcp_settle_seconds: float = 0.0) -> None:
+        self._mcp_settle_seconds = max(0.0, mcp_settle_seconds)
+
     async def add_user_message(
         self,
         client: DroidClient,
@@ -77,7 +86,7 @@ class DroidRpcExtension:
             params["files"] = files
         if output_format is not None:
             params["outputFormat"] = output_format
-        await self._request(client, "droid.add_user_message", params)
+        await self._request(client, DroidServerMethod.ADD_USER_MESSAGE.value, params)
 
     async def disable_native_tools(self, client: DroidClient) -> None:
         await self._wait_for_mcp_catalog(client)
@@ -87,10 +96,10 @@ class DroidRpcExtension:
         tool_ids = sorted({_required_str(tool, "id") for tool in tools})
         await self._request(
             client,
-            "droid.update_session_settings",
+            DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
             {
-                "interactionMode": "auto",
-                "autonomyLevel": "off",
+                "interactionMode": DroidInteractionMode.Auto.value,
+                "autonomyLevel": AutonomyLevel.Off.value,
                 "enabledToolIds": [],
                 "disabledToolIds": tool_ids,
             },
@@ -106,13 +115,20 @@ class DroidRpcExtension:
             raise DroidClientError(f"Failed to disable native Droid tools: {rendered}")
 
     async def _wait_for_mcp_catalog(self, client: DroidClient) -> None:
-        deadline = asyncio.get_running_loop().time() + _MCP_SETTLE_SECONDS
+        # Off by default: MCP servers that never leave "connecting" would
+        # otherwise burn the whole window on every turn, and the catalog can
+        # still grow afterwards. Droid registers tools disallowed by default,
+        # so waiting buys a larger verification snapshot, not the guarantee.
+        if self._mcp_settle_seconds <= 0:
+            return
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._mcp_settle_seconds
         while True:
-            result = await self._request(client, "droid.list_mcp_servers", {})
+            result = await self._request(client, DroidServerMethod.LIST_MCP_SERVERS.value, {})
             servers = _required_list(result, "servers")
-            if not any(_required_str(server, "status") == "connecting" for server in servers):
+            if not any(server.get("status") == "connecting" for server in servers):
                 return
-            if asyncio.get_running_loop().time() >= deadline:
+            if loop.time() >= deadline:
                 return
             await asyncio.sleep(_MCP_POLL_SECONDS)
 

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from droid_sdk.errors import DroidClientError
+
+if TYPE_CHECKING:
+    from droid_sdk import DroidClient
+
+_RPC_TIMEOUT_SECONDS = 30.0
+_COMPACTION_TIMEOUT_SECONDS = 300.0
+_MCP_SETTLE_SECONDS = 3.0
+_MCP_POLL_SECONDS = 0.1
+_UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
+
+
+class _ProtocolEngine(Protocol):
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        timeout: float | None = None,
+        request_id: str | None = None,
+    ) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ContextStats:
+    used: int
+    remaining: int
+    limit: int
+    accuracy: str
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContextCategory:
+    name: str
+    tokens: int
+    color_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContextBreakdown:
+    model_id: str
+    model_display_name: str
+    context_budget: int
+    used_tokens: int
+    free_tokens: int
+    categories: tuple[ContextCategory, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CompactionResult:
+    new_session_id: str
+    removed_count: int
+
+
+class DroidRpcExtension:
+    """Compatibility shim for RPCs not yet exposed by droid-sdk-python."""
+
+    async def add_user_message(
+        self,
+        client: DroidClient,
+        *,
+        text: str,
+        images: list[dict[str, Any]] | None,
+        files: list[dict[str, Any]] | None,
+        output_format: dict[str, Any] | None,
+    ) -> None:
+        params: dict[str, Any] = {"text": text}
+        if images is not None:
+            params["images"] = images
+        if files is not None:
+            params["files"] = files
+        if output_format is not None:
+            params["outputFormat"] = output_format
+        await self._request(client, "droid.add_user_message", params)
+
+    async def disable_native_tools(self, client: DroidClient) -> None:
+        await self._wait_for_mcp_catalog(client)
+        tools = await self._list_tools(client)
+        if not tools:
+            raise DroidClientError("Droid returned an empty native tool catalog")
+        tool_ids = sorted({_required_str(tool, "id") for tool in tools})
+        await self._request(
+            client,
+            "droid.update_session_settings",
+            {
+                "interactionMode": "auto",
+                "autonomyLevel": "off",
+                "enabledToolIds": [],
+                "disabledToolIds": tool_ids,
+            },
+        )
+        remaining = {
+            _required_str(tool, "id")
+            for tool in await self._list_tools(client)
+            if _required_bool(tool, "currentlyAllowed")
+        }
+        unexpected = remaining - _UNAVOIDABLE_TOOL_IDS
+        if unexpected:
+            rendered = ", ".join(sorted(unexpected))
+            raise DroidClientError(f"Failed to disable native Droid tools: {rendered}")
+
+    async def _wait_for_mcp_catalog(self, client: DroidClient) -> None:
+        deadline = asyncio.get_running_loop().time() + _MCP_SETTLE_SECONDS
+        while True:
+            result = await self._request(client, "droid.list_mcp_servers", {})
+            servers = _required_list(result, "servers")
+            if not any(_required_str(server, "status") == "connecting" for server in servers):
+                return
+            if asyncio.get_running_loop().time() >= deadline:
+                return
+            await asyncio.sleep(_MCP_POLL_SECONDS)
+
+    async def get_context_stats(self, client: DroidClient) -> ContextStats:
+        result = await self._request(client, "droid.get_context_stats", {})
+        return ContextStats(
+            used=_required_int(result, "used"),
+            remaining=_required_int(result, "remaining"),
+            limit=_required_int(result, "limit"),
+            accuracy=_required_str(result, "accuracy"),
+            updated_at=_required_str(result, "updatedAt"),
+        )
+
+    async def get_context_breakdown(self, client: DroidClient) -> ContextBreakdown:
+        result = await self._request(client, "droid.get_context_breakdown", {})
+        categories = tuple(
+            ContextCategory(
+                name=_required_str(item, "name"),
+                tokens=_required_int(item, "tokens"),
+                color_key=_required_str(item, "colorKey"),
+            )
+            for item in _required_list(result, "categories")
+        )
+        return ContextBreakdown(
+            model_id=_required_str(result, "modelId"),
+            model_display_name=_required_str(result, "modelDisplayName"),
+            context_budget=_required_int(result, "contextBudget"),
+            used_tokens=_required_int(result, "usedTokens"),
+            free_tokens=_required_int(result, "freeTokens"),
+            categories=categories,
+        )
+
+    async def compact_session(
+        self,
+        client: DroidClient,
+        *,
+        custom_instructions: str | None,
+    ) -> CompactionResult:
+        params = (
+            {"customInstructions": custom_instructions} if custom_instructions is not None else {}
+        )
+        result = await self._request(
+            client,
+            "droid.compact_session",
+            params,
+            timeout=_COMPACTION_TIMEOUT_SECONDS,
+        )
+        return CompactionResult(
+            new_session_id=_required_str(result, "newSessionId"),
+            removed_count=_required_int(result, "removedCount"),
+        )
+
+    async def fork_session(self, client: DroidClient) -> str:
+        result = await self._request(client, "droid.fork_session", {})
+        return _required_str(result, "newSessionId")
+
+    async def rename_session(self, client: DroidClient, *, title: str) -> None:
+        await self._request(client, "droid.rename_session", {"title": title})
+
+    async def close_session(self, client: DroidClient, *, reason: str = "other") -> None:
+        await self._request(client, "droid.close_session", {"reason": reason})
+
+    async def _list_tools(self, client: DroidClient) -> list[dict[str, Any]]:
+        result = await self._request(client, "droid.list_tools", {})
+        return _required_list(result, "tools")
+
+    async def _request(
+        self,
+        client: DroidClient,
+        method: str,
+        params: dict[str, Any],
+        *,
+        timeout: float = _RPC_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        response = await _protocol(client).send_request(
+            method=method,
+            params=params,
+            timeout=timeout,
+        )
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise DroidClientError(f"{method} returned a malformed result")
+        return result
+
+
+def _protocol(client: DroidClient) -> _ProtocolEngine:
+    protocol = getattr(client, "_protocol", None)
+    if protocol is None or not callable(getattr(protocol, "send_request", None)):
+        raise DroidClientError("Droid SDK protocol engine is unavailable")
+    return cast("_ProtocolEngine", protocol)
+
+
+def _required_list(payload: dict[str, Any], field: str) -> list[dict[str, Any]]:
+    value = payload.get(field)
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise DroidClientError(f"Droid RPC field '{field}' is malformed")
+    return cast("list[dict[str, Any]]", value)
+
+
+def _required_str(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str):
+        raise DroidClientError(f"Droid RPC field '{field}' is malformed")
+    return value
+
+
+def _required_int(payload: dict[str, Any], field: str) -> int:
+    value = payload.get(field)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise DroidClientError(f"Droid RPC field '{field}' is malformed")
+    return value
+
+
+def _required_bool(payload: dict[str, Any], field: str) -> bool:
+    value = payload.get(field)
+    if not isinstance(value, bool):
+        raise DroidClientError(f"Droid RPC field '{field}' is malformed")
+    return value

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -21,6 +21,7 @@ class BridgeMetrics:
         self._overload_rejections = 0
         self._payload_rejections = 0
         self._forced_kills = 0
+        self._model_discovery_failures = 0
 
     def record_request(self, outcome: str, status_code: int, seconds: float) -> None:
         with self._lock:
@@ -60,6 +61,10 @@ class BridgeMetrics:
         with self._lock:
             self._forced_kills += 1
 
+    def increment_model_discovery_failures(self) -> None:
+        with self._lock:
+            self._model_discovery_failures += 1
+
     def render(self) -> str:
         with self._lock:
             request_totals = sorted(self._request_totals.items())
@@ -77,6 +82,7 @@ class BridgeMetrics:
                 "overload_rejections": self._overload_rejections,
                 "payload_rejections": self._payload_rejections,
                 "forced_kills": self._forced_kills,
+                "model_discovery_failures": self._model_discovery_failures,
             }
 
         lines = [
@@ -113,5 +119,10 @@ class BridgeMetrics:
             (f"factory_droid_openai_payload_rejections_total {values['payload_rejections']}"),
             "# TYPE factory_droid_openai_forced_kills_total counter",
             f"factory_droid_openai_forced_kills_total {values['forced_kills']}",
+            "# TYPE factory_droid_openai_model_discovery_failures_total counter",
+            (
+                "factory_droid_openai_model_discovery_failures_total "
+                f"{values['model_discovery_failures']}"
+            ),
         ]
         return "\n".join(lines) + "\n"

--- a/src/factory_droid_openai/models.py
+++ b/src/factory_droid_openai/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -54,6 +54,11 @@ class ModelInfo(BaseModel):
     object: Literal["model"] = "model"
     created: int
     owned_by: str
+    factory_droid_display_name: str | None = None
+    factory_droid_supported_reasoning_efforts: list[str] | None = None
+    factory_droid_default_reasoning_effort: str | None = None
+    factory_droid_supports_images: bool | None = None
+    factory_droid_supports_pdfs: bool | None = None
 
 
 class ModelListResponse(BaseModel):
@@ -103,6 +108,34 @@ class ErrorResponse(BaseModel):
     error: ErrorDetail
 
 
+class JsonSchemaDefinition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=64, pattern=r"^[A-Za-z0-9_-]+$")
+    description: str | None = None
+    schema_: dict[str, Any] = Field(alias="schema")
+    strict: bool | None = None
+
+
+class JsonSchemaResponseFormat(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["json_schema"]
+    json_schema: JsonSchemaDefinition
+
+
+class JsonObjectResponseFormat(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["json_object"]
+
+
+ResponseFormat = Annotated[
+    JsonSchemaResponseFormat | JsonObjectResponseFormat,
+    Field(discriminator="type"),
+]
+
+
 class ChatCompletionRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -120,6 +153,7 @@ class ChatCompletionRequest(BaseModel):
     parallel_tool_calls: bool = True
     factory_droid_session_id: str | None = None
     factory_droid_status: bool = False
+    response_format: ResponseFormat | None = None
 
     @model_validator(mode="after")
     def validate_messages(self) -> ChatCompletionRequest:
@@ -133,3 +167,54 @@ class ChatCompletionRequest(BaseModel):
             return ()
         values = [self.stop] if isinstance(self.stop, str) else self.stop
         return tuple(value for value in values if value)
+
+
+class ContextStatsResponse(BaseModel):
+    used: int
+    remaining: int
+    limit: int
+    accuracy: str
+    updated_at: str
+
+
+class ContextCategoryResponse(BaseModel):
+    name: str
+    tokens: int
+    color_key: str
+
+
+class ContextBreakdownResponse(BaseModel):
+    model_id: str
+    model_display_name: str
+    context_budget: int
+    used_tokens: int
+    free_tokens: int
+    categories: list[ContextCategoryResponse]
+
+
+class SessionContextResponse(BaseModel):
+    session_id: str
+    stats: ContextStatsResponse
+    breakdown: ContextBreakdownResponse
+
+
+class CompactSessionRequest(BaseModel):
+    custom_instructions: str | None = Field(default=None, max_length=16_384)
+
+
+class CompactSessionResponse(BaseModel):
+    session_id: str
+    removed_count: int
+
+
+class ForkSessionResponse(BaseModel):
+    session_id: str
+
+
+class RenameSessionRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=256)
+
+
+class SessionOperationResponse(BaseModel):
+    session_id: str
+    status: Literal["renamed", "closed"]

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -28,6 +29,7 @@ __all__ = [
     "ToolCallEmission",
     "ToolCallStreamParser",
     "build_prompt",
+    "parse_strict_json",
 ]
 
 
@@ -257,10 +259,11 @@ class ToolCallStreamParser:
             return self._consume_tool_payload(chunk)
         return self._consume_text(chunk)
 
-    def finish(self) -> list[ProtocolEmission]:
+    def finish(self) -> list[TextEmission]:
+        """Flushes buffered text. A tool call can only complete inside ``feed``."""
         if self._capturing:
             raise ProtocolError("incomplete tool-call marker")
-        emissions: list[ProtocolEmission] = []
+        emissions: list[TextEmission] = []
         if self._text_tail:
             # After a tool call only whitespace may separate further calls; any
             # residual non-whitespace is trailing output and must fail closed.
@@ -359,7 +362,7 @@ class ToolCallStreamParser:
         if not self._allowed_tool_names:
             raise ProtocolError("the model requested a tool when none are available")
         try:
-            parsed = json.loads(payload, object_pairs_hook=_reject_duplicate_keys)
+            parsed = parse_strict_json(payload)
         except (json.JSONDecodeError, ValueError) as exc:
             raise ProtocolError(f"invalid tool-call JSON: {exc}") from exc
         if not isinstance(parsed, dict):
@@ -431,6 +434,21 @@ class StopSequenceBuffer:
         return held
 
 
+def parse_strict_json(text: str) -> Any:
+    """Parses model-generated JSON, rejecting everything outside RFC 8259.
+
+    Duplicate keys, ``NaN``/``Infinity`` literals and numbers that overflow to
+    a non-finite float are all refused, so a caller never forwards a value a
+    strict JSON parser on the client side would reject.
+    """
+    return json.loads(
+        text,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_json_constant,
+        parse_float=_parse_finite_float,
+    )
+
+
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
@@ -438,6 +456,17 @@ def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
             raise ValueError(f"duplicate key '{key}'")
         result[key] = value
     return result
+
+
+def _reject_non_json_constant(value: str) -> None:
+    raise ValueError(f"non-JSON numeric constant '{value}'")
+
+
+def _parse_finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite number '{value}'")
+    return parsed
 
 
 def _serialize_json(value: Any) -> tuple[str, int]:

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
 
 from droid_sdk import (
     AssistantTextDelta,
@@ -25,7 +25,18 @@ from droid_sdk import (
     WorkingStateChanged,
 )
 from droid_sdk import TimeoutError as DroidTimeoutError
-from droid_sdk.schemas.enums import AutonomyLevel, ReasoningEffort
+from droid_sdk.schemas.enums import (
+    AutonomyLevel,
+    DroidInteractionMode,
+    ReasoningEffort,
+)
+
+from factory_droid_openai.droid_rpc import (
+    CompactionResult,
+    ContextBreakdown,
+    ContextStats,
+    DroidRpcExtension,
+)
 
 # droid exec flags the SDK's ProcessTransport always passes. Overriding
 # exec_args replaces this list wholesale, so extra flags must be appended
@@ -63,6 +74,18 @@ class RunRequest:
     images: tuple[dict[str, Any], ...] = ()
     documents: tuple[dict[str, Any], ...] = ()
     session_id: str | None = None
+    output_format: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DroidModel:
+    id: str
+    display_name: str
+    provider: str
+    supported_reasoning_efforts: tuple[str, ...]
+    default_reasoning_effort: str
+    supports_images: bool
+    supports_pdfs: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,6 +128,7 @@ class StatusUpdate:
 
 RunEvent = TextDelta | ReasoningDelta | UsageUpdate | RunComplete | SessionStarted | StatusUpdate
 ClientFactory = Callable[[str, Path], DroidClient]
+OperationResult = TypeVar("OperationResult")
 
 
 class RunnerMetrics(Protocol):
@@ -183,6 +207,7 @@ class DroidRunner:
         metrics: RunnerMetrics | None = None,
         worktree: str | None = None,
         append_system_prompt_file: Path | None = None,
+        rpc_extension: DroidRpcExtension | None = None,
     ) -> None:
         self._droid_path = droid_path
         self._workdir = workdir
@@ -190,6 +215,7 @@ class DroidRunner:
         self._process_grace_seconds = process_grace_seconds
         self._cleanup_timeout_seconds = cleanup_timeout_seconds
         self._metrics = metrics
+        self._rpc = rpc_extension or DroidRpcExtension()
         self._exec_args = _build_exec_args(
             worktree=worktree,
             append_system_prompt_file=append_system_prompt_file,
@@ -226,25 +252,40 @@ class DroidRunner:
                 if request.session_id is not None:
                     # Continuation: reuse the stored Droid session so only the
                     # new turn is sent instead of the whole transcript.
-                    await client.load_session(session_id=request.session_id)
+                    await client.load_session(
+                        session_id=request.session_id,
+                        mcp_servers=[],
+                    )
                 else:
                     await client.initialize_session(
                         machine_id="factory-droid-openai",
                         cwd=str(self._workdir),
+                        mcp_servers=[],
                         model_id=_resolve_model_id(request.model, request.model_alias),
                         reasoning_effort=reasoning_effort,
+                        interaction_mode=DroidInteractionMode.Auto,
                         autonomy_level=AutonomyLevel.Off,
                         skip_permissions_unsafe=False,
                         enabled_tool_ids=[],
                     )
                 initialized = True
+                await self._rpc.disable_native_tools(client)
                 if client.session_id is not None:
                     yield SessionStarted(client.session_id)
-                await client.add_user_message(
-                    text=request.prompt,
-                    images=list(request.images) or None,
-                    files=list(request.documents) or None,
-                )
+                if request.output_format is None:
+                    await client.add_user_message(
+                        text=request.prompt,
+                        images=list(request.images) or None,
+                        files=list(request.documents) or None,
+                    )
+                else:
+                    await self._rpc.add_user_message(
+                        client,
+                        text=request.prompt,
+                        images=list(request.images) or None,
+                        files=list(request.documents) or None,
+                        output_format=request.output_format,
+                    )
 
                 async for event in client.receive_response():
                     if isinstance(event, AssistantTextDelta):
@@ -299,6 +340,176 @@ class DroidRunner:
                     interrupt=initialized and not completed,
                 )
             )
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                await cleanup_task
+                raise
+
+    async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+        async def operation(client: DroidClient) -> tuple[DroidModel, ...]:
+            result = await client.initialize_session(
+                machine_id="factory-droid-openai-models",
+                cwd=str(self._workdir),
+                mcp_servers=[],
+                interaction_mode=DroidInteractionMode.Auto,
+                autonomy_level=AutonomyLevel.Off,
+                skip_permissions_unsafe=False,
+                enabled_tool_ids=[],
+            )
+            models = result.available_models or []
+            await self._rpc.close_session(client, reason="clear")
+            return tuple(
+                DroidModel(
+                    id=model.id,
+                    display_name=model.display_name,
+                    provider=_state_value(model.model_provider),
+                    supported_reasoning_efforts=tuple(
+                        _state_value(effort) for effort in model.supported_reasoning_efforts
+                    ),
+                    default_reasoning_effort=_state_value(model.default_reasoning_effort),
+                    supports_images=not bool(model.no_image_support),
+                    supports_pdfs=bool(model.supports_pdfs),
+                )
+                for model in models
+            )
+
+        return await self._session_operation(
+            operation,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def get_context(
+        self,
+        session_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[ContextStats, ContextBreakdown]:
+        async def operation(
+            client: DroidClient,
+        ) -> tuple[ContextStats, ContextBreakdown]:
+            return (
+                await self._rpc.get_context_stats(client),
+                await self._rpc.get_context_breakdown(client),
+            )
+
+        return await self._loaded_session_operation(
+            session_id,
+            operation,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def compact_session(
+        self,
+        session_id: str,
+        *,
+        custom_instructions: str | None,
+        timeout_seconds: float,
+    ) -> CompactionResult:
+        async def operation(client: DroidClient) -> CompactionResult:
+            return await self._rpc.compact_session(
+                client,
+                custom_instructions=custom_instructions,
+            )
+
+        return await self._loaded_session_operation(
+            session_id,
+            operation,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def fork_session(self, session_id: str, *, timeout_seconds: float) -> str:
+        return await self._loaded_session_operation(
+            session_id,
+            self._rpc.fork_session,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def rename_session(
+        self,
+        session_id: str,
+        *,
+        title: str,
+        timeout_seconds: float,
+    ) -> None:
+        async def operation(client: DroidClient) -> None:
+            await self._rpc.rename_session(client, title=title)
+
+        await self._loaded_session_operation(
+            session_id,
+            operation,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def close_session(self, session_id: str, *, timeout_seconds: float) -> None:
+        async def operation(client: DroidClient) -> None:
+            await self._rpc.close_session(client)
+
+        await self._loaded_session_operation(
+            session_id,
+            operation,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def _loaded_session_operation(
+        self,
+        session_id: str,
+        operation: Callable[[DroidClient], Awaitable[OperationResult]],
+        *,
+        timeout_seconds: float,
+    ) -> OperationResult:
+        async def loaded(client: DroidClient) -> OperationResult:
+            await client.load_session(session_id=session_id, mcp_servers=[])
+            await self._rpc.disable_native_tools(client)
+            return await operation(client)
+
+        return await self._session_operation(
+            loaded,
+            timeout_seconds=timeout_seconds,
+            session_id=session_id,
+        )
+
+    async def _session_operation(
+        self,
+        operation: Callable[[DroidClient], Awaitable[OperationResult]],
+        *,
+        timeout_seconds: float,
+        session_id: str | None = None,
+    ) -> OperationResult:
+        client, transport = self._new_client()
+        client.set_permission_handler(lambda _params: "cancel")
+        client.set_ask_user_handler(
+            lambda _params: {"cancelled": True, "answers": []},
+        )
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                await client.connect()
+                return await operation(client)
+        except (TimeoutError, DroidTimeoutError) as exc:
+            raise RunnerError(
+                f"Factory Droid timed out after {timeout_seconds:.1f} seconds.",
+                status_code=504,
+                error_type="factory_droid_timeout",
+            ) from exc
+        except FileNotFoundError as exc:
+            raise RunnerError(
+                f"Factory Droid executable was not found: {self._droid_path}",
+                status_code=503,
+                error_type="factory_droid_unavailable",
+            ) from exc
+        except SessionNotFoundError as exc:
+            raise RunnerError(
+                f"Factory Droid session '{session_id}' was not found.",
+                status_code=404,
+                error_type="session_not_found",
+            ) from exc
+        except DroidClientError as exc:
+            raise RunnerError(
+                f"Factory Droid SDK failed: {exc}",
+                error_type="factory_droid_sdk_error",
+            ) from exc
+        finally:
+            cleanup_task = asyncio.create_task(self._cleanup(client, transport, interrupt=False))
             try:
                 await asyncio.shield(cleanup_task)
             except asyncio.CancelledError:

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -388,15 +388,17 @@ class DroidRunner:
         async def operation(
             client: DroidClient,
         ) -> tuple[ContextStats, ContextBreakdown]:
-            return (
-                await self._rpc.get_context_stats(client),
-                await self._rpc.get_context_breakdown(client),
+            stats, breakdown = await asyncio.gather(
+                self._rpc.get_context_stats(client),
+                self._rpc.get_context_breakdown(client),
             )
+            return stats, breakdown
 
         return await self._loaded_session_operation(
             session_id,
             operation,
             timeout_seconds=timeout_seconds,
+            disable_tools=False,
         )
 
     async def compact_session(
@@ -423,6 +425,7 @@ class DroidRunner:
             session_id,
             self._rpc.fork_session,
             timeout_seconds=timeout_seconds,
+            disable_tools=False,
         )
 
     async def rename_session(
@@ -439,6 +442,7 @@ class DroidRunner:
             session_id,
             operation,
             timeout_seconds=timeout_seconds,
+            disable_tools=False,
         )
 
     async def close_session(self, session_id: str, *, timeout_seconds: float) -> None:
@@ -449,6 +453,7 @@ class DroidRunner:
             session_id,
             operation,
             timeout_seconds=timeout_seconds,
+            disable_tools=False,
         )
 
     async def _loaded_session_operation(
@@ -457,10 +462,14 @@ class DroidRunner:
         operation: Callable[[DroidClient], Awaitable[OperationResult]],
         *,
         timeout_seconds: float,
+        disable_tools: bool = True,
     ) -> OperationResult:
         async def loaded(client: DroidClient) -> OperationResult:
             await client.load_session(session_id=session_id, mcp_servers=[])
-            await self._rpc.disable_native_tools(client)
+            # Metadata-only operations never run a model turn, so they neither
+            # need the tool guard nor should they rewrite session settings.
+            if disable_tools:
+                await self._rpc.disable_native_tools(client)
             return await operation(client)
 
         return await self._session_operation(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,6 +24,12 @@ from factory_droid_openai.app import (
     create_app,
 )
 from factory_droid_openai.config import Settings
+from factory_droid_openai.droid_rpc import (
+    CompactionResult,
+    ContextBreakdown,
+    ContextCategory,
+    ContextStats,
+)
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.protocol import (
     TOOL_CALL_CLOSE,
@@ -31,6 +37,7 @@ from factory_droid_openai.protocol import (
     ToolCallStreamParser,
 )
 from factory_droid_openai.runner import (
+    DroidModel,
     ReasoningDelta,
     RunComplete,
     RunEvent,
@@ -62,6 +69,7 @@ class FakeRunner:
         self.error = error
         self.requests: list[RunRequest] = []
         self.closed = False
+        self.session_operations: list[tuple[str, str, object | None]] = []
 
     async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
         self.requests.append(request)
@@ -72,6 +80,70 @@ class FakeRunner:
                 yield event
         finally:
             self.closed = True
+
+    async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+        del timeout_seconds
+        return (
+            DroidModel(
+                id="gpt-5.4",
+                display_name="GPT-5.4",
+                provider="openai",
+                supported_reasoning_efforts=("low", "high"),
+                default_reasoning_effort="high",
+                supports_images=True,
+                supports_pdfs=True,
+            ),
+        )
+
+    async def get_context(
+        self,
+        session_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> tuple[ContextStats, ContextBreakdown]:
+        del timeout_seconds
+        self.session_operations.append(("context", session_id, None))
+        return (
+            ContextStats(100, 900, 1000, "exact", "2026-07-27T00:00:00Z"),
+            ContextBreakdown(
+                "gpt-5.4",
+                "GPT-5.4",
+                1000,
+                100,
+                900,
+                (ContextCategory("messages", 100, "blue"),),
+            ),
+        )
+
+    async def compact_session(
+        self,
+        session_id: str,
+        *,
+        custom_instructions: str | None,
+        timeout_seconds: float,
+    ) -> CompactionResult:
+        del timeout_seconds
+        self.session_operations.append(("compact", session_id, custom_instructions))
+        return CompactionResult("session-compact", 4)
+
+    async def fork_session(self, session_id: str, *, timeout_seconds: float) -> str:
+        del timeout_seconds
+        self.session_operations.append(("fork", session_id, None))
+        return "session-fork"
+
+    async def rename_session(
+        self,
+        session_id: str,
+        *,
+        title: str,
+        timeout_seconds: float,
+    ) -> None:
+        del timeout_seconds
+        self.session_operations.append(("rename", session_id, title))
+
+    async def close_session(self, session_id: str, *, timeout_seconds: float) -> None:
+        del timeout_seconds
+        self.session_operations.append(("close", session_id, None))
 
 
 class BlockingRunner(FakeRunner):
@@ -164,6 +236,38 @@ async def test_health_and_models(tmp_path: Path) -> None:
 
     assert health.json() == {"status": "ok"}
     assert models.json()["data"][0]["id"] == "factory-droid"
+    assert models.json()["data"][1] == {
+        "id": "gpt-5.4",
+        "object": "model",
+        "created": 0,
+        "owned_by": "openai",
+        "factory_droid_display_name": "GPT-5.4",
+        "factory_droid_supported_reasoning_efforts": ["low", "high"],
+        "factory_droid_default_reasoning_effort": "high",
+        "factory_droid_supports_images": True,
+        "factory_droid_supports_pdfs": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_models_falls_back_to_alias_when_droid_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    class UnavailableRunner(FakeRunner):
+        async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+            del timeout_seconds
+            raise RunnerError(
+                "Droid missing",
+                status_code=503,
+                error_type="factory_droid_unavailable",
+            )
+
+    runner = UnavailableRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.get("/v1/models")
+
+    assert response.status_code == 200
+    assert [model["id"] for model in response.json()["data"]] == ["factory-droid"]
 
 
 @pytest.mark.asyncio
@@ -1347,6 +1451,275 @@ async def test_rejected_attachment_returns_a_client_error(tmp_path: Path) -> Non
 
     assert response.status_code == 400
     assert "remote image URLs" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_json_schema_response_format_is_enforced_and_forwarded(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta('{"answer":7}'), RunComplete(Usage())])
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+    payload = _payload(
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "strict": True,
+                "schema": schema,
+            },
+        }
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == '{"answer":7}'
+    assert runner.requests[0].output_format == {
+        "type": "json_schema",
+        "schema": schema,
+    }
+
+
+@pytest.mark.asyncio
+async def test_json_object_response_format_maps_to_a_generic_schema(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta('{"ok":true}'), RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(response_format={"type": "json_object"}),
+        )
+
+    assert response.status_code == 200
+    assert runner.requests[0].output_format == {
+        "type": "json_schema",
+        "schema": {"type": "object", "additionalProperties": True},
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "not_object",
+                "schema": {"type": "array"},
+            },
+        },
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "invalid",
+                "schema": {"type": "object", "required": "not-an-array"},
+            },
+        },
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "remote",
+                "schema": {
+                    "type": "object",
+                    "properties": {"value": {"$ref": "https://example.com/schema"}},
+                },
+            },
+        },
+    ],
+)
+async def test_invalid_response_format_is_rejected_before_the_runner(
+    tmp_path: Path,
+    response_format: dict[str, object],
+) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(response_format=response_format),
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert runner.requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ['{"answer":"wrong"}', '{"answer":1,"answer":2}', "NaN"])
+async def test_invalid_structured_output_fails_closed(
+    tmp_path: Path,
+    text: str,
+) -> None:
+    runner = FakeRunner([TextDelta(text), RunComplete(Usage())])
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+    }
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"name": "answer", "schema": schema},
+                }
+            ),
+        )
+
+    assert response.status_code == 502
+    assert response.json()["error"]["type"] == "factory_protocol_error"
+
+
+@pytest.mark.asyncio
+async def test_streaming_structured_output_is_checked_before_finish(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta('{"answer":7}'), RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                stream=True,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "answer",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "integer"}},
+                            "required": ["answer"],
+                        },
+                    },
+                },
+            ),
+        )
+
+    assert '"content":"{\\"answer\\":7}"' in response.text
+    assert '"finish_reason":"stop"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_invalid_streaming_structured_output_is_not_emitted(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta('{"answer":"wrong"}'), RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                stream=True,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "answer",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "integer"}},
+                            "required": ["answer"],
+                        },
+                    },
+                },
+            ),
+        )
+
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: {")
+    ]
+    content = [
+        choice["delta"].get("content")
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+        if choice["delta"].get("content")
+    ]
+    assert content == []
+    assert chunks[-1]["error"]["type"] == "factory_protocol_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"stop": "HALT"},
+        {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "lookup", "parameters": {}},
+                }
+            ]
+        },
+    ],
+)
+async def test_response_format_rejects_incompatible_bridge_options(
+    tmp_path: Path,
+    extra: dict[str, object],
+) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    payload = _payload(response_format={"type": "json_object"}, **extra)
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    assert runner.requests == []
+
+
+@pytest.mark.asyncio
+async def test_guarded_factory_session_operations(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            SessionStarted("session-77"),
+            TextDelta("created"),
+            RunComplete(Usage()),
+        ]
+    )
+    app = _feature_app(tmp_path, runner, session_continuity=True)
+    async with _client(app) as client:
+        assert (await client.post("/v1/chat/completions", json=_payload())).status_code == 200
+        context = await client.get("/v1/factory/sessions/session-77/context")
+        compact = await client.post(
+            "/v1/factory/sessions/session-77/compact",
+            json={"custom_instructions": "Keep decisions."},
+        )
+        fork = await client.post("/v1/factory/sessions/session-77/fork")
+        rename = await client.patch(
+            "/v1/factory/sessions/session-77",
+            json={"title": "New title"},
+        )
+        close = await client.delete("/v1/factory/sessions/session-77")
+        missing = await client.get("/v1/factory/sessions/session-77/context")
+
+    assert context.json()["stats"]["used"] == 100
+    assert context.json()["breakdown"]["categories"][0]["name"] == "messages"
+    assert compact.json() == {"session_id": "session-compact", "removed_count": 4}
+    assert fork.json() == {"session_id": "session-fork"}
+    assert rename.json()["status"] == "renamed"
+    assert close.json()["status"] == "closed"
+    assert missing.status_code == 404
+    assert runner.session_operations == [
+        ("context", "session-77", None),
+        ("compact", "session-77", "Keep decisions."),
+        ("fork", "session-77", None),
+        ("rename", "session-77", "New title"),
+        ("close", "session-77", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_factory_session_operations_require_continuity(tmp_path: Path) -> None:
+    runner = FakeRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.get("/v1/factory/sessions/session-1/context")
+
+    assert response.status_code == 400
+    assert "disabled" in response.json()["error"]["message"]
 
 
 def test_session_registry_evicts_the_oldest_entries() -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -235,11 +235,13 @@ async def test_health_and_models(tmp_path: Path) -> None:
         models = await client.get("/v1/models")
 
     assert health.json() == {"status": "ok"}
-    assert models.json()["data"][0]["id"] == "factory-droid"
+    alias = models.json()["data"][0]
+    assert alias["id"] == "factory-droid"
+    assert alias["created"] > 0
     assert models.json()["data"][1] == {
         "id": "gpt-5.4",
         "object": "model",
-        "created": 0,
+        "created": alias["created"],
         "owned_by": "openai",
         "factory_droid_display_name": "GPT-5.4",
         "factory_droid_supported_reasoning_efforts": ["low", "high"],
@@ -265,9 +267,149 @@ async def test_models_falls_back_to_alias_when_droid_is_unavailable(
     runner = UnavailableRunner([])
     async with _client(_app(tmp_path, runner)) as client:
         response = await client.get("/v1/models")
+        metrics = await client.get("/metrics")
 
     assert response.status_code == 200
     assert [model["id"] for model in response.json()["data"]] == ["factory-droid"]
+    assert response.headers["x-factory-droid-model-discovery"] == "degraded"
+    assert "factory_droid_openai_model_discovery_failures_total 1" in metrics.text
+    assert 'outcome="success",status="200"' in metrics.text
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_is_cached_and_shared_between_callers(
+    tmp_path: Path,
+) -> None:
+    class CountingRunner(FakeRunner):
+        calls = 0
+
+        async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+            type(self).calls += 1
+            await asyncio.sleep(0)
+            return await super().list_models(timeout_seconds=timeout_seconds)
+
+    runner = CountingRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        first, second = await asyncio.gather(
+            client.get("/v1/models"),
+            client.get("/v1/models"),
+        )
+        third = await client.get("/v1/models")
+
+    assert CountingRunner.calls == 1
+    assert [response.status_code for response in (first, second, third)] == [200, 200, 200]
+    assert "x-factory-droid-model-discovery" not in third.headers
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_serves_the_last_known_catalog_when_droid_breaks(
+    tmp_path: Path,
+) -> None:
+    class FlakyRunner(FakeRunner):
+        fail = False
+
+        async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+            if type(self).fail:
+                raise RunnerError(
+                    "Droid crashed",
+                    status_code=502,
+                    error_type="factory_droid_error",
+                )
+            return await super().list_models(timeout_seconds=timeout_seconds)
+
+    runner = FlakyRunner([])
+    async with _client(_feature_app(tmp_path, runner, model_cache_seconds=0.0)) as client:
+        fresh = await client.get("/v1/models")
+        FlakyRunner.fail = True
+        stale = await client.get("/v1/models")
+
+    assert [model["id"] for model in fresh.json()["data"]] == ["factory-droid", "gpt-5.4"]
+    assert [model["id"] for model in stale.json()["data"]] == ["factory-droid", "gpt-5.4"]
+    assert stale.headers["x-factory-droid-model-discovery"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_model_discovery_hides_an_alias_collision(tmp_path: Path) -> None:
+    class AliasRunner(FakeRunner):
+        async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+            del timeout_seconds
+            return (
+                DroidModel(
+                    id="factory-droid",
+                    display_name="Alias collision",
+                    provider="factory",
+                    supported_reasoning_efforts=("low",),
+                    default_reasoning_effort="low",
+                    supports_images=False,
+                    supports_pdfs=False,
+                ),
+            )
+
+    runner = AliasRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.get("/v1/models")
+
+    assert [model["id"] for model in response.json()["data"]] == ["factory-droid"]
+    assert response.json()["data"][0]["owned_by"] == "factory"
+
+
+@pytest.mark.asyncio
+async def test_overloaded_bridge_rejects_model_and_session_operations(
+    tmp_path: Path,
+) -> None:
+    runner = GateRunner()
+    app = _feature_app(
+        tmp_path,
+        runner,
+        max_concurrency=1,
+        max_queue_size=0,
+        session_continuity=True,
+        retry_after_seconds=3,
+    )
+    app.state.sessions.remember("session-9")
+    async with _client(app) as client:
+        active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
+        await runner.started.wait()
+
+        models = await client.get("/v1/models")
+        context = await client.get("/v1/factory/sessions/session-9/context")
+
+        runner.release.set()
+        assert (await active).status_code == 200
+
+    assert models.status_code == 429
+    assert models.headers["retry-after"] == "3"
+    assert context.status_code == 429
+    assert context.json()["error"]["type"] == "rate_limit_error"
+    assert runner.session_operations == []
+
+
+@pytest.mark.asyncio
+async def test_session_operations_time_out_when_the_queue_eats_the_budget(
+    tmp_path: Path,
+) -> None:
+    runner = GateRunner()
+    app = _feature_app(
+        tmp_path,
+        runner,
+        timeout_seconds=0.2,
+        max_concurrency=1,
+        max_queue_size=1,
+        session_continuity=True,
+    )
+    app.state.sessions.remember("session-9")
+    async with _client(app) as client:
+        active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
+        await runner.started.wait()
+
+        response = await client.delete("/v1/factory/sessions/session-9")
+
+        runner.release.set()
+        await active
+
+    assert response.status_code == 504
+    assert response.json()["error"]["type"] == "factory_droid_timeout"
+    assert runner.session_operations == []
 
 
 @pytest.mark.asyncio
@@ -916,6 +1058,37 @@ async def test_stream_generator_emits_tool_call_from_finish_buffer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_generator_flushes_text_left_in_the_finish_buffer() -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("answer <too"),
+            RunComplete(Usage()),
+        ]
+    )
+
+    events = await _collect_stream(runner)
+
+    assert any('"content":"answer "' in event for event in events)
+    assert any('"content":"<too"' in event for event in events)
+    assert any('"finish_reason":"stop"' in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_flushes_a_partial_stop_sequence() -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("keep HA"),
+            RunComplete(Usage()),
+        ]
+    )
+
+    events = await _collect_stream(runner, stop_sequences=("HALT",))
+
+    assert any('"content":"keep "' in event for event in events)
+    assert any('"content":"HA"' in event for event in events)
+
+
+@pytest.mark.asyncio
 async def test_stream_generator_maps_incomplete_response_to_sse_error() -> None:
     events = await _collect_stream(FakeRunner([TextDelta("partial")]))
 
@@ -1049,6 +1222,7 @@ async def _collect_stream(
     *,
     allowed_tool_names: frozenset[str] = frozenset(),
     include_usage: bool = False,
+    stop_sequences: tuple[str, ...] = (),
 ) -> list[str]:
     metrics = BridgeMetrics()
     admission = AdmissionController(max_concurrency=1, max_queue_size=1, metrics=metrics)
@@ -1070,6 +1244,7 @@ async def _collect_stream(
             ),
             lease=lease,
             include_usage=include_usage,
+            stop_sequences=stop_sequences,
         )
     ]
 
@@ -1133,6 +1308,20 @@ async def test_stop_sequence_truncates_non_streaming_content(tmp_path: Path) -> 
     body = response.json()
     assert body["choices"][0]["message"]["content"] == "keep this "
     assert body["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_partial_stop_sequence_is_flushed_into_the_final_content(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta("keep HA"), RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(stop=["HALT"]),
+        )
+
+    assert response.json()["choices"][0]["message"]["content"] == "keep HA"
 
 
 @pytest.mark.asyncio
@@ -1550,7 +1739,16 @@ async def test_invalid_response_format_is_rejected_before_the_runner(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("text", ['{"answer":"wrong"}', '{"answer":1,"answer":2}', "NaN"])
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"answer":"wrong"}',
+        '{"answer":1,"answer":2}',
+        "NaN",
+        '{"answer":1e999}',
+        '{"answer":1} trailing',
+    ],
+)
 async def test_invalid_structured_output_fails_closed(
     tmp_path: Path,
     text: str,
@@ -1713,6 +1911,110 @@ async def test_guarded_factory_session_operations(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_response_format_schema_over_the_size_cap_is_rejected(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    schema = {
+        "type": "object",
+        "properties": {f"field_{index}": {"type": "string"} for index in range(64)},
+    }
+    app = _feature_app(tmp_path, runner, max_tool_schema_bytes=128)
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"name": "wide", "schema": schema},
+                }
+            ),
+        )
+        metrics = await client.get("/metrics")
+
+    assert response.status_code == 413
+    assert "schema exceeds maximum" in response.json()["error"]["message"]
+    assert runner.requests == []
+    assert "factory_droid_openai_payload_rejections_total 1" in metrics.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_structured_output_over_the_byte_cap_fails_closed(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(json.dumps({"answer": "x" * 256})),
+            RunComplete(Usage()),
+        ]
+    )
+    app = _feature_app(tmp_path, runner, max_structured_output_bytes=64)
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                stream=stream,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "answer",
+                        "schema": {
+                            "type": "object",
+                            "properties": {"answer": {"type": "string"}},
+                        },
+                    },
+                },
+            ),
+        )
+
+    if not stream:
+        assert response.status_code == 502
+        assert "exceeds maximum" in response.json()["error"]["message"]
+        return
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: {")
+    ]
+    assert chunks[-1]["error"]["type"] == "factory_protocol_error"
+    assert "exceeds maximum" in chunks[-1]["error"]["message"]
+    assert not [
+        choice
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+        if choice["delta"].get("content")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_limits_cover_the_factory_session_endpoints(tmp_path: Path) -> None:
+    runner = FakeRunner([])
+    app = _feature_app(
+        tmp_path,
+        runner,
+        session_continuity=True,
+        max_request_bytes=256,
+    )
+    app.state.sessions.remember("session-9")
+    async with _client(app) as client:
+        oversized = await client.post(
+            "/v1/factory/sessions/session-9/compact",
+            json={"custom_instructions": "x" * 512},
+        )
+        deep = await client.patch(
+            "/v1/factory/sessions/session-9",
+            content=b'{"title":' + b"[" * 64 + b"]" * 64 + b"}",
+            headers={"content-type": "application/json"},
+        )
+        metrics = await client.get("/metrics")
+
+    assert oversized.status_code == 413
+    assert deep.status_code == 413
+    assert runner.session_operations == []
+    assert 'outcome="payload_too_large",status="413"' in metrics.text
+
+
+@pytest.mark.asyncio
 async def test_factory_session_operations_require_continuity(tmp_path: Path) -> None:
     runner = FakeRunner([])
     async with _client(_app(tmp_path, runner)) as client:
@@ -1745,6 +2047,32 @@ def test_session_registry_ignores_duplicate_entries() -> None:
 
     assert registry.knows("a") is True
     assert registry.knows("b") is True
+
+
+@pytest.mark.asyncio
+async def test_request_limit_middleware_passes_non_http_scopes_through() -> None:
+    seen: list[str] = []
+
+    async def downstream(scope: Any, _receive: Any, _send: Any) -> None:
+        seen.append(scope["type"])
+
+    middleware = RequestSizeLimitMiddleware(
+        cast("Any", downstream),
+        max_request_bytes=16,
+        max_json_depth=4,
+        body_timeout_seconds=1.0,
+        metrics=BridgeMetrics(),
+    )
+
+    async def receive() -> Any:  # pragma: no cover - never awaited
+        raise AssertionError("lifespan scopes must not read a body")
+
+    async def send(_message: Any) -> None:  # pragma: no cover - never awaited
+        raise AssertionError("lifespan scopes must not send a response")
+
+    await middleware(cast("Any", {"type": "lifespan"}), receive, send)
+
+    assert seen == ["lifespan"]
 
 
 @pytest.mark.parametrize("value", [b"not-a-number", b"-1"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,10 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_MAX_TOOLS",
     "FACTORY_DROID_OPENAI_MAX_TRANSCRIPT_BYTES",
     "FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES",
+    "FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES",
     "FACTORY_DROID_OPENAI_MAX_JSON_DEPTH",
+    "FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS",
+    "FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS",
     "FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS",
     "FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS",
     "FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS",
@@ -81,7 +84,10 @@ def test_settings_from_env_reads_all_overrides(
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_TOOLS", "16")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_TRANSCRIPT_BYTES", "2048")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES", "512")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES", "4096")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_JSON_DEPTH", "8")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "1.5")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS", "0")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS", "3")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS", "2.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS", "6.5")
@@ -106,7 +112,10 @@ def test_settings_from_env_reads_all_overrides(
         max_tools=16,
         max_transcript_bytes=2048,
         max_tool_schema_bytes=512,
+        max_structured_output_bytes=4096,
         max_json_depth=8,
+        mcp_settle_seconds=1.5,
+        model_cache_seconds=0.0,
         retry_after_seconds=3,
         process_grace_seconds=2.5,
         cleanup_timeout_seconds=6.5,
@@ -140,7 +149,15 @@ def test_settings_from_env_reads_all_overrides(
             "0",
             "must be greater than zero",
         ),
+        (
+            "FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES",
+            "0",
+            "must be greater than zero",
+        ),
         ("FACTORY_DROID_OPENAI_MAX_JSON_DEPTH", "0", "must be greater than zero"),
+        ("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "invalid", "must be a number"),
+        ("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "-1", "must be zero or greater"),
+        ("FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS", "inf", "must be zero or greater"),
         (
             "FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS",
             "0",

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from droid_sdk.errors import DroidClientError
+
+from factory_droid_openai.droid_rpc import DroidRpcExtension
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from droid_sdk import DroidClient
+
+
+class FakeProtocol:
+    def __init__(
+        self,
+        handler: Callable[[str, dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        self.handler = handler
+        self.calls: list[tuple[str, dict[str, Any], float | None]] = []
+
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        timeout: float | None = None,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        del request_id
+        self.calls.append((method, params, timeout))
+        return self.handler(method, params)
+
+
+def _client(protocol: object | None) -> DroidClient:
+    return cast("DroidClient", SimpleNamespace(_protocol=protocol))
+
+
+@pytest.mark.asyncio
+async def test_add_user_message_forwards_all_structured_fields() -> None:
+    protocol = FakeProtocol(lambda _method, _params: {"result": {}})
+    extension = DroidRpcExtension()
+    output_format = {"type": "json_schema", "schema": {"type": "object"}}
+
+    await extension.add_user_message(
+        _client(protocol),
+        text="prompt",
+        images=[{"type": "base64"}],
+        files=[{"type": "text"}],
+        output_format=output_format,
+    )
+    await extension.add_user_message(
+        _client(protocol),
+        text="plain",
+        images=None,
+        files=None,
+        output_format=None,
+    )
+
+    assert protocol.calls[0][1] == {
+        "text": "prompt",
+        "images": [{"type": "base64"}],
+        "files": [{"type": "text"}],
+        "outputFormat": output_format,
+    }
+    assert protocol.calls[1][1] == {"text": "plain"}
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_verifies_exec_and_mcp_catalogs() -> None:
+    disabled: set[str] = set()
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": []}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": "read-cli",
+                            "currentlyAllowed": "read-cli" not in disabled,
+                        },
+                        {"id": "exit-spec-mode", "currentlyAllowed": True},
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            disabled.update(params["disabledToolIds"])
+            return {"result": {}}
+        raise AssertionError(method)
+
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension().disable_native_tools(_client(protocol))
+
+    update = next(params for method, params, _ in protocol.calls if "update" in method)
+    assert update["interactionMode"] == "auto"
+    assert update["disabledToolIds"] == ["exit-spec-mode", "read-cli"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tools", "message"),
+    [
+        ([], "empty native tool catalog"),
+        ([{"id": 3, "currentlyAllowed": True}], "'id' is malformed"),
+        ([{"id": "read-cli", "currentlyAllowed": "yes"}], "'currentlyAllowed' is malformed"),
+    ],
+)
+async def test_disable_native_tools_rejects_malformed_catalogs(
+    tools: list[dict[str, object]],
+    message: str,
+) -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": []}}
+        if method == "droid.list_tools":
+            return {"result": {"tools": tools}}
+        return {"result": {}}
+
+    protocol = FakeProtocol(handler)
+
+    with pytest.raises(DroidClientError, match=message):
+        await DroidRpcExtension().disable_native_tools(_client(protocol))
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_bounds_mcp_catalog_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from factory_droid_openai import droid_rpc
+
+    monkeypatch.setattr(droid_rpc, "_MCP_SETTLE_SECONDS", 0.0)
+    disabled = False
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        nonlocal disabled
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"status": "connecting"}]}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {"id": "mcp_tool", "currentlyAllowed": not disabled},
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            disabled = params["disabledToolIds"] == ["mcp_tool"]
+            return {"result": {}}
+        raise AssertionError(method)
+
+    await DroidRpcExtension().disable_native_tools(_client(FakeProtocol(handler)))
+
+    assert disabled is True
+
+
+@pytest.mark.asyncio
+async def test_context_and_session_operations_parse_rpc_results() -> None:
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        results: dict[str, dict[str, Any]] = {
+            "droid.get_context_stats": {
+                "used": 1,
+                "remaining": 9,
+                "limit": 10,
+                "accuracy": "estimated",
+                "updatedAt": "now",
+            },
+            "droid.get_context_breakdown": {
+                "modelId": "model",
+                "modelDisplayName": "Model",
+                "contextBudget": 10,
+                "usedTokens": 1,
+                "freeTokens": 9,
+                "categories": [{"name": "system", "tokens": 1, "colorKey": "gray"}],
+            },
+            "droid.compact_session": {
+                "newSessionId": "compact",
+                "removedCount": 2,
+            },
+            "droid.fork_session": {"newSessionId": "fork"},
+            "droid.rename_session": {},
+            "droid.close_session": {},
+        }
+        assert params == (
+            {"customInstructions": "Keep facts."}
+            if method == "droid.compact_session"
+            else {"title": "Title"}
+            if method == "droid.rename_session"
+            else {"reason": "clear"}
+            if method == "droid.close_session"
+            else {}
+        )
+        return {"result": results[method]}
+
+    protocol = FakeProtocol(handler)
+    client = _client(protocol)
+    extension = DroidRpcExtension()
+
+    stats = await extension.get_context_stats(client)
+    breakdown = await extension.get_context_breakdown(client)
+    compacted = await extension.compact_session(
+        client,
+        custom_instructions="Keep facts.",
+    )
+    forked = await extension.fork_session(client)
+    await extension.rename_session(client, title="Title")
+    await extension.close_session(client, reason="clear")
+
+    assert stats.remaining == 9
+    assert breakdown.categories[0].tokens == 1
+    assert compacted.removed_count == 2
+    assert forked == "fork"
+
+
+@pytest.mark.asyncio
+async def test_compaction_omits_absent_custom_instructions() -> None:
+    protocol = FakeProtocol(
+        lambda _method, params: {"result": {"newSessionId": "compact", "removedCount": len(params)}}
+    )
+
+    result = await DroidRpcExtension().compact_session(
+        _client(protocol),
+        custom_instructions=None,
+    )
+
+    assert result.removed_count == 0
+    assert protocol.calls[0][2] == 300.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result",
+    [
+        None,
+        {"used": True},
+        {"used": 1, "remaining": 2, "limit": 3, "accuracy": 4, "updatedAt": "now"},
+    ],
+)
+async def test_rpc_extension_rejects_malformed_results(result: object) -> None:
+    protocol = FakeProtocol(lambda _method, _params: {"result": result})
+
+    with pytest.raises(DroidClientError, match="malformed"):
+        await DroidRpcExtension().get_context_stats(_client(protocol))
+
+
+@pytest.mark.asyncio
+async def test_rpc_extension_requires_an_sdk_protocol_engine() -> None:
+    with pytest.raises(DroidClientError, match="protocol engine"):
+        await DroidRpcExtension().fork_session(_client(None))

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -106,12 +106,13 @@ async def test_disable_native_tools_verifies_exec_and_mcp_catalogs() -> None:
     ("tools", "message"),
     [
         ([], "empty native tool catalog"),
+        ("not-a-list", "'tools' is malformed"),
         ([{"id": 3, "currentlyAllowed": True}], "'id' is malformed"),
         ([{"id": "read-cli", "currentlyAllowed": "yes"}], "'currentlyAllowed' is malformed"),
     ],
 )
 async def test_disable_native_tools_rejects_malformed_catalogs(
-    tools: list[dict[str, object]],
+    tools: object,
     message: str,
 ) -> None:
     def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
@@ -128,18 +129,50 @@ async def test_disable_native_tools_rejects_malformed_catalogs(
 
 
 @pytest.mark.asyncio
-async def test_disable_native_tools_bounds_mcp_catalog_wait(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from factory_droid_openai import droid_rpc
+async def test_disable_native_tools_skips_the_mcp_probe_by_default() -> None:
+    protocol = FakeProtocol(_settle_handler())
 
-    monkeypatch.setattr(droid_rpc, "_MCP_SETTLE_SECONDS", 0.0)
+    await DroidRpcExtension().disable_native_tools(_client(protocol))
+
+    assert [method for method, _, _ in protocol.calls] == [
+        "droid.list_tools",
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_bounds_mcp_catalog_wait() -> None:
+    protocol = FakeProtocol(_settle_handler())
+
+    await DroidRpcExtension(mcp_settle_seconds=0.15).disable_native_tools(_client(protocol))
+
+    probes = [method for method, _, _ in protocol.calls if method == "droid.list_mcp_servers"]
+    assert len(probes) > 1
+    assert any(method == "droid.update_session_settings" for method, _, _ in protocol.calls)
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_tolerates_mcp_servers_without_status() -> None:
+    handler = _settle_handler(servers=[{"name": "local"}])
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension(mcp_settle_seconds=5.0).disable_native_tools(_client(protocol))
+
+    probes = [method for method, _, _ in protocol.calls if method == "droid.list_mcp_servers"]
+    assert probes == ["droid.list_mcp_servers"]
+
+
+def _settle_handler(
+    servers: list[dict[str, Any]] | None = None,
+) -> Callable[[str, dict[str, Any]], dict[str, Any]]:
+    resolved_servers = [{"status": "connecting"}] if servers is None else servers
     disabled = False
 
     def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
         nonlocal disabled
         if method == "droid.list_mcp_servers":
-            return {"result": {"servers": [{"status": "connecting"}]}}
+            return {"result": {"servers": resolved_servers}}
         if method == "droid.list_tools":
             return {
                 "result": {
@@ -153,9 +186,7 @@ async def test_disable_native_tools_bounds_mcp_catalog_wait(
             return {"result": {}}
         raise AssertionError(method)
 
-    await DroidRpcExtension().disable_native_tools(_client(FakeProtocol(handler)))
-
-    assert disabled is True
+    return handler
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -11,6 +11,7 @@ from factory_droid_openai.app import create_app
 from factory_droid_openai.config import Settings
 from factory_droid_openai.protocol import TOOL_CALL_CLOSE, TOOL_CALL_OPEN
 from factory_droid_openai.runner import (
+    DroidModel,
     ReasoningDelta,
     RunComplete,
     RunEvent,
@@ -36,6 +37,20 @@ class ScriptedRunner:
         self.requests.append(request)
         for event in self.events:
             yield event
+
+    async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+        del timeout_seconds
+        return (
+            DroidModel(
+                id="gpt-5.4",
+                display_name="GPT-5.4",
+                provider="openai",
+                supported_reasoning_efforts=("low", "high"),
+                default_reasoning_effort="high",
+                supports_images=True,
+                supports_pdfs=True,
+            ),
+        )
 
 
 class BlockingRunner(ScriptedRunner):
@@ -140,6 +155,36 @@ async def test_official_openai_client_parses_stream(
     assert chunks[-1].choices == []
     assert chunks[-1].usage is not None
     assert chunks[-1].usage.total_tokens == 6
+
+
+@pytest.mark.asyncio
+async def test_official_openai_client_sends_structured_output_format(
+    tmp_path: Path,
+) -> None:
+    runner = ScriptedRunner([TextDelta('{"answer":7}'), RunComplete(Usage())])
+    client, http_client = _sdk_client(tmp_path, runner)
+    async with http_client:
+        completion = await client.chat.completions.create(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Pick a number."}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "integer"}},
+                        "required": ["answer"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+        )
+
+    assert completion.choices[0].message.content == '{"answer":7}'
+    assert runner.requests[0].output_format is not None
+    assert runner.requests[0].output_format["type"] == "json_schema"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -23,7 +23,15 @@ def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> Non
     schema: dict[str, Any] = create_app(Settings(workdir=tmp_path)).openapi()
     paths = schema["paths"]
 
-    assert set(paths) == {"/health", "/v1/models", "/v1/chat/completions"}
+    assert set(paths) == {
+        "/health",
+        "/v1/models",
+        "/v1/chat/completions",
+        "/v1/factory/sessions/{session_id}",
+        "/v1/factory/sessions/{session_id}/compact",
+        "/v1/factory/sessions/{session_id}/context",
+        "/v1/factory/sessions/{session_id}/fork",
+    }
     assert "security" not in paths["/health"]["get"]
     assert paths["/v1/models"]["get"]["security"] == [{"HTTPBearer": []}]
 
@@ -45,3 +53,8 @@ def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> Non
         "text/event-stream",
     }
     assert schema["components"]["securitySchemes"]["HTTPBearer"]["scheme"].lower() == "bearer"
+    assert paths["/v1/factory/sessions/{session_id}/context"]["get"]["security"] == [
+        {"HTTPBearer": []}
+    ]
+    request_schema = schema["components"]["schemas"]["ChatCompletionRequest"]
+    assert "response_format" in request_schema["properties"]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,6 +15,7 @@ from factory_droid_openai.protocol import (
     ToolCallEmission,
     ToolCallStreamParser,
     build_prompt,
+    parse_strict_json,
 )
 
 
@@ -346,6 +347,36 @@ def test_stream_parser_rejects_duplicate_keys() -> None:
     with pytest.raises(ProtocolError, match="duplicate key"):
         parser.feed(
             f'{TOOL_CALL_OPEN}{{"name":"weather","name":"shell","arguments":{{}}}}{TOOL_CALL_CLOSE}'
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ("1e999", "non-finite number"),
+        ("-1e999", "non-finite number"),
+        ("NaN", "non-JSON numeric constant"),
+        ("Infinity", "non-JSON numeric constant"),
+    ],
+)
+def test_strict_json_rejects_values_outside_the_json_grammar(
+    value: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_strict_json(f'{{"amount":{value}}}')
+
+
+def test_strict_json_keeps_finite_numbers() -> None:
+    assert parse_strict_json('{"amount":1.5,"count":2}') == {"amount": 1.5, "count": 2}
+
+
+def test_stream_parser_rejects_non_finite_tool_arguments() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="non-finite number"):
+        parser.feed(
+            f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"lat":1e999}}}}{TOOL_CALL_CLOSE}'
         )
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -959,3 +959,74 @@ async def test_runner_exposes_guarded_session_rpc_operations(tmp_path: Path) -> 
     assert client.loaded_session_id == "session"
     assert any(method == "droid.rename_session" for method, _, _ in client.rpc_requests)
     assert any(method == "droid.close_session" for method, _, _ in client.rpc_requests)
+    # Metadata operations run no model turn, so they must not touch the tool
+    # catalog or rewrite session settings. Compaction does run a turn.
+    assert [method for method, _, _ in client.rpc_requests].count(
+        "droid.update_session_settings"
+    ) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure", "status_code", "error_type"),
+    [
+        (SessionNotFoundError("session"), 404, "session_not_found"),
+        (FileNotFoundError("droid"), 503, "factory_droid_unavailable"),
+        (DroidClientError("broken"), 502, "factory_droid_sdk_error"),
+        (DroidTimeoutError("slow"), 504, "factory_droid_timeout"),
+    ],
+)
+async def test_session_operations_map_sdk_failures(
+    tmp_path: Path,
+    failure: Exception,
+    status_code: int,
+    error_type: str,
+) -> None:
+    class FailingClient(FakeClient):
+        async def load_session(
+            self,
+            *,
+            session_id: str,
+            mcp_servers: list[dict[str, Any]] | None = None,
+        ) -> None:
+            del session_id, mcp_servers
+            raise failure
+
+    client = FailingClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError) as excinfo:
+        await runner.rename_session("session", title="Title", timeout_seconds=1)
+
+    assert excinfo.value.status_code == status_code
+    assert excinfo.value.error_type == error_type
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_session_operations_time_out_on_a_slow_droid(tmp_path: Path) -> None:
+    class SlowClient(FakeClient):
+        async def load_session(
+            self,
+            *,
+            session_id: str,
+            mcp_servers: list[dict[str, Any]] | None = None,
+        ) -> None:
+            del session_id, mcp_servers
+            await asyncio.sleep(1)
+
+    client = SlowClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="timed out"):
+        await runner.close_session("session", timeout_seconds=0.01)
+
+    assert client.closed is True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,6 +5,7 @@ import os
 import sys
 import textwrap
 import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -23,6 +24,7 @@ from droid_sdk import TimeoutError as DroidTimeoutError
 from droid_sdk.errors import SessionNotFoundError
 from droid_sdk.schemas.enums import (
     AutonomyLevel,
+    DroidInteractionMode,
     DroidWorkingState,
     ReasoningEffort,
 )
@@ -64,6 +66,10 @@ class FakeClient:
         self.init_kwargs: dict[str, Any] = {}
         self.permission_handler: Any = None
         self.ask_user_handler: Any = None
+        self.rpc_requests: list[tuple[str, dict[str, Any], float | None]] = []
+        self.disabled_tool_ids: set[str] = set()
+        self.output_format: dict[str, Any] | None = None
+        self._protocol = self
 
     def set_permission_handler(self, handler: Any) -> None:
         self.permission_handler = handler
@@ -77,7 +83,13 @@ class FakeClient:
     async def initialize_session(self, **kwargs: Any) -> None:
         self.init_kwargs = kwargs
 
-    async def load_session(self, *, session_id: str) -> None:
+    async def load_session(
+        self,
+        *,
+        session_id: str,
+        mcp_servers: list[dict[str, Any]] | None = None,
+    ) -> None:
+        del mcp_servers
         self.loaded_session_id = session_id
         self.session_id = session_id
 
@@ -91,6 +103,45 @@ class FakeClient:
         self.prompt = text
         self.images = images
         self.files = files
+
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        timeout: float | None = None,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        del request_id
+        self.rpc_requests.append((method, params, timeout))
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": []}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": "read-cli",
+                            "currentlyAllowed": "read-cli" not in self.disabled_tool_ids,
+                        },
+                        {
+                            "id": "exit-spec-mode",
+                            "currentlyAllowed": True,
+                        },
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            self.disabled_tool_ids = set(params["disabledToolIds"])
+            return {"result": {}}
+        if method == "droid.add_user_message":
+            self.prompt = params["text"]
+            self.images = params.get("images")
+            self.files = params.get("files")
+            self.output_format = params.get("outputFormat")
+            return {"result": {}}
+        if method in {"droid.close_session", "droid.rename_session"}:
+            return {"result": {"success": True}}
+        raise AssertionError(f"unexpected RPC method: {method}")
 
     async def receive_response(self) -> AsyncIterator[object]:
         for event in self.events:
@@ -150,7 +201,10 @@ async def test_runner_maps_sdk_stream_and_usage(tmp_path: Path) -> None:
     assert events[3].usage.cache_read_tokens == 3
     assert client.init_kwargs["model_id"] is None
     assert client.init_kwargs["reasoning_effort"] is ReasoningEffort.High
+    assert client.init_kwargs["interaction_mode"] is DroidInteractionMode.Auto
     assert client.init_kwargs["autonomy_level"] is AutonomyLevel.Off
+    assert client.init_kwargs["mcp_servers"] == []
+    assert client.disabled_tool_ids == {"read-cli", "exit-spec-mode"}
     assert client.permission_handler({}) == "cancel"
     assert client.ask_user_handler({}) == {"cancelled": True, "answers": []}
     assert client.closed is True
@@ -517,7 +571,13 @@ async def test_runner_loads_existing_session_instead_of_initializing(
 @pytest.mark.asyncio
 async def test_runner_reports_unknown_session_as_not_found(tmp_path: Path) -> None:
     class MissingSessionClient(FakeClient):
-        async def load_session(self, *, session_id: str) -> None:
+        async def load_session(
+            self,
+            *,
+            session_id: str,
+            mcp_servers: list[dict[str, Any]] | None = None,
+        ) -> None:
+            del mcp_servers
             raise SessionNotFoundError(session_id)
 
     client = MissingSessionClient([])
@@ -555,6 +615,64 @@ async def test_runner_forwards_attachments_to_the_sdk(tmp_path: Path) -> None:
 
     assert client.images == [image]
     assert client.files == [document]
+
+
+@pytest.mark.asyncio
+async def test_runner_forwards_structured_output_through_raw_rpc(
+    tmp_path: Path,
+) -> None:
+    client = FakeClient([AssistantTextDelta('{"answer":7}'), TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    output_format = {
+        "type": "json_schema",
+        "schema": {"type": "object", "properties": {"answer": {"type": "integer"}}},
+    }
+
+    events = await _collect(runner, _request(output_format=output_format))
+
+    assert TextDelta('{"answer":7}') in events
+    assert client.output_format == output_format
+    assert client.prompt == "prompt"
+
+
+@pytest.mark.asyncio
+async def test_runner_fails_before_prompt_if_native_tools_remain_enabled(
+    tmp_path: Path,
+) -> None:
+    class UnsafeClient(FakeClient):
+        async def send_request(
+            self,
+            method: str,
+            params: dict[str, Any],
+            timeout: float | None = None,
+            request_id: str | None = None,
+        ) -> dict[str, Any]:
+            if method == "droid.list_tools":
+                return {
+                    "result": {
+                        "tools": [
+                            {"id": "execute-cli", "currentlyAllowed": True},
+                        ]
+                    }
+                }
+            return await super().send_request(method, params, timeout, request_id)
+
+    client = UnsafeClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="Failed to disable native Droid tools"):
+        await _collect(runner, _request())
+
+    assert client.prompt == ""
+    assert client.interrupted is True
 
 
 @pytest.mark.asyncio
@@ -732,3 +850,112 @@ async def test_cleanup_completes_when_the_caller_is_cancelled_again(
     with pytest.raises(asyncio.CancelledError):
         await task
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_runner_discovers_models_from_session_initialization(
+    tmp_path: Path,
+) -> None:
+    class ModelClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> Any:
+            await super().initialize_session(**kwargs)
+            return SimpleNamespace(
+                available_models=[
+                    SimpleNamespace(
+                        id="gpt-5.4",
+                        display_name="GPT-5.4",
+                        model_provider=SimpleNamespace(value="openai"),
+                        supported_reasoning_efforts=[
+                            ReasoningEffort.Low,
+                            ReasoningEffort.High,
+                        ],
+                        default_reasoning_effort=ReasoningEffort.High,
+                        no_image_support=False,
+                        supports_pdfs=True,
+                    )
+                ]
+            )
+
+    client = ModelClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    models = await runner.list_models(timeout_seconds=1)
+
+    assert models[0].id == "gpt-5.4"
+    assert models[0].provider == "openai"
+    assert models[0].supported_reasoning_efforts == ("low", "high")
+    assert models[0].supports_images is True
+    assert models[0].supports_pdfs is True
+    assert ("droid.close_session", {"reason": "clear"}, 30.0) in client.rpc_requests
+
+
+@pytest.mark.asyncio
+async def test_runner_exposes_guarded_session_rpc_operations(tmp_path: Path) -> None:
+    class SessionOperationClient(FakeClient):
+        async def send_request(
+            self,
+            method: str,
+            params: dict[str, Any],
+            timeout: float | None = None,
+            request_id: str | None = None,
+        ) -> dict[str, Any]:
+            if method == "droid.get_context_stats":
+                return {
+                    "result": {
+                        "used": 10,
+                        "remaining": 90,
+                        "limit": 100,
+                        "accuracy": "exact",
+                        "updatedAt": "now",
+                    }
+                }
+            if method == "droid.get_context_breakdown":
+                return {
+                    "result": {
+                        "modelId": "gpt-5.4",
+                        "modelDisplayName": "GPT-5.4",
+                        "contextBudget": 100,
+                        "usedTokens": 10,
+                        "freeTokens": 90,
+                        "categories": [{"name": "messages", "tokens": 10, "colorKey": "blue"}],
+                    }
+                }
+            if method == "droid.compact_session":
+                return {"result": {"newSessionId": "compact", "removedCount": 3}}
+            if method == "droid.fork_session":
+                return {"result": {"newSessionId": "fork"}}
+            return await super().send_request(method, params, timeout, request_id)
+
+    client = SessionOperationClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    stats, breakdown = await runner.get_context("session", timeout_seconds=1)
+    compacted = await runner.compact_session(
+        "session",
+        custom_instructions="Keep decisions.",
+        timeout_seconds=1,
+    )
+    forked = await runner.fork_session("session", timeout_seconds=1)
+    await runner.rename_session(
+        "session",
+        title="Title",
+        timeout_seconds=1,
+    )
+    await runner.close_session("session", timeout_seconds=1)
+
+    assert stats.used == 10
+    assert breakdown.categories[0].name == "messages"
+    assert compacted.new_session_id == "compact"
+    assert compacted.removed_count == 3
+    assert forked == "fork"
+    assert client.loaded_session_id == "session"
+    assert any(method == "droid.rename_session" for method, _, _ in client.rpc_requests)
+    assert any(method == "droid.close_session" for method, _, _ in client.rpc_requests)

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,7 @@ source = { editable = "." }
 dependencies = [
     { name = "droid-sdk" },
     { name = "fastapi" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "uvicorn" },
 ]
@@ -248,6 +249,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
@@ -255,6 +257,7 @@ requires-dist = [
     { name = "droid-sdk", specifier = "==0.1.2" },
     { name = "fastapi", specifier = ">=0.133.1,<1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1,<1" },
+    { name = "jsonschema", specifier = ">=4.26.0,<5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0,<3" },
     { name = "openai", marker = "extra == 'dev'", specifier = ">=2.48.0,<3" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.9.0,<1" },
@@ -263,6 +266,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0,<8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10,<1" },
+    { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0,<5" },
     { name = "uvicorn", specifier = ">=0.41.0,<1" },
 ]
 provides-extras = ["dev"]
@@ -1246,6 +1250,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/84/da0e5038228fa34dfd77c5026b173ed035d2a3ba31f1077590c013de2bff/tqdm-4.69.1.tar.gz", hash = "sha256:2be21080a0ce17e902c2f1baeb6a74bf551b67bbdfa4bc0109fad471d0b4cb0d", size = 793046, upload-time = "2026-07-24T14:22:02.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/50/5817619a0fca56aff06383dbfde7ae017b3ca383915b3f1e4713164273cf/tqdm-4.69.1-py3-none-any.whl", hash = "sha256:0a654b96f7a2660cceb615b56f307ec2bef96c515409014a429a561981ab52b4", size = 675452, upload-time = "2026-07-24T14:22:00.048Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- discover authenticated Droid models dynamically
- add guarded context, compact, fork, rename, and close session APIs
- enforce structured outputs and verify native Droid tools stay disabled
- update OpenAPI contract, client coverage, and documentation

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`