### PR TITLE
perf(pool): retune warm sessions instead of cold starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,8 @@ opens `chatLanguageModels.json`; add this provider entry:
 ]
 ```
 
-A ready-to-use provider entry with several Droid models is committed at
+A ready-to-use provider entry covering every model the reference host exposed
+is committed at
 [`examples/vscode/chatLanguageModels.json`](examples/vscode/chatLanguageModels.json).
 Copy its contents into VS Code's `chatLanguageModels.json`, then adjust
 `apiKey` and the endpoint URL. Regenerate it against a running bridge, which
@@ -969,7 +970,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_TIMEOUT_SECONDS` | `600` | Maximum request duration |
 | `FACTORY_DROID_OPENAI_BODY_TIMEOUT_SECONDS` | `30` | Maximum time to receive a request body |
 | `FACTORY_DROID_OPENAI_MAX_CONCURRENCY` | `2` | Concurrent Droid subprocesses |
-| `FACTORY_DROID_OPENAI_WARM_SESSIONS` | `MAX_CONCURRENCY` | Pre-started Droid sessions kept ready (`0` disables) |
+| `FACTORY_DROID_OPENAI_WARM_SESSIONS` | `MAX_CONCURRENCY + 1` | Pre-started Droid sessions kept ready (`0` disables) |
 | `FACTORY_DROID_OPENAI_WARM_SESSION_TTL_SECONDS` | `600` | Age at which an unused warm session is replaced |
 | `FACTORY_DROID_OPENAI_DETACHED_CLEANUP` | `true` | Tear down Droid processes after the response is sent |
 | `FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE` | `8` | Requests waiting for a Droid slot |
@@ -981,7 +982,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES` | `1048576` | Serialized tool schema size limit |
 | `FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES` | `1048576` | Buffered structured output size limit |
 | `FACTORY_DROID_OPENAI_MAX_JSON_DEPTH` | `32` | Request JSON nesting limit |
-| `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` | `1` | Wait before killing a Droid process |
+| `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` | `2` | Wait before killing a Droid process |
 | `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` | `4` | Total budget for session cleanup |
 | `FACTORY_DROID_OPENAI_UVICORN_LIMIT_CONCURRENCY` | `64` | Uvicorn connection limit |
 | `FACTORY_DROID_OPENAI_UVICORN_BACKLOG` | `128` | Uvicorn listen backlog |
@@ -1049,14 +1050,15 @@ surface.
 | `factory_droid_openai_model_discovery_failures_total` | Failed Droid model discovery attempts |
 | `factory_droid_openai_warm_sessions` | Warm Droid sessions ready now |
 | `factory_droid_openai_warm_session_hits_total` | Requests served from a warm session |
+| `factory_droid_openai_warm_session_retunes_total` | Warm sessions repointed at another model |
 | `factory_droid_openai_warm_session_misses_total` | Requests that had to start their own session |
 | `factory_droid_openai_warm_session_failures_total` | Failed warm-up attempts |
 | `factory_droid_openai_pending_reaps` | Droid teardowns still running in the background |
 
-`forced_kills_total` counts any process that did not exit within its grace
-period. `droid exec` usually keeps running after its session is closed, so in
-practice most requests end with a kill and the counter tracks traffic rather
-than stuck processes.
+`forced_kills_total` counts processes that had to be killed with a signal
+because they did not exit within `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS`.
+`droid exec` shuts down cleanly in about a second, so a rising counter means
+stuck processes, not ordinary traffic.
 
 Serve `/metrics` on a loopback interface or behind your own access control;
 it carries no prompt content, but it does expose traffic shape.
@@ -1073,22 +1075,28 @@ short request. Measured on an Apple M-series laptop with a trivial prompt:
 | Disabling Factory-native tools | 6 ms | no, pre-warmed |
 | Prompt serialization and send | 4 ms | yes |
 | Model time to first token | 2.8-3.8 s | yes |
-| Session close, grace period, kill | 1.0 s | no, detached |
+| Session close and process exit | 1.0 s | no, detached |
 
 So the bridge keeps `FACTORY_DROID_OPENAI_WARM_SESSIONS` sessions initialized
 and idle, and hands one to each incoming request. A warm session serves a
 single turn and is then discarded, so requests stay isolated exactly as
 before. End to end, the same prompt drops from about 7.2 s to about 2.8 s,
-leaving little more than model time.
+leaving little more than model time. The default keeps one spare session per
+concurrency slot, so back-to-back requests still find one warm while the pool
+refills.
 
-Warm sessions are keyed by model and reasoning effort, because switching the
-model on a live session costs about 2 s, as much as starting a new one. The
-pool tracks the settings recent traffic used and rebalances itself when
-clients switch models; the first request for a new model still starts its own
-session and logs `pool.miss`.
+Warm sessions are keyed by the model and reasoning effort they were
+initialized with. An exact match serves a turn with no extra round trip.
+Otherwise the bridge repoints a session warmed for another model at the
+requested one, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
+`pool.retune` plus `droid.session_retuned`. Requests that ask for the model
+alias, or for the model's default reasoning effort on a session that carries
+an explicit one, cannot be expressed as an update and still log `pool.miss`.
+The pool tracks the settings recent traffic used, so repeat traffic converges
+on exact matches.
 
-Teardown runs after the response is finished, so the grace period and the
-final kill no longer delay the last token. Set
+Teardown runs after the response is finished, so session close and the second
+`droid exec` needs to exit no longer delay the last token. Set
 `FACTORY_DROID_OPENAI_DETACHED_CLEANUP=false` to wait for teardown on the
 request path instead, and `FACTORY_DROID_OPENAI_WARM_SESSIONS=0` to disable
 pre-warming. Either way one Droid process serves one request; warm sessions
@@ -1112,7 +1120,7 @@ factory-droid-openai --log-level debug --no-access-log
 |---|---|
 | `warning` | Rejections, failures, degraded model discovery, forced process kills |
 | `info` | One `chat.completed` summary per request with phase timings and token usage |
-| `debug` | Per-phase events: prompt built, admission, warm-session hit or miss, Droid startup, session ready, first token, turn complete, cleanup |
+| `debug` | Per-phase events: prompt built, admission, warm-session hit, retune or miss, Droid startup, session ready, first token, turn complete, cleanup |
 | `trace` | One line per Droid SDK event kind |
 
 ```text
