### PR TITLE
fix(ci): build docker images without blocked third-party actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,44 +4,66 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Publish an existing release tag, for example v1.2.1
+        required: false
+        type: string
 
 permissions:
   contents: read
   packages: write
 
+# The repository only allows GitHub-owned actions plus a short allowlist, so
+# this workflow drives Buildx through the Docker CLI instead of the
+# docker/*-action steps, which fail before the job starts.
 jobs:
   build:
     name: Build and publish image
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          ref: ${{ inputs.release_tag || github.sha }}
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=sha,prefix=sha-,format=short
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+      - name: Set up Buildx and QEMU
+        run: |
+          docker run --privileged --rm \
+            tonistiigi/binfmt@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6 \
+            --install arm64
+          docker buildx create --name bridge --driver docker-container --use
+          docker buildx inspect --bootstrap
 
       - name: Build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+        env:
+          INPUT_TAG: ${{ inputs.release_tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY}"
+          release_tag="${INPUT_TAG:-}"
+          if [ -z "${release_tag}" ] && [ "${EVENT_NAME}" = "release" ]; then
+            release_tag="${EVENT_REF_NAME}"
+          fi
+          args=(--tag "${image}:sha-$(git rev-parse --short=7 HEAD)")
+          if [ -n "${release_tag}" ]; then
+            args+=(
+              --tag "${image}:${release_tag}"
+              --tag "${image}:${release_tag#v}"
+              --tag "${image}:latest"
+            )
+          fi
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            "${args[@]}" \
+            .
+
+      - name: Report published tags
+        run: docker buildx imagetools inspect "ghcr.io/${GITHUB_REPOSITORY}:sha-$(git rev-parse --short=7 HEAD)"

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Droid's configured default.
 - Optional constant-time bearer authentication
 - Bounded request timeout, payload size, and process concurrency
 - Queue-based admission control and Prometheus-style metrics
+- Warm Droid session pool and detached teardown for low request latency
+- Structured phase-timed logging in text or JSON
 - Inline image and document attachments over the native SDK channel
 - Stop sequences, `n` choices, and multiple tool calls per turn
 - Optional Droid session continuity across requests
@@ -1028,28 +1030,6 @@ Admission control then bounds how many requests reach Droid. Requests beyond
 `FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE`; once that is full the bridge answers
 `429` with a `Retry-After` header rather than queueing without limit.
 
-## Warm sessions
-
-Starting a Droid session takes about three seconds, and tearing one down
-costs another second, so by default the bridge keeps
-`FACTORY_DROID_OPENAI_WARM_SESSIONS` sessions initialized and idle and hands
-one to each incoming request. A warm session serves a single turn and is then
-discarded, so requests stay isolated exactly as before.
-
-Warm sessions are keyed by model and reasoning effort, because switching the
-model on a live session costs as much as starting a new one. The pool tracks
-the settings recent traffic used and rebalances itself when clients switch
-models; the first request for a new model still starts its own session and
-shows up as `pool.miss`.
-
-Teardown runs after the response is finished, so the grace period and the
-final kill no longer delay the last token. Set
-`FACTORY_DROID_OPENAI_DETACHED_CLEANUP=false` to wait for teardown on the
-request path instead, and `FACTORY_DROID_OPENAI_WARM_SESSIONS=0` to disable
-pre-warming. Both keep one Droid process per request either way; warm
-sessions only move the startup cost off the request path, and each idle
-session holds a Droid process while it waits.
-
 `GET /metrics` renders Prometheus-style text. It is excluded from the OpenAPI
 contract because it is an operational endpoint, not part of the OpenAI API
 surface.
@@ -1074,10 +1054,46 @@ surface.
 | `factory_droid_openai_pending_reaps` | Droid teardowns still running in the background |
 
 `forced_kills_total` counts any process that did not exit within its grace
-period, so treat it as an upper bound on genuinely stuck processes.
+period. `droid exec` usually keeps running after its session is closed, so in
+practice most requests end with a kill and the counter tracks traffic rather
+than stuck processes.
 
 Serve `/metrics` on a loopback interface or behind your own access control;
 it carries no prompt content, but it does expose traffic shape.
+
+## Warm sessions
+
+Starting a Droid session and tearing it down again dominates the cost of a
+short request. Measured on an Apple M-series laptop with a trivial prompt:
+
+| Phase | Cost | On the request path? |
+|---|---:|---|
+| `droid exec` spawn and JSON-RPC connect | 3 ms | yes |
+| `droid.initialize_session` | 2.4-3.2 s | no, pre-warmed |
+| Disabling Factory-native tools | 6 ms | no, pre-warmed |
+| Prompt serialization and send | 4 ms | yes |
+| Model time to first token | 2.8-3.8 s | yes |
+| Session close, grace period, kill | 1.0 s | no, detached |
+
+So the bridge keeps `FACTORY_DROID_OPENAI_WARM_SESSIONS` sessions initialized
+and idle, and hands one to each incoming request. A warm session serves a
+single turn and is then discarded, so requests stay isolated exactly as
+before. End to end, the same prompt drops from about 7.2 s to about 2.8 s,
+leaving little more than model time.
+
+Warm sessions are keyed by model and reasoning effort, because switching the
+model on a live session costs about 2 s, as much as starting a new one. The
+pool tracks the settings recent traffic used and rebalances itself when
+clients switch models; the first request for a new model still starts its own
+session and logs `pool.miss`.
+
+Teardown runs after the response is finished, so the grace period and the
+final kill no longer delay the last token. Set
+`FACTORY_DROID_OPENAI_DETACHED_CLEANUP=false` to wait for teardown on the
+request path instead, and `FACTORY_DROID_OPENAI_WARM_SESSIONS=0` to disable
+pre-warming. Either way one Droid process serves one request; warm sessions
+only move the startup cost off the request path, and each idle session holds
+a Droid process while it waits.
 
 ## Logging
 
@@ -1096,18 +1112,22 @@ factory-droid-openai --log-level debug --no-access-log
 |---|---|
 | `warning` | Rejections, failures, degraded model discovery, forced process kills |
 | `info` | One `chat.completed` summary per request with phase timings and token usage |
-| `debug` | Per-phase events: prompt built, admission, Droid startup, session ready, first token, turn complete, cleanup |
+| `debug` | Per-phase events: prompt built, admission, warm-session hit or miss, Droid startup, session ready, first token, turn complete, cleanup |
 | `trace` | One line per Droid SDK event kind |
 
 ```text
 DEBUG    2026-07-27T14:10:02+0200 event=chat.received request_id=chatcmpl-8f2a model=gpt-5.4 stream=true messages=6 tools=14
 DEBUG    2026-07-27T14:10:02+0200 event=chat.prompt_built request_id=chatcmpl-8f2a prompt_bytes=48213 allowed_tools=14 prompt_ms=7.9
 DEBUG    2026-07-27T14:10:02+0200 event=chat.admitted request_id=chatcmpl-8f2a queue_ms=0.2
-DEBUG    2026-07-27T14:10:04+0200 event=droid.connected request_id=chatcmpl-8f2a droid_startup_ms=1811.4
-DEBUG    2026-07-27T14:10:05+0200 event=droid.session_ready request_id=chatcmpl-8f2a session_ready_ms=2530.6
-DEBUG    2026-07-27T14:10:07+0200 event=chat.first_token request_id=chatcmpl-8f2a ttft_ms=4402.1
-INFO     2026-07-27T14:10:12+0200 event=chat.completed request_id=chatcmpl-8f2a outcome=success stream=true input_tokens=9123 output_tokens=412 total_ms=9860.3
+DEBUG    2026-07-27T14:10:02+0200 event=pool.hit request_id=chatcmpl-8f2a model=gpt-5.4 warm_sessions=1
+DEBUG    2026-07-27T14:10:02+0200 event=droid.session_ready request_id=chatcmpl-8f2a warm=true session_ready_ms=3.1
+DEBUG    2026-07-27T14:10:06+0200 event=chat.first_token request_id=chatcmpl-8f2a ttft_ms=3908.4
+INFO     2026-07-27T14:10:11+0200 event=chat.completed request_id=chatcmpl-8f2a outcome=success stream=true input_tokens=9123 output_tokens=412 total_ms=8712.6
+WARNING  2026-07-27T14:10:12+0200 event=droid.forced_kill request_id=chatcmpl-8f2a cleanup_ms=1014.1
 ```
+
+`droid.connected` and `droid_startup_ms` only appear on a cold session, and
+`droid.forced_kill` is logged after the response because cleanup is detached.
 
 Phase fields, in the order they occur:
 
@@ -1120,7 +1140,7 @@ Phase fields, in the order they occur:
 | `prompt_sent_ms` | Elapsed until the prompt was handed to Droid |
 | `ttft_ms` | Elapsed until the first text or reasoning delta |
 | `turn_ms` | Elapsed until Droid reported turn completion |
-| `total_ms` | Whole request, including cleanup and response encoding |
+| `total_ms` | Whole request, including response encoding |
 
 One Droid process serves each request. A warm session brings
 `session_ready_ms` down to a few milliseconds, so a request that logs
@@ -1189,7 +1209,7 @@ This is a compatibility bridge, not a native OpenAI inference implementation.
 |---|---|
 | No native SDK chat-history input | History is serialized into one prompt unless session continuity is enabled |
 | No native SDK external-tool schemas | Tool definitions are serialized into the prompt |
-| No native SDK tool-result continuation | Each request creates a new Droid session |
+| No native SDK tool-result continuation | Each request runs a fresh Droid session; warm sessions remove its startup cost, not its empty state |
 | Python SDK protocol drift | A small isolated compatibility shim supplies structured output, tool controls, and session RPCs |
 | Session-per-request execution | Prompt caching differs from a native inference endpoint |
 | Strict tool marker protocol | Invalid generated tool payloads fail closed |
@@ -1233,6 +1253,20 @@ factory_incomplete_response
 
 The Droid stream ended without a turn-complete event. Check Droid CLI health,
 request timeout, and bridge logs.
+
+### One slow request after switching models
+
+The warm pool holds sessions for the model and reasoning effort recent traffic
+used, so the first request with new settings pays full session startup and
+logs `pool.miss` with a multi-second `session_ready_ms`. Following requests
+for the same settings hit the pool. Raise
+`FACTORY_DROID_OPENAI_WARM_SESSIONS` when clients alternate between models.
+
+### Every request logs a forced kill
+
+Expected. `droid exec` normally stays alive after its session is closed, so
+the bridge kills it once the grace period expires. With detached cleanup this
+happens after the response, so it costs the client nothing.
 
 ## Development
 


### PR DESCRIPTION
## Problem

The Docker workflow failed with `startup_failure` for every release, so no image was published for `v1.2.0` or `v1.2.1`.

Cause is repository policy, not the workflow YAML:

```json
{"allowed_actions":"selected","sha_pinning_required":true}
{"github_owned_allowed":true,"verified_allowed":false,
 "patterns_allowed":["astral-sh/setup-uv@*","codecov/codecov-action@*",
                     "googleapis/release-please-action@*","pypa/gh-action-pypi-publish@*"]}
```

`docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/metadata-action`, and `docker/build-push-action` are not on the allowlist and are not GitHub-owned, so GitHub rejects the run before any job is created. That is why no logs, jobs, or annotations existed for runs 30266611809 (`v1.2.0`) and 30268171483 (`v1.2.1`). Commit 6655828 introduced those steps when it added multi-arch builds; the raw-CLI workflow it replaced (ef1e28c) had worked.

## Change

- Drive Buildx from the Docker CLI: `tonistiigi/binfmt` (digest-pinned) for QEMU, `docker buildx create`, `docker buildx build --platform linux/amd64,linux/arm64 --push`. Only `actions/checkout` remains, which is GitHub-owned and allowed.
- Compute tags in bash from environment variables instead of inline interpolation: `sha-<short>` always, plus `<tag>`, `<version>`, and `latest` on a release.
- New `workflow_dispatch` input `release_tag` so a missed release, for example `v1.2.1`, can be published from `main` without moving the tag.
- Timeout raised to 60 minutes because arm64 builds under QEMU are slow (this run took about 13 minutes).

Alternative considered: add `docker/*@*` to the actions allowlist. Rejected to keep `verified_allowed: false` and the short allowlist intact.

## Docs

- Fix section nesting from 0178b7e: `## Warm sessions` had been inserted inside `## Limits and metrics`, which pulled the `GET /metrics` paragraph and the metrics table under the wrong heading.
- Document the measured phase costs behind the warm session pool: `initialize_session` 2.4-3.2 s, teardown 1.0 s, model TTFT 2.8-3.8 s, live model switch about 2 s, and the resulting 7.2 s to 2.8 s end-to-end drop.
- Logging sample now shows the warm path (`pool.hit`, `warm=true`, `session_ready_ms=3.1`) and the post-response `droid.forced_kill`.
- Two new troubleshooting entries: one slow request after switching models, and why every request logs a forced kill.
- Features list mentions the warm pool and structured logging.

## Validation

- Run 30281122783 (`workflow_dispatch` on this branch): success. `docker buildx imagetools inspect` reports a manifest list for `ghcr.io/mrwogu/factory-droid-openai:sha-1731039` with `linux/amd64` and `linux/arm64`.
- `python -c 'yaml.safe_load(...)'` on the workflow file.
- No source changes, so the Python suite is untouched.

## Follow-up after merge

Publish the missing release images:

```bash
gh workflow run docker.yml --ref main -f release_tag=v1.2.1
```