### PR TITLE
fix(models): withhold models an organization policy blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,16 @@ reads image support and reasoning effort levels from `GET /v1/models`:
 uv run python scripts/generate_vscode_models.py
 uv run python scripts/generate_vscode_models.py --all-models
 uv run python scripts/generate_vscode_models.py --model gpt-5.4 --model claude-opus-5
+uv run python scripts/generate_vscode_models.py --all-models --verify
 ```
+
+The committed example lists every model the reference host exposed. `GET
+/v1/models` returns the whole Droid catalog, including models an organization
+policy blocks for the signed-in account, so generate your own file with
+`--verify`: it starts a session for every selected model, drops the ones Droid
+refuses, and prints the refusals to stderr. No model turn runs, so verification
+costs no tokens; it spawns Droid directly and takes roughly a minute for a full
+catalog.
 
 `id` is the explicit Droid model ID. Replace it with another ID from
 `GET /v1/models` or `droid exec --help`, such as `gemini-3.1-pro-preview` or
@@ -810,6 +819,15 @@ endpoint preserves compatibility by serving the last known catalog, or the
 bridge alias alone, and marks the response with the
 `x-factory-droid-model-discovery: degraded` header while incrementing
 `factory_droid_openai_model_discovery_failures_total`.
+
+The Droid catalog also lists models an organization policy blocks for the
+signed-in account. Droid rejects those when a session starts, which the bridge
+maps to `404 model_not_found` and remembers for
+`FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS`. While a model is quarantined,
+`GET /v1/models` withholds it and reports how many entries were withheld in the
+`x-factory-droid-models-quarantined` header, chat requests for it are refused
+without starting Droid, and the warm-session pool stops warming it. Set the
+value to `0` to disable quarantining.
 
 ### Reasoning
 
@@ -997,6 +1015,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE` | unset | File appended to the Droid system prompt |
 | `FACTORY_DROID_OPENAI_MODEL_ALIAS` | `factory-droid` | Alias using Droid default model |
 | `FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS` | `300` | `GET /v1/models` catalog cache lifetime |
+| `FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS` | `900` | How long a refused model stays withheld |
 | `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` | `0` | MCP initialization window before tool discovery |
 | `FACTORY_DROID_OPENAI_LOG_LEVEL` | `info` | Bridge and Uvicorn log level |
 | `FACTORY_DROID_OPENAI_LOG_FORMAT` | `text` | Bridge log rendering: `text` or `json` |
@@ -1048,6 +1067,7 @@ surface.
 | `factory_droid_openai_payload_rejections_total` | Requests rejected with `413` |
 | `factory_droid_openai_forced_kills_total` | Droid processes that needed a kill |
 | `factory_droid_openai_model_discovery_failures_total` | Failed Droid model discovery attempts |
+| `factory_droid_openai_model_quarantines_total` | Models withheld after Droid refused them |
 | `factory_droid_openai_warm_sessions` | Warm Droid sessions ready now |
 | `factory_droid_openai_warm_session_hits_total` | Requests served from a warm session |
 | `factory_droid_openai_warm_session_retunes_total` | Warm sessions repointed at another model |
@@ -1118,7 +1138,7 @@ factory-droid-openai --log-level debug --no-access-log
 
 | Level | Content |
 |---|---|
-| `warning` | Rejections, failures, degraded model discovery, forced process kills |
+| `warning` | Rejections, failures, degraded model discovery, quarantined models, forced process kills |
 | `info` | One `chat.completed` summary per request with phase timings and token usage |
 | `debug` | Per-phase events: prompt built, admission, warm-session hit, retune or miss, Droid startup, session ready, first token, turn complete, cleanup |
 | `trace` | One line per Droid SDK event kind |
@@ -1282,6 +1302,16 @@ Not expected any more. `droid exec` exits cleanly in about a second, so raise
 a slower host; `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` must stay above
 it. With detached cleanup the kill happens after the response, so it costs the
 client nothing either way.
+
+### Model not allowed by organization policy
+
+Droid lists the full catalog but refuses to start a session for models the
+account's organization policy blocks. The bridge answers `404 model_not_found`,
+logs `models.quarantined`, and withholds the model from `GET /v1/models` for
+`FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS`, so a client that rebuilds its
+model list recovers on its own. Regenerate client configuration with
+`uv run python scripts/generate_vscode_models.py --all-models --verify` to drop
+blocked models up front.
 
 ## Development
 

--- a/scripts/generate_vscode_models.py
+++ b/scripts/generate_vscode_models.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import os
+import sys
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -14,6 +16,7 @@ ALIAS_LABEL = "Factory Droid (server default model)"
 DEFAULT_MAX_INPUT_TOKENS = 180000
 DEFAULT_MAX_OUTPUT_TOKENS = 20000
 NON_THINKING_EFFORTS = frozenset({"off", "none"})
+ALIAS_MODEL_ID = "factory-droid"
 CURATED_MODELS = (
     "factory-droid",
     "claude-opus-5",
@@ -37,6 +40,69 @@ def _fetch_models(base_url: str, api_key: str | None) -> list[dict[str, Any]]:
         payload = json.load(response)
     models: list[dict[str, Any]] = payload["data"]
     return models
+
+
+async def _probe_model(
+    model_id: str,
+    *,
+    droid_path: str,
+    workdir: Path,
+    timeout_seconds: float,
+    gate: asyncio.Semaphore,
+) -> str | None:
+    """Return why ``model_id`` is unusable, or ``None`` when it works.
+
+    Only a session is initialized, which is where Droid refuses models an
+    organization policy blocks. No model turn runs, so probing the whole
+    catalog costs no tokens.
+    """
+    from factory_droid_openai.runner import DroidRunner, SessionKey
+
+    runner = DroidRunner(droid_path=droid_path, workdir=workdir)
+    async with gate:
+        try:
+            session = await runner.warm(
+                SessionKey(model_id=model_id, reasoning_effort=None),
+                timeout_seconds=timeout_seconds,
+            )
+        except Exception as exc:
+            # Any refusal disqualifies the model, whatever its shape.
+            return str(exc) or type(exc).__name__
+    await runner.discard(session)
+    return None
+
+
+def _verify_models(
+    model_ids: list[str],
+    *,
+    droid_path: str,
+    workdir: Path,
+    timeout_seconds: float,
+    concurrency: int,
+) -> dict[str, str]:
+    """Probe every model and map the unusable ones to their refusal."""
+
+    async def run() -> dict[str, str]:
+        gate = asyncio.Semaphore(max(1, concurrency))
+        results = await asyncio.gather(
+            *(
+                _probe_model(
+                    model_id,
+                    droid_path=droid_path,
+                    workdir=workdir,
+                    timeout_seconds=timeout_seconds,
+                    gate=gate,
+                )
+                for model_id in model_ids
+            )
+        )
+        return {
+            model_id: reason
+            for model_id, reason in zip(model_ids, results, strict=True)
+            if reason is not None
+        }
+
+    return asyncio.run(run())
 
 
 def _model_entry(
@@ -113,6 +179,16 @@ def _parse_args() -> argparse.Namespace:
         help="Model ID to include; repeatable. Defaults to a curated set.",
     )
     parser.add_argument("--all-models", action="store_true", help="Include every discovered model.")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Drop models Droid refuses to start a session with, such as ones "
+        "blocked by an organization policy.",
+    )
+    parser.add_argument("--verify-concurrency", type=int, default=4)
+    parser.add_argument("--verify-timeout-seconds", type=float, default=60.0)
+    parser.add_argument("--droid-path", default=os.getenv("FACTORY_DROID_PATH", "droid"))
+    parser.add_argument("--workdir", type=Path, default=None)
     parser.add_argument("--output", type=Path, default=None)
     return parser.parse_args()
 
@@ -133,6 +209,24 @@ def main() -> None:
             message = f"Models not available on the bridge: {', '.join(missing)}"
             raise SystemExit(message)
         selected = [by_id[model_id] for model_id in wanted]
+
+    if args.verify:
+        alias = ALIAS_MODEL_ID
+        probed = [str(model["id"]) for model in selected if str(model["id"]) != alias]
+        refused = _verify_models(
+            probed,
+            droid_path=str(args.droid_path),
+            workdir=Path(args.workdir) if args.workdir else Path.cwd(),
+            timeout_seconds=float(args.verify_timeout_seconds),
+            concurrency=int(args.verify_concurrency),
+        )
+        for model_id, reason in sorted(refused.items()):
+            print(f"skipping {model_id}: {reason}", file=sys.stderr)
+        print(
+            f"verified {len(probed) - len(refused)}/{len(probed)} models",
+            file=sys.stderr,
+        )
+        selected = [model for model in selected if str(model["id"]) not in refused]
 
     config = _build_config(
         selected,

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -20,6 +20,7 @@ from jsonschema import ValidationError as JsonSchemaValidationError
 from jsonschema.exceptions import SchemaError
 from jsonschema.validators import validator_for
 
+from factory_droid_openai.availability import ModelQuarantine
 from factory_droid_openai.config import Settings
 from factory_droid_openai.droid_rpc import DroidRpcExtension
 from factory_droid_openai.logs import bind_request, current_timeline
@@ -591,6 +592,7 @@ def create_app(
     )
     bridge_created = int(time.time())
     sessions = SessionRegistry(resolved_settings.max_tracked_sessions)
+    quarantine = ModelQuarantine(ttl_seconds=resolved_settings.model_quarantine_seconds)
     admission = AdmissionController(
         max_concurrency=resolved_settings.max_concurrency,
         max_queue_size=resolved_settings.max_queue_size,
@@ -662,6 +664,7 @@ def create_app(
     application.state.sessions = sessions
     application.state.pool = pool
     application.state.reaper = reaper
+    application.state.quarantine = quarantine
 
     async def require_auth(credentials: BearerCredentials) -> None:
         expected = resolved_settings.api_key
@@ -746,6 +749,17 @@ def create_app(
         ),
     )
 
+    def note_runner_failure(model: str, exc: RunnerError) -> None:
+        if exc.error_type != "model_not_found":
+            return
+        if quarantine.record(model, str(exc)):
+            metrics.increment_model_quarantines()
+            log_warning(
+                "models.quarantined",
+                model=model,
+                ttl_seconds=resolved_settings.model_quarantine_seconds,
+            )
+
     def require_known_session(session_id: str) -> None:
         if not resolved_settings.session_continuity:
             raise BridgeHTTPError(
@@ -792,12 +806,19 @@ def create_app(
             metrics.increment_model_discovery_failures()
             log_warning("models.discovery_degraded", cached=len(discovered))
             response.headers["x-factory-droid-model-discovery"] = "degraded"
-        else:
-            log_debug("models.listed", discovered=len(discovered))
+        # The Droid catalog also lists models an organization policy blocks, so
+        # anything already known to be refused is withheld from clients that
+        # build their model picker from this response.
+        available = tuple(model for model in discovered if quarantine.allows(model.id))
+        withheld = len(discovered) - len(available)
+        if not degraded:
+            log_debug("models.listed", discovered=len(available), quarantined=withheld or None)
+        if withheld:
+            response.headers["x-factory-droid-models-quarantined"] = str(withheld)
         return ModelListResponse(
             data=_model_list(
                 resolved_settings.model_alias,
-                discovered,
+                available,
                 created=bridge_created,
             )
         )
@@ -1029,6 +1050,11 @@ def create_app(
             log_warning("chat.rejected", status=exc.status_code, phase="reasoning_effort")
             return _error_response(str(exc), exc.status_code, exc.error_type)
 
+        quarantined = quarantine.reason(payload.model)
+        if quarantined is not None:
+            log_warning("chat.rejected", status=404, phase="model", model=payload.model)
+            return _error_response(quarantined, 404, "model_not_found")
+
         created = int(time.time())
         run_request = RunRequest(
             prompt=plan.prompt,
@@ -1109,6 +1135,7 @@ def create_app(
                 session_callback=sessions.remember,
                 expose_session=resolved_settings.session_continuity,
                 structured=structured,
+                failure_callback=note_runner_failure,
             )
             return FinalizingStreamingResponse(
                 event_stream,
@@ -1177,6 +1204,7 @@ def create_app(
             return _error_response(str(exc), 502, "factory_protocol_error")
         except RunnerError as exc:
             log_warning("chat.failed", status=exc.status_code, error_type=exc.error_type)
+            note_runner_failure(payload.model, exc)
             return _error_response(str(exc), exc.status_code, exc.error_type)
 
         log_info(
@@ -1360,6 +1388,7 @@ async def _stream_completion(
     session_callback: Callable[[str], None] | None = None,
     expose_session: bool = False,
     structured: StructuredOutput | None = None,
+    failure_callback: Callable[[str, RunnerError], None] | None = None,
 ) -> AsyncIterator[str]:
     usage = Usage()
     completed = False
@@ -1525,6 +1554,8 @@ async def _stream_completion(
         except RunnerError as exc:
             outcome = "timeout" if exc.error_type == "factory_droid_timeout" else "error"
             log_warning("chat.failed", stream=True, error_type=exc.error_type)
+            if failure_callback is not None:
+                failure_callback(model, exc)
             yield _sse(_error_body(str(exc), exc.error_type))
         except asyncio.CancelledError:
             log_warning("chat.cancelled", stream=True)

--- a/src/factory_droid_openai/availability.py
+++ b/src/factory_droid_openai/availability.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantinedModel:
+    model_id: str
+    reason: str
+    until: float
+
+
+class ModelQuarantine:
+    """Remembers models Droid refused, so the bridge stops offering them.
+
+    The Droid catalog lists every model the CLI knows about, including ones an
+    organization policy blocks, and the refusal only surfaces when a session is
+    initialized. Recording the refusal keeps blocked models out of
+    ``GET /v1/models`` and turns later requests into an immediate error instead
+    of another Droid startup.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_seconds = max(0.0, ttl_seconds)
+        self._clock = clock
+        self._entries: dict[str, QuarantinedModel] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._ttl_seconds > 0
+
+    def record(self, model_id: str, reason: str) -> bool:
+        """Quarantine ``model_id``; returns whether it was newly recorded."""
+        if not self.enabled or not model_id:
+            return False
+        known = self.reason(model_id) is not None
+        self._entries[model_id] = QuarantinedModel(
+            model_id=model_id,
+            reason=reason,
+            until=self._clock() + self._ttl_seconds,
+        )
+        return not known
+
+    def reason(self, model_id: str) -> str | None:
+        """Why ``model_id`` is unavailable, or ``None`` when it may be used."""
+        entry = self._entries.get(model_id)
+        if entry is None:
+            return None
+        if entry.until <= self._clock():
+            del self._entries[model_id]
+            return None
+        return entry.reason
+
+    def allows(self, model_id: str) -> bool:
+        return self.reason(model_id) is None
+
+    def blocked(self) -> tuple[str, ...]:
+        return tuple(sorted(model_id for model_id in self._entries if not self.allows(model_id)))
+
+    def filter(self, model_ids: Iterable[str]) -> tuple[str, ...]:
+        return tuple(model_id for model_id in model_ids if self.allows(model_id))

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -40,6 +40,7 @@ class Settings:
     max_tracked_sessions: int = 256
     mcp_settle_seconds: float = 0.0
     model_cache_seconds: float = 300.0
+    model_quarantine_seconds: float = 900.0
     worktree: str | None = None
     append_system_prompt_file: Path | None = None
     model_alias: str = "factory-droid"
@@ -183,6 +184,10 @@ class Settings:
             "FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS",
             default=300.0,
         )
+        model_quarantine_seconds = _non_negative_float(
+            "FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS",
+            default=900.0,
+        )
         worktree = os.getenv("FACTORY_DROID_OPENAI_WORKTREE") or None
         append_system_prompt_file = _optional_file(
             "FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE",
@@ -231,6 +236,7 @@ class Settings:
             max_tracked_sessions=max_tracked_sessions,
             mcp_settle_seconds=mcp_settle_seconds,
             model_cache_seconds=model_cache_seconds,
+            model_quarantine_seconds=model_quarantine_seconds,
             worktree=worktree,
             append_system_prompt_file=append_system_prompt_file,
             model_alias=os.getenv("FACTORY_DROID_OPENAI_MODEL_ALIAS", "factory-droid"),

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -22,6 +22,7 @@ class BridgeMetrics:
         self._payload_rejections = 0
         self._forced_kills = 0
         self._model_discovery_failures = 0
+        self._model_quarantines = 0
         self._warm_sessions = 0
         self._warm_hits = 0
         self._warm_retunes = 0
@@ -71,6 +72,10 @@ class BridgeMetrics:
         with self._lock:
             self._model_discovery_failures += 1
 
+    def increment_model_quarantines(self) -> None:
+        with self._lock:
+            self._model_quarantines += 1
+
     def set_warm_sessions(self, count: int) -> None:
         with self._lock:
             self._warm_sessions = count
@@ -113,6 +118,7 @@ class BridgeMetrics:
                 "payload_rejections": self._payload_rejections,
                 "forced_kills": self._forced_kills,
                 "model_discovery_failures": self._model_discovery_failures,
+                "model_quarantines": self._model_quarantines,
                 "warm_sessions": self._warm_sessions,
                 "warm_hits": self._warm_hits,
                 "warm_retunes": self._warm_retunes,
@@ -160,6 +166,8 @@ class BridgeMetrics:
                 "factory_droid_openai_model_discovery_failures_total "
                 f"{values['model_discovery_failures']}"
             ),
+            "# TYPE factory_droid_openai_model_quarantines_total counter",
+            f"factory_droid_openai_model_quarantines_total {values['model_quarantines']}",
             "# TYPE factory_droid_openai_warm_sessions gauge",
             f"factory_droid_openai_warm_sessions {values['warm_sessions']}",
             "# TYPE factory_droid_openai_warm_session_hits_total counter",

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -243,7 +243,16 @@ class WarmSessionPool:
             if self._metrics is not None:
                 self._metrics.increment_warm_failures()
             log_warning("pool.warm_failed", model=key.model_id, error=type(exc).__name__)
+            # Settings Droid rejects, such as a model an organization policy
+            # blocks, would otherwise be retried for as long as they stay in
+            # the wanted list. Traffic that still works re-adds the key.
+            self._forget(key)
             return None
+
+    def _forget(self, key: SessionKey) -> None:
+        if key in self._wanted:
+            self._wanted.remove(key)
+        self._drop(key)
 
     def _targets(self) -> dict[SessionKey, int]:
         """Split the pool size across the keys traffic is currently using."""

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import re
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from dataclasses import dataclass
@@ -53,6 +54,13 @@ _BASE_EXEC_ARGS = (
     "stream-jsonrpc",
     "--output-format",
     "stream-jsonrpc",
+)
+# Droid refuses a model an organization policy blocks with a JSON-RPC internal
+# error, so the wording is the only signal that the model, not the bridge, is
+# at fault.
+_MODEL_DENIED_PATTERN = re.compile(
+    r"model (?:is )?not (?:allowed|available|permitted|enabled)",
+    re.IGNORECASE,
 )
 
 
@@ -244,7 +252,7 @@ class DroidRunner:
         droid_path: str,
         workdir: Path,
         client_factory: ClientFactory | None = None,
-        process_grace_seconds: float = 1.0,
+        process_grace_seconds: float = 2.0,
         cleanup_timeout_seconds: float = 4.0,
         metrics: RunnerMetrics | None = None,
         worktree: str | None = None,
@@ -506,10 +514,8 @@ class DroidRunner:
                 error_type="session_not_found",
             ) from exc
         except DroidClientError as exc:
-            raise RunnerError(
-                f"Factory Droid SDK failed: {exc}",
-                error_type="factory_droid_sdk_error",
-            ) from exc
+            model_id = _resolve_model_id(request.model, request.model_alias)
+            raise sdk_error(exc, model=model_id) from exc
         finally:
             interrupt = initialized and not completed
             if self._reaper is not None:
@@ -790,6 +796,27 @@ def _build_exec_args(
 
 def _resolve_model_id(model: str, model_alias: str) -> str | None:
     return None if model == model_alias else model
+
+
+def sdk_error(exc: DroidClientError, *, model: str | None = None) -> RunnerError:
+    """Map a Droid SDK failure onto the closest OpenAI-compatible error.
+
+    Droid lists every model its CLI knows about and only refuses the ones an
+    organization policy blocks when a session is initialized, so that refusal
+    has to read as an unavailable model rather than a bridge failure.
+    """
+    message = str(exc)
+    if _MODEL_DENIED_PATTERN.search(message):
+        subject = f"Model '{model}'" if model else "The requested model"
+        return RunnerError(
+            f"{subject} is not available for this Factory account: {message}",
+            status_code=404,
+            error_type="model_not_found",
+        )
+    return RunnerError(
+        f"Factory Droid SDK failed: {message}",
+        error_type="factory_droid_sdk_error",
+    )
 
 
 def _resolve_reasoning_effort(value: str | None) -> ReasoningEffort | None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -255,6 +255,77 @@ async def test_health_and_models(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_quarantines_a_model_droid_refuses(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [],
+        error=RunnerError(
+            "Model 'gpt-5.4' is not available for this Factory account: "
+            "Model not allowed by organization policy",
+            status_code=404,
+            error_type="model_not_found",
+        ),
+    )
+    app = _app(tmp_path, runner)
+
+    async with _client(app) as client:
+        first = await client.post("/v1/chat/completions", json=_payload(model="gpt-5.4"))
+        models = await client.get("/v1/models")
+        second = await client.post("/v1/chat/completions", json=_payload(model="gpt-5.4"))
+        metrics = await client.get("/metrics")
+
+    assert first.status_code == 404
+    assert first.json()["error"]["type"] == "model_not_found"
+    assert [model["id"] for model in models.json()["data"]] == ["factory-droid"]
+    assert models.headers["x-factory-droid-models-quarantined"] == "1"
+    assert second.status_code == 404
+    # The second request is refused before a Droid session is started.
+    assert len(runner.requests) == 1
+    assert "factory_droid_openai_model_quarantines_total 1" in metrics.text
+
+
+@pytest.mark.asyncio
+async def test_streamed_chat_quarantines_a_model_droid_refuses(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [],
+        error=RunnerError(
+            "Model 'gpt-5.4' is not available for this Factory account",
+            status_code=404,
+            error_type="model_not_found",
+        ),
+    )
+    app = _app(tmp_path, runner)
+
+    async with _client(app) as client:
+        payload = _payload(model="gpt-5.4", stream=True)
+        stream = await client.post("/v1/chat/completions", json=payload)
+        blocked = await client.post("/v1/chat/completions", json=payload)
+
+    assert "model_not_found" in stream.text
+    assert blocked.status_code == 404
+    assert len(runner.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_keeps_serving_models_droid_did_not_refuse(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [],
+        error=RunnerError("Factory Droid SDK failed: boom", error_type="factory_droid_sdk_error"),
+    )
+    app = _app(tmp_path, runner)
+
+    async with _client(app) as client:
+        first = await client.post("/v1/chat/completions", json=_payload(model="gpt-5.4"))
+        second = await client.post("/v1/chat/completions", json=_payload(model="gpt-5.4"))
+        models = await client.get("/v1/models")
+
+    assert first.status_code == 502
+    assert second.status_code == 502
+    assert len(runner.requests) == 2
+    assert [model["id"] for model in models.json()["data"]] == ["factory-droid", "gpt-5.4"]
+    assert "x-factory-droid-models-quarantined" not in models.headers
+
+
+@pytest.mark.asyncio
 async def test_models_falls_back_to_alias_when_droid_is_unavailable(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from factory_droid_openai.availability import ModelQuarantine
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_quarantine_hides_a_model_until_the_ttl_expires() -> None:
+    clock = FakeClock()
+    quarantine = ModelQuarantine(ttl_seconds=60.0, clock=clock)
+
+    assert quarantine.enabled is True
+    assert quarantine.record("claude-fable-5", "not allowed") is True
+    assert quarantine.reason("claude-fable-5") == "not allowed"
+    assert quarantine.allows("claude-fable-5") is False
+    assert quarantine.allows("gpt-5.4") is True
+    assert quarantine.blocked() == ("claude-fable-5",)
+    assert quarantine.filter(["gpt-5.4", "claude-fable-5"]) == ("gpt-5.4",)
+
+    clock.now = 60.0
+
+    assert quarantine.reason("claude-fable-5") is None
+    assert quarantine.blocked() == ()
+    assert quarantine.filter(["gpt-5.4", "claude-fable-5"]) == ("gpt-5.4", "claude-fable-5")
+
+
+def test_quarantine_reports_only_the_first_record_as_new() -> None:
+    clock = FakeClock()
+    quarantine = ModelQuarantine(ttl_seconds=60.0, clock=clock)
+
+    assert quarantine.record("gpt-5.4", "first") is True
+    assert quarantine.record("gpt-5.4", "second") is False
+    assert quarantine.reason("gpt-5.4") == "second"
+
+    clock.now = 120.0
+
+    assert quarantine.record("gpt-5.4", "third") is True
+
+
+def test_quarantine_can_be_disabled_and_ignores_empty_model_ids() -> None:
+    quarantine = ModelQuarantine(ttl_seconds=0.0)
+
+    assert quarantine.enabled is False
+    assert quarantine.record("gpt-5.4", "not allowed") is False
+    assert quarantine.allows("gpt-5.4") is True
+
+    enabled = ModelQuarantine(ttl_seconds=60.0)
+
+    assert enabled.record("", "not allowed") is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,7 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_MAX_JSON_DEPTH",
     "FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS",
     "FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS",
+    "FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS",
     "FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS",
     "FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS",
     "FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS",
@@ -180,6 +181,7 @@ def test_settings_from_env_reads_all_overrides(
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_JSON_DEPTH", "8")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "1.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS", "0")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS", "120")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS", "3")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS", "2.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS", "6.5")
@@ -208,6 +210,7 @@ def test_settings_from_env_reads_all_overrides(
         max_json_depth=8,
         mcp_settle_seconds=1.5,
         model_cache_seconds=0.0,
+        model_quarantine_seconds=120.0,
         retry_after_seconds=3,
         process_grace_seconds=2.5,
         cleanup_timeout_seconds=6.5,
@@ -250,6 +253,7 @@ def test_settings_from_env_reads_all_overrides(
         ("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "invalid", "must be a number"),
         ("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "-1", "must be zero or greater"),
         ("FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS", "inf", "must be zero or greater"),
+        ("FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS", "-1", "must be zero or greater"),
         (
             "FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS",
             "0",

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -230,6 +230,32 @@ async def test_pool_records_warm_failures_and_keeps_running() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pool_stops_warming_a_key_droid_rejects() -> None:
+    class CountingRunner(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__(fail=True)
+            self.attempts = 0
+
+        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+            self.attempts += 1
+            return await super().warm(key, timeout_seconds=timeout_seconds)
+
+    runner = CountingRunner()
+    pool = _pool(runner, retry_seconds=0.01)
+
+    pool.start(initial_key=KEY)
+    await asyncio.sleep(0.1)
+
+    assert runner.attempts == 1
+
+    pool.note(KEY)
+    await asyncio.sleep(0.05)
+
+    assert runner.attempts == 2
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
 async def test_pool_spreads_warm_sessions_across_keys() -> None:
     log: list[str] = []
     runner = FakeRunner(log=log)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -21,7 +21,7 @@ from droid_sdk import (
     WorkingStateChanged,
 )
 from droid_sdk import TimeoutError as DroidTimeoutError
-from droid_sdk.errors import SessionNotFoundError
+from droid_sdk.errors import ProtocolError, SessionNotFoundError
 from droid_sdk.schemas.enums import (
     AutonomyLevel,
     DroidInteractionMode,
@@ -1210,6 +1210,47 @@ async def test_runner_rejects_a_warm_session_it_cannot_retune(tmp_path: Path) ->
 
     assert client.rpc_requests == []
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_runner_reports_a_policy_blocked_model_as_unavailable(tmp_path: Path) -> None:
+    class DeniedClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> None:
+            del kwargs
+            raise ProtocolError("Model not allowed by organization policy", code=-32603)
+
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: DeniedClient([])),
+    )
+
+    with pytest.raises(RunnerError, match="not available for this Factory account") as caught:
+        _ = [event async for event in runner.run(_request(model="claude-fable-5"))]
+
+    assert caught.value.status_code == 404
+    assert caught.value.error_type == "model_not_found"
+    assert "claude-fable-5" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_other_sdk_failures_as_bridge_errors(tmp_path: Path) -> None:
+    class BrokenClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> None:
+            del kwargs
+            raise DroidClientError("session storage exploded")
+
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: BrokenClient([])),
+    )
+
+    with pytest.raises(RunnerError, match="Factory Droid SDK failed") as caught:
+        _ = [event async for event in runner.run(_request())]
+
+    assert caught.value.status_code == 502
+    assert caught.value.error_type == "factory_droid_sdk_error"
 
 
 def test_session_key_retuning_requires_an_expressible_target() -> None:


### PR DESCRIPTION
## Problem

`GET /v1/models` served the entire Droid catalog, including models the signed-in
account's organization policy blocks. On the reference host 7 of 41 models are
blocked:

`claude-fable-5`, `claude-opus-4-8-fast`, `claude-opus-5-fast`, `glm-5.2-fast`,
`gpt-5.3-codex-fast`, `gpt-5.4-fast`, `gpt-5.5-fast`

Droid refuses those at `initialize_session`:

```
ProtocolError: Model not allowed by organization policy, code=-32603
```

Consequences: VS Code listed models that error on the first message, the bridge
answered `502 factory_droid_sdk_error` (a client cannot act on that), and the
warm pool kept the key in its wanted list, so logs filled with
`pool.warm_failed` plus `droid.forced_kill` every retry window, forever.

## Change

- `runner.sdk_error()` maps a refusal to `404 model_not_found` naming the model.
- New `availability.ModelQuarantine`: TTL blocklist,
  `FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS` (default `900`, `0` disables).
- `GET /v1/models` withholds quarantined models and reports the count in
  `x-factory-droid-models-quarantined`.
- Chat requests for a quarantined model are refused before Droid is spawned.
- `WarmSessionPool` forgets a key whose warm-up failed, ending the retry loop.
  Live traffic re-adds keys that work.
- New metric `factory_droid_openai_model_quarantines_total`, new log event
  `models.quarantined`.
- `scripts/generate_vscode_models.py --verify` starts a session per model, drops
  the refused ones, and prints them to stderr. Session only, no model turn, so
  it costs no tokens (~45 s for 41 models at concurrency 4).
- Committed example still lists the full catalog (42 entries); `--verify` is for
  generating an account-specific file, since the blocked set differs per account.

## Validation

`ruff check`, `ruff format --check`, strict `mypy`, 341 tests, 98.19% branch
coverage, `openapi-spec-validator`, `uv lock --check`, `uv build`. No route or
schema change, so `openapi.json` is untouched.
