### PR TITLE
fix(runner): count only SIGKILL as a forced kill

### DIFF
--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import re
+import signal
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from dataclasses import dataclass
@@ -221,10 +222,11 @@ class _ManagedProcessTransport(ProcessTransport):
         was_running = process is not None and process.returncode is None
         await super().close()
         if was_running and process is not None and process.returncode is not None:
-            # A signal death is the only reliable evidence of a kill: droid
-            # takes about a second to shut down cleanly, so timing the close
-            # against the grace period misreports every graceful exit.
-            self._forced_kill = process.returncode < 0
+            # Only SIGKILL proves a forced kill. The SDK's own close() sends
+            # SIGTERM as its first shutdown step, so a droid build that does
+            # not trap SIGTERM dies with -SIGTERM during a fully graceful
+            # close and must not be counted.
+            self._forced_kill = process.returncode == -signal.SIGKILL
 
     async def force_kill_and_reap(self, timeout: float) -> bool:
         process = self._owned_process

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -516,6 +516,55 @@ async def test_runner_kills_and_reaps_process_ignoring_sigterm(
     assert "factory_droid_openai_forced_kills_total 1" in metrics.render()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal behavior")
+@pytest.mark.asyncio
+async def test_runner_does_not_count_sigterm_death_as_forced_kill(
+    tmp_path: Path,
+) -> None:
+    """A process that dies from the SDK's own SIGTERM is a graceful close."""
+    executable = tmp_path / "fake-droid"
+    pid_file = tmp_path / "child.pid"
+    executable.write_text(
+        textwrap.dedent(
+            f"""\
+            #!{sys.executable}
+            import os
+            import time
+            from pathlib import Path
+
+            Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+            while True:
+                time.sleep(1)
+            """
+        ),
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+    metrics = BridgeMetrics()
+    runner = DroidRunner(
+        droid_path=str(executable),
+        workdir=tmp_path,
+        process_grace_seconds=0.05,
+        cleanup_timeout_seconds=0.5,
+        metrics=metrics,
+    )
+
+    task = asyncio.create_task(_collect(runner, _request(timeout_seconds=10)))
+    for _ in range(100):
+        if pid_file.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert pid_file.exists()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+    assert "factory_droid_openai_forced_kills_total 0" in metrics.render()
+
+
 @pytest.mark.asyncio
 async def test_runner_clamps_negative_usage_to_zero(tmp_path: Path) -> None:
     usage = TokenUsageUpdate(


### PR DESCRIPTION
## Problem

Every successful request in Linux containers logged `WARNING event=droid.forced_kill` and bumped `forced_kills_total`, despite the shutdown being graceful.

Root cause: the droid SDK's own `close()` sends SIGTERM as its first shutdown step (`droid_sdk/transport.py`). A droid build that does not trap SIGTERM (observed with the Linux 0.180.0 binary; the macOS build exits with code 0) dies with `returncode == -SIGTERM`. The bridge counted **any** signal death (`returncode < 0`) as a forced kill.

Verified live: macOS droid 0.180.0 closes cleanly (no warning), container droid 0.180.0 dies by SIGTERM (warning every request, `cleanup_ms≈1026` ≈ normal droid shutdown time).

## Fix

Only `-SIGKILL` (the last-resort escalation in `force_kill_and_reap` and the SDK's own grace-period escalation) counts as a forced kill. SIGTERM death after our own `close()` is the SDK's designed shutdown path.

## Tests

- New regression test: a process without a SIGTERM handler dies by `-SIGTERM` on close → `forced_kills_total 0`
- Existing SIGKILL-escalation tests unchanged and passing
- `ruff`, `ruff format --check`, `mypy` clean; 342 tests pass, coverage 98.25%