@@ -1123,11 +1131,13 @@ DEBUG    2026-07-27T14:10:02+0200 event=pool.hit request_id=chatcmpl-8f2a model=
 DEBUG    2026-07-27T14:10:02+0200 event=droid.session_ready request_id=chatcmpl-8f2a warm=true session_ready_ms=3.1
 DEBUG    2026-07-27T14:10:06+0200 event=chat.first_token request_id=chatcmpl-8f2a ttft_ms=3908.4
 INFO     2026-07-27T14:10:11+0200 event=chat.completed request_id=chatcmpl-8f2a outcome=success stream=true input_tokens=9123 output_tokens=412 total_ms=8712.6
-WARNING  2026-07-27T14:10:12+0200 event=droid.forced_kill request_id=chatcmpl-8f2a cleanup_ms=1014.1
+DEBUG    2026-07-27T14:10:12+0200 event=droid.cleanup request_id=chatcmpl-8f2a cleanup_ms=1021.4
 ```
 
-`droid.connected` and `droid_startup_ms` only appear on a cold session, and
-`droid.forced_kill` is logged after the response because cleanup is detached.
+`droid.connected` and `droid_startup_ms` only appear on a cold session,
+`pool.retune` and `droid.session_retuned` only when a session warmed for
+another model is reused, and cleanup is logged after the response because it
+is detached.
 
 Phase fields, in the order they occur:
 
@@ -1136,6 +1146,7 @@ Phase fields, in the order they occur:
 | `prompt_ms` | Transcript and tool-schema serialization in the bridge |
 | `queue_ms` | Waiting for a Droid concurrency slot |
 | `droid_startup_ms` | `droid exec` process spawn and SDK handshake |
+| `retune_ms` | Repointing a warm session at the requested model |
 | `session_ready_ms` | Elapsed until the Droid session accepts a prompt |
 | `prompt_sent_ms` | Elapsed until the prompt was handed to Droid |
 | `ttft_ms` | Elapsed until the first text or reasoning delta |
@@ -1257,16 +1268,20 @@ request timeout, and bridge logs.
 ### One slow request after switching models
 
 The warm pool holds sessions for the model and reasoning effort recent traffic
-used, so the first request with new settings pays full session startup and
-logs `pool.miss` with a multi-second `session_ready_ms`. Following requests
-for the same settings hit the pool. Raise
-`FACTORY_DROID_OPENAI_WARM_SESSIONS` when clients alternate between models.
+used. A session warmed for another model is repointed in milliseconds and logs
+`pool.retune`, so only requests that cannot be expressed as a settings
+update - the model alias, or a model default effort on a session with an
+explicit one - pay full startup and log `pool.miss` with a multi-second
+`session_ready_ms`. Raise `FACTORY_DROID_OPENAI_WARM_SESSIONS` when clients
+alternate between models faster than the pool refills.
 
 ### Every request logs a forced kill
 
-Expected. `droid exec` normally stays alive after its session is closed, so
-the bridge kills it once the grace period expires. With detached cleanup this
-happens after the response, so it costs the client nothing.
+Not expected any more. `droid exec` exits cleanly in about a second, so raise
+`FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` if teardown is being cut short on
+a slower host; `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` must stay above
+it. With detached cleanup the kill happens after the response, so it costs the
+client nothing either way.
 
 ## Development
 

--- a/examples/vscode/chatLanguageModels.json
+++ b/examples/vscode/chatLanguageModels.json
@@ -17,6 +17,37 @@
         "maxOutputTokens": 20000
       },
       {
+        "id": "auto",
+        "name": "Auto Model via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": false,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000
+      },
+      {
+        "id": "claude-fable-5",
+        "name": "Fable 5 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
         "id": "claude-opus-5",
         "name": "Opus 5 via Factory Droid",
         "url": "http://127.0.0.1:8787/v1/chat/completions",
@@ -33,6 +64,123 @@
           "high",
           "xhigh",
           "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-opus-5-fast",
+        "name": "Opus 5 Fast Mode via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-opus-4-8",
+        "name": "Opus 4.8 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-opus-4-8-fast",
+        "name": "Opus 4.8 Fast Mode via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-opus-4-7",
+        "name": "Opus 4.7 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-opus-4-6",
+        "name": "Opus 4.6 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-opus-4-5-20251101",
+        "name": "Opus 4.5 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high"
         ],
         "reasoningEffortFormat": "chat-completions"
       },
@@ -57,6 +205,61 @@
         "reasoningEffortFormat": "chat-completions"
       },
       {
+        "id": "claude-sonnet-4-6",
+        "name": "Sonnet 4.6 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Sonnet 4.5 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Haiku 4.5 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
         "id": "gpt-5.6-sol",
         "name": "GPT-5.6 Sol via Factory Droid",
         "url": "http://127.0.0.1:8787/v1/chat/completions",
@@ -77,6 +280,99 @@
         "reasoningEffortFormat": "chat-completions"
       },
       {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.5-fast",
+        "name": "GPT-5.5 Fast Mode via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.5-pro",
+        "name": "GPT-5.5 Pro via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
         "id": "gpt-5.4",
         "name": "GPT-5.4 via Factory Droid",
         "url": "http://127.0.0.1:8787/v1/chat/completions",
@@ -87,6 +383,97 @@
         "maxInputTokens": 180000,
         "maxOutputTokens": 20000,
         "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.4-fast",
+        "name": "GPT-5.4 Fast Mode via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 Mini via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3-Codex via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.3-codex-fast",
+        "name": "GPT-5.3-Codex Fast Mode via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
           "low",
           "medium",
           "high",
@@ -112,6 +499,60 @@
         "reasoningEffortFormat": "chat-completions"
       },
       {
+        "id": "gemini-3.6-flash",
+        "name": "Gemini 3.6 Flash via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
         "id": "glm-5.2",
         "name": "GLM-5.2 (Droid Core) via Factory Droid",
         "url": "http://127.0.0.1:8787/v1/chat/completions",
@@ -125,6 +566,187 @@
           "off",
           "high",
           "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "glm-5.2-fast",
+        "name": "GLM-5.2 Fast (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": false,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "high",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "kimi-k3",
+        "name": "Kimi K3 (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "high",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "kimi-k2.7-code",
+        "name": "Kimi K2.7 Code (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6 (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "nemotron-3-ultra",
+        "name": "Nemotron 3 Ultra (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": false,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": false,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "low",
+          "high",
+          "max"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "minimax-m3",
+        "name": "MiniMax M3 (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "minimax-m2.7",
+        "name": "MiniMax M2.7 (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": false,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "minimax-m2.5",
+        "name": "MiniMax M2.5 (Droid Core) via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": false,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "grok-4.5",
+        "name": "Grok 4.5 via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "reasoningEffortFormat": "chat-completions"
+      },
+      {
+        "id": "glm-5.1",
+        "name": "GLM-5.1 (Droid Core) [Deprecated] via Factory Droid",
+        "url": "http://127.0.0.1:8787/v1/chat/completions",
+        "toolCalling": true,
+        "vision": false,
+        "streaming": true,
+        "thinking": true,
+        "maxInputTokens": 180000,
+        "maxOutputTokens": 20000,
+        "supportsReasoningEffort": [
+          "off",
+          "high"
         ],
         "reasoningEffortFormat": "chat-completions"
       }

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -27,7 +27,7 @@ class Settings:
     max_structured_output_bytes: int = 1_048_576
     max_json_depth: int = 32
     retry_after_seconds: int = 1
-    process_grace_seconds: float = 1.0
+    process_grace_seconds: float = 2.0
     cleanup_timeout_seconds: float = 4.0
     server_limit_concurrency: int = 64
     server_backlog: int = 128
@@ -50,9 +50,13 @@ class Settings:
     detached_cleanup: bool = True
 
     def warm_session_count(self) -> int:
-        """Warm sessions to keep ready; ``-1`` tracks ``max_concurrency``."""
+        """Warm sessions to keep ready; ``-1`` keeps one spare per concurrency slot.
+
+        A session serves a single turn, and refilling one costs seconds, so the
+        spare covers back-to-back requests while the pool refills.
+        """
         if self.warm_sessions < 0:
-            return self.max_concurrency
+            return self.max_concurrency + 1
         return self.warm_sessions
 
     @classmethod
@@ -120,7 +124,9 @@ class Settings:
         )
         process_grace_seconds = _positive_float(
             "FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS",
-            default=1.0,
+            # droid shuts down cleanly in about a second, so a shorter grace
+            # period turns every teardown into a SIGKILL.
+            default=2.0,
         )
         cleanup_timeout_seconds = _positive_float(
             "FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS",

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -88,6 +88,33 @@ class DroidRpcExtension:
             params["outputFormat"] = output_format
         await self._request(client, DroidServerMethod.ADD_USER_MESSAGE.value, params)
 
+    async def retune_session(
+        self,
+        client: DroidClient,
+        *,
+        model_id: str,
+        reasoning_effort: str | None,
+    ) -> None:
+        """Repoint an initialized session at another model and effort.
+
+        Droid applies this without restarting the process, so a warm session
+        can serve a model it was not initialized with. Interaction mode and
+        autonomy level are resent so the bridge invariants stay pinned; the
+        disabled native tool list is preserved by Droid.
+        """
+        params: dict[str, Any] = {
+            "modelId": model_id,
+            "interactionMode": DroidInteractionMode.Auto.value,
+            "autonomyLevel": AutonomyLevel.Off.value,
+        }
+        if reasoning_effort is not None:
+            params["reasoningEffort"] = reasoning_effort
+        await self._request(
+            client,
+            DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
+            params,
+        )
+
     async def disable_native_tools(self, client: DroidClient) -> None:
         await self._wait_for_mcp_catalog(client)
         tools = await self._list_tools(client)

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -24,6 +24,7 @@ class BridgeMetrics:
         self._model_discovery_failures = 0
         self._warm_sessions = 0
         self._warm_hits = 0
+        self._warm_retunes = 0
         self._warm_misses = 0
         self._warm_failures = 0
         self._pending_reaps = 0
@@ -78,6 +79,10 @@ class BridgeMetrics:
         with self._lock:
             self._warm_hits += 1
 
+    def increment_warm_retunes(self) -> None:
+        with self._lock:
+            self._warm_retunes += 1
+
     def increment_warm_misses(self) -> None:
         with self._lock:
             self._warm_misses += 1
@@ -110,6 +115,7 @@ class BridgeMetrics:
                 "model_discovery_failures": self._model_discovery_failures,
                 "warm_sessions": self._warm_sessions,
                 "warm_hits": self._warm_hits,
+                "warm_retunes": self._warm_retunes,
                 "warm_misses": self._warm_misses,
                 "warm_failures": self._warm_failures,
                 "pending_reaps": self._pending_reaps,
@@ -158,6 +164,8 @@ class BridgeMetrics:
             f"factory_droid_openai_warm_sessions {values['warm_sessions']}",
             "# TYPE factory_droid_openai_warm_session_hits_total counter",
             f"factory_droid_openai_warm_session_hits_total {values['warm_hits']}",
+            "# TYPE factory_droid_openai_warm_session_retunes_total counter",
+            f"factory_droid_openai_warm_session_retunes_total {values['warm_retunes']}",
             "# TYPE factory_droid_openai_warm_session_misses_total counter",
             f"factory_droid_openai_warm_session_misses_total {values['warm_misses']}",
             "# TYPE factory_droid_openai_warm_session_failures_total counter",

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -19,6 +19,8 @@ class PoolMetrics(Protocol):
 
     def increment_warm_hits(self) -> None: ...
 
+    def increment_warm_retunes(self) -> None: ...
+
     def increment_warm_misses(self) -> None: ...
 
     def increment_warm_failures(self) -> None: ...
@@ -77,9 +79,11 @@ class BackgroundReaper:
 class WarmSessionPool:
     """Keeps initialized Droid sessions ready so requests skip session startup.
 
-    Sessions are keyed by the settings they were initialized with, because
-    switching a model on a live session costs as much as starting a new one.
-    A session serves at most one turn, which keeps the bridge stateless.
+    Sessions are keyed by the settings they were initialized with. An exact
+    key match serves a turn with no extra round trip; otherwise a session
+    warmed for another model is handed over and the runner repoints it, which
+    costs milliseconds instead of a fresh process. A session serves at most
+    one turn, which keeps the bridge stateless.
     """
 
     def __init__(
@@ -154,20 +158,51 @@ class WarmSessionPool:
         if not self.enabled:
             return None
         self.note(key)
-        queue = self._sessions.get(key)
-        while queue:
-            session = queue.popleft()
-            if self._usable(session):
-                self._publish()
-                if self._metrics is not None:
-                    self._metrics.increment_warm_hits()
-                log_debug("pool.hit", model=key.model_id, warm_sessions=self._total())
-                return session
-            self._discard(session)
+        session = self._take(key)
+        if session is not None:
+            self._publish()
+            if self._metrics is not None:
+                self._metrics.increment_warm_hits()
+            log_debug("pool.hit", model=key.model_id, warm_sessions=self._total())
+            return session
+        session = self._take_retunable(key)
+        if session is not None:
+            self._publish()
+            if self._metrics is not None:
+                self._metrics.increment_warm_hits()
+                self._metrics.increment_warm_retunes()
+            log_debug(
+                "pool.retune",
+                model=key.model_id,
+                warmed_for=session.key.model_id,
+                warm_sessions=self._total(),
+            )
+            return session
         self._publish()
         if self._metrics is not None:
             self._metrics.increment_warm_misses()
         log_debug("pool.miss", model=key.model_id, warm_sessions=self._total())
+        return None
+
+    def _take(self, key: SessionKey) -> WarmSession | None:
+        queue = self._sessions.get(key)
+        while queue:
+            session = queue.popleft()
+            if self._usable(session):
+                return session
+            self._discard(session)
+        return None
+
+    def _take_retunable(self, key: SessionKey) -> WarmSession | None:
+        """Borrow a session warmed for other settings the runner can repoint."""
+        for warmed_key, queue in self._sessions.items():
+            if warmed_key == key or not key.can_retune_from(warmed_key):
+                continue
+            while queue:
+                session = queue.popleft()
+                if self._usable(session):
+                    return session
+                self._discard(session)
         return None
 
     async def _loop(self) -> None:
@@ -185,21 +220,30 @@ class WarmSessionPool:
         self._drop_stale()
         self._rebalance()
         while True:
-            key = self._deficit_key()
-            if key is None:
+            deficits = self._deficits()
+            if not deficits:
                 return
-            runner = self._runner_factory()
-            try:
-                session = await runner.warm(key, timeout_seconds=self._warm_timeout_seconds)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                if self._metrics is not None:
-                    self._metrics.increment_warm_failures()
-                log_warning("pool.warm_failed", model=key.model_id, error=type(exc).__name__)
+            # Droid startup is seconds of mostly idle waiting, so a burst that
+            # drained the pool refills in one startup instead of N.
+            warmed = await asyncio.gather(*(self._warm(key) for key in deficits))
+            for session in warmed:
+                if session is not None:
+                    self.offer(session)
+            if any(session is None for session in warmed):
                 await asyncio.sleep(self._retry_seconds)
                 return
-            self.offer(session)
+
+    async def _warm(self, key: SessionKey) -> WarmSession | None:
+        runner = self._runner_factory()
+        try:
+            return await runner.warm(key, timeout_seconds=self._warm_timeout_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if self._metrics is not None:
+                self._metrics.increment_warm_failures()
+            log_warning("pool.warm_failed", model=key.model_id, error=type(exc).__name__)
+            return None
 
     def _targets(self) -> dict[SessionKey, int]:
         """Split the pool size across the keys traffic is currently using."""
@@ -208,11 +252,12 @@ class WarmSessionPool:
         base, extra = divmod(self._size, len(self._wanted))
         return {key: base + (1 if index < extra else 0) for index, key in enumerate(self._wanted)}
 
-    def _deficit_key(self) -> SessionKey | None:
+    def _deficits(self) -> list[SessionKey]:
+        deficits: list[SessionKey] = []
         for key, target in self._targets().items():
-            if len(self._sessions.get(key, ())) < target:
-                return key
-        return None
+            missing = target - len(self._sessions.get(key, ()))
+            deficits.extend([key] * max(0, missing))
+        return deficits
 
     def _rebalance(self) -> None:
         """Free capacity held for keys that traffic has moved away from."""

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import signal
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from dataclasses import dataclass
@@ -72,15 +71,21 @@ class RunnerError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class SessionKey:
-    """Droid session settings a warm session must already have applied.
-
-    Switching the model on an initialized session costs about as much as a
-    fresh session, so warm sessions are only reusable for the exact settings
-    they were created with.
-    """
+    """Droid session settings a warm session was initialized with."""
 
     model_id: str | None
     reasoning_effort: str | None
+
+    def can_retune_from(self, other: SessionKey) -> bool:
+        """Whether a session warmed for ``other`` can be repointed at ``self``.
+
+        ``None`` means "whatever Droid defaults to", which cannot be restored
+        on a session that already carries an explicit value, so those keys are
+        only reusable for an exact match.
+        """
+        if self.model_id is None:
+            return False
+        return not (self.reasoning_effort is None and other.reasoning_effort is not None)
 
 
 @dataclass(slots=True)
@@ -198,7 +203,6 @@ class _ManagedProcessTransport(ProcessTransport):
         )
         self._owned_process: asyncio.subprocess.Process | None = None
         self._forced_kill = False
-        self._grace_period_seconds = grace_period
 
     async def connect(self) -> None:
         await super().connect()
@@ -207,18 +211,12 @@ class _ManagedProcessTransport(ProcessTransport):
     async def close(self) -> None:
         process = self._owned_process
         was_running = process is not None and process.returncode is None
-        started = asyncio.get_running_loop().time()
         await super().close()
-        elapsed = asyncio.get_running_loop().time() - started
         if was_running and process is not None and process.returncode is not None:
-            sigkill = getattr(signal, "SIGKILL", None)
-            # The elapsed-time arm reports a forced kill the SDK performed
-            # internally, where the exit status is no longer visible here. A
-            # process that happens to exit on its own right at the grace
-            # boundary is counted too, so treat the metric as an upper bound.
-            self._forced_kill = (
-                sigkill is not None and process.returncode == -sigkill
-            ) or elapsed >= self._grace_period_seconds
+            # A signal death is the only reliable evidence of a kill: droid
+            # takes about a second to shut down cleanly, so timing the close
+            # against the grace period misreports every graceful exit.
+            self._forced_kill = process.returncode < 0
 
     async def force_kill_and_reap(self, timeout: float) -> bool:
         process = self._owned_process
@@ -307,6 +305,38 @@ class DroidRunner:
         """Tear down a warm session that will not serve a turn."""
         await self._cleanup(session.client, session.transport, interrupt=False)
 
+    async def _retune(self, warm: WarmSession, key: SessionKey) -> None:
+        """Repoint a warm session at the settings this turn asked for."""
+        if key == warm.key:
+            return
+        model_id = key.model_id
+        if model_id is None or not key.can_retune_from(warm.key):
+            raise RunnerError(
+                "Warm Droid session cannot be repointed at the requested model.",
+            )
+        started = time.perf_counter()
+        effort = _resolve_reasoning_effort(key.reasoning_effort)
+        await self._rpc.retune_session(
+            warm.client,
+            model_id=model_id,
+            reasoning_effort=effort.value if effort is not None else None,
+        )
+        previous = warm.key
+        warm.key = key
+        timeline = current_timeline()
+        retune_seconds = time.perf_counter() - started
+        log_debug(
+            "droid.session_retuned",
+            model=key.model_id,
+            previous_model=previous.model_id,
+            reasoning_effort=key.reasoning_effort,
+            retune_ms=(
+                timeline.observe("retune_ms", retune_seconds)
+                if timeline is not None
+                else _millis(retune_seconds)
+            ),
+        )
+
     async def run(self, request: RunRequest) -> AsyncGenerator[RunEvent, None]:
         reasoning_effort = _resolve_reasoning_effort(request.reasoning_effort)
         loop = asyncio.get_running_loop()
@@ -374,6 +404,8 @@ class DroidRunner:
                         )
                     initialized = True
                     await self._rpc.disable_native_tools(client)
+                else:
+                    await self._retune(warm, request.session_key())
                 session_timeline = current_timeline()
                 log_debug(
                     "droid.session_ready",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2237,10 +2237,11 @@ async def test_lifespan_prewarms_and_drains_the_pool(tmp_path: Path) -> None:
 
     async with app.router.lifespan_context(app):
         await asyncio.sleep(0.05)
-        assert runner.warmed == [SessionKey(model_id=None, reasoning_effort=None)]
-        assert "factory_droid_openai_warm_sessions 1" in app.state.metrics.render()
+        # One session per concurrency slot plus a spare for the refill window.
+        assert runner.warmed == [SessionKey(model_id=None, reasoning_effort=None)] * 2
+        assert "factory_droid_openai_warm_sessions 2" in app.state.metrics.render()
 
-    assert len(runner.discarded) == 1
+    assert len(runner.discarded) == 2
     assert "factory_droid_openai_warm_sessions 0" in app.state.metrics.render()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,10 +114,10 @@ def test_warm_session_count_tracks_max_concurrency_unless_set(
 
     tracking = Settings.from_env()
     assert tracking.warm_sessions == -1
-    assert tracking.warm_session_count() == 3
+    assert tracking.warm_session_count() == 4
 
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WARM_SESSIONS", " ")
-    assert Settings.from_env().warm_session_count() == 3
+    assert Settings.from_env().warm_session_count() == 4
 
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WARM_SESSIONS", "0")
     disabled = Settings.from_env()

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -69,6 +69,36 @@ async def test_add_user_message_forwards_all_structured_fields() -> None:
 
 
 @pytest.mark.asyncio
+async def test_retune_session_pins_modes_and_omits_a_default_effort() -> None:
+    protocol = FakeProtocol(lambda _method, _params: {"result": {}})
+    extension = DroidRpcExtension()
+
+    await extension.retune_session(
+        _client(protocol),
+        model_id="gpt-5.4",
+        reasoning_effort="low",
+    )
+    await extension.retune_session(
+        _client(protocol),
+        model_id="glm-5.2",
+        reasoning_effort=None,
+    )
+
+    assert protocol.calls[0][0] == "droid.update_session_settings"
+    assert protocol.calls[0][1] == {
+        "modelId": "gpt-5.4",
+        "interactionMode": "auto",
+        "autonomyLevel": "off",
+        "reasoningEffort": "low",
+    }
+    assert protocol.calls[1][1] == {
+        "modelId": "glm-5.2",
+        "interactionMode": "auto",
+        "autonomyLevel": "off",
+    }
+
+
+@pytest.mark.asyncio
 async def test_disable_native_tools_verifies_exec_and_mcp_catalogs() -> None:
     disabled: set[str] = set()
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 KEY = SessionKey(model_id="model-a", reasoning_effort="high")
 OTHER_KEY = SessionKey(model_id="model-b", reasoning_effort=None)
+RETUNE_KEY = SessionKey(model_id="model-b", reasoning_effort="high")
 
 
 class FakeTransport:
@@ -330,6 +331,75 @@ async def test_pool_moves_capacity_to_the_key_traffic_switched_to() -> None:
     assert sorted(log) == ["discard:model-a", "warm:model-a", "warm:model-b"]
     session = pool.acquire(OTHER_KEY)
     assert session is not None
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_hands_over_a_session_the_runner_can_retune() -> None:
+    metrics = BridgeMetrics()
+    pool = _pool(FakeRunner(), size=2, metrics=metrics)
+    pool.note(KEY)
+    pool.offer(_session(created_at=asyncio.get_running_loop().time()))
+
+    session = pool.acquire(RETUNE_KEY)
+
+    assert session is not None
+    assert session.key == KEY
+    rendered = metrics.render()
+    assert "factory_droid_openai_warm_session_retunes_total 1" in rendered
+    assert "factory_droid_openai_warm_session_hits_total 1" in rendered
+    assert "factory_droid_openai_warm_session_misses_total 0" in rendered
+
+
+@pytest.mark.asyncio
+async def test_pool_hands_over_a_retunable_session_without_metrics() -> None:
+    pool = _pool(FakeRunner(), size=2)
+    pool.note(KEY)
+    pool.offer(_session(created_at=asyncio.get_running_loop().time()))
+
+    assert pool.acquire(RETUNE_KEY) is not None
+
+
+@pytest.mark.asyncio
+async def test_pool_does_not_hand_over_dead_sessions_for_retuning() -> None:
+    log: list[str] = []
+    metrics = BridgeMetrics()
+    pool = _pool(FakeRunner(log=log), size=2, metrics=metrics)
+    pool.note(KEY)
+    pool.offer(_session(reaped=True))
+
+    assert pool.acquire(RETUNE_KEY) is None
+    await asyncio.sleep(0)
+
+    assert log == ["discard:model-a"]
+    assert "factory_droid_openai_warm_session_misses_total 1" in metrics.render()
+
+
+@pytest.mark.asyncio
+async def test_pool_refills_every_missing_session_in_one_pass() -> None:
+    class SlowRunner(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.concurrent = 0
+            self.peak = 0
+
+        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+            self.concurrent += 1
+            self.peak = max(self.peak, self.concurrent)
+            try:
+                await asyncio.sleep(0.02)
+                return await super().warm(key, timeout_seconds=timeout_seconds)
+            finally:
+                self.concurrent -= 1
+
+    runner = SlowRunner()
+    pool = _pool(runner, size=3)
+
+    pool.start(initial_key=KEY)
+    await asyncio.sleep(0.05)
+
+    assert runner.warmed == 3
+    assert runner.peak == 3
     await pool.aclose()
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -133,7 +133,8 @@ class FakeClient:
                 }
             }
         if method == "droid.update_session_settings":
-            self.disabled_tool_ids = set(params["disabledToolIds"])
+            if "disabledToolIds" in params:
+                self.disabled_tool_ids = set(params["disabledToolIds"])
             return {"result": {}}
         if method == "droid.add_user_message":
             self.prompt = params["text"]
@@ -1108,6 +1109,117 @@ async def test_runner_reuses_a_warm_session_without_reinitializing(tmp_path: Pat
     assert client.init_kwargs == {}
     assert client.prompt == "prompt"
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_runner_retunes_a_warm_session_to_the_requested_model(tmp_path: Path) -> None:
+    client = FakeClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort=None),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+    )
+
+    events = [
+        event
+        async for event in runner.run(
+            _request(model="gpt-5.4", reasoning_effort="low", warm_session=warm),
+        )
+    ]
+
+    assert isinstance(events[-1], RunComplete)
+    assert client.init_kwargs == {}
+    retunes = [
+        params
+        for method, params, _timeout in client.rpc_requests
+        if method == "droid.update_session_settings"
+    ]
+    assert retunes == [
+        {
+            "modelId": "gpt-5.4",
+            "interactionMode": "auto",
+            "autonomyLevel": "off",
+            "reasoningEffort": "low",
+        }
+    ]
+    assert warm.key == SessionKey(model_id="gpt-5.4", reasoning_effort="low")
+    assert client.disabled_tool_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_runner_retune_keeps_the_droid_default_effort(tmp_path: Path) -> None:
+    client = FakeClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort=None),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+    )
+
+    events = [
+        event
+        async for event in runner.run(
+            _request(model="glm-5.2", reasoning_effort=None, warm_session=warm),
+        )
+    ]
+
+    assert isinstance(events[-1], RunComplete)
+    assert client.rpc_requests[0][1] == {
+        "modelId": "glm-5.2",
+        "interactionMode": "auto",
+        "autonomyLevel": "off",
+    }
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_a_warm_session_it_cannot_retune(tmp_path: Path) -> None:
+    client = FakeClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id="gpt-5.4", reasoning_effort="high"),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+    )
+
+    with pytest.raises(RunnerError, match="cannot be repointed"):
+        _ = [
+            event
+            async for event in runner.run(
+                _request(model="gpt-5.4", reasoning_effort=None, warm_session=warm),
+            )
+        ]
+
+    assert client.rpc_requests == []
+    assert client.closed is True
+
+
+def test_session_key_retuning_requires_an_expressible_target() -> None:
+    default = SessionKey(model_id=None, reasoning_effort=None)
+    explicit = SessionKey(model_id="gpt-5.4", reasoning_effort="high")
+
+    assert explicit.can_retune_from(default) is True
+    assert SessionKey(model_id="glm-5.2", reasoning_effort=None).can_retune_from(default) is True
+    assert default.can_retune_from(explicit) is False
+    assert SessionKey(model_id="glm-5.2", reasoning_effort=None).can_retune_from(explicit) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Warm Droid sessions can now be repointed at another model instead of being thrown away, plus the teardown reporting that flagged a forced kill on every request is fixed.

- `droid_rpc.retune_session()` sends `droid.update_session_settings` with `modelId`/`reasoningEffort` and re-pins `interactionMode=auto` / `autonomyLevel=off`. Verified against a live droid: the disabled native tool list survives (`currentlyAllowed` stays `exit-spec-mode` only).
- `SessionKey.can_retune_from()` gates it. The model alias and "model default effort on a session that carries an explicit one" cannot be expressed as an update, so those still start a session.
- Pool hands over a retunable session from another key (`pool.retune`), refills every missing session in one startup window instead of sequentially, and keeps one spare per concurrency slot by default.
- Forced-kill detection keys off signal death instead of timing `close()` against the grace period; default `PROCESS_GRACE_SECONDS` is 2 s because `droid exec` needs ~1.02 s to exit cleanly.
- `examples/vscode/chatLanguageModels.json` regenerated with `--all-models` (7 -> 42 entries).

## Measured on a live bridge

| Scenario | Before | After |
|---|---:|---:|
| First request, `gpt-5.4`, pool warmed for the default | `session_ready_ms=3120` (`pool.miss`) | `retune_ms=7.2`, `session_ready_ms=7.9` (`pool.retune`) |
| Repeat request, same model | ~3200 | `session_ready_ms=0.4` (`pool.hit`) |
| Switch to `claude-haiku-4-5-20251001` | ~2600 | `retune_ms=11.0`, `session_ready_ms=11.8` |
| `droid.forced_kill` | every request, 1018 ms | none, `forced_kills_total=0` |
| Pool warm-up (3 sessions) | 3 sequential startups | one startup window |

Metrics after three requests: `warm_session_hits_total 3`, `warm_session_retunes_total 2`, `warm_session_misses_total 0`.

`ttft_ms` (2.8-4.2 s) is model time and unchanged; nothing bridge-side is left on the request path.

## New surface

- Metric `factory_droid_openai_warm_session_retunes_total`
- Log events `pool.retune`, `droid.session_retuned`, phase field `retune_ms`
- Defaults: `FACTORY_DROID_OPENAI_WARM_SESSIONS` = `MAX_CONCURRENCY + 1`, `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` = `2`

## Validation

`ruff check`, `ruff format --check`, strict `mypy`, 331 tests, 98.19% coverage (gate 95), `openapi-spec-validator`, `uv lock --check`, `uv build` all pass. No route or schema change, so `openapi.json` is untouched.