### PR TITLE
fix(protocol): repair malformed tool-call markers

### DIFF
--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1200,7 +1200,12 @@ def create_app(
                     total_usage = _add_usage(total_usage, result.usage)
                     choices.append(_choice_dict(result, index))
         except ProtocolError as exc:
-            log_warning("chat.failed", status=502, error_type="factory_protocol_error")
+            log_warning(
+                "chat.failed",
+                status=502,
+                error_type="factory_protocol_error",
+                reason=str(exc),
+            )
             return _error_response(str(exc), 502, "factory_protocol_error")
         except RunnerError as exc:
             log_warning("chat.failed", status=exc.status_code, error_type=exc.error_type)
@@ -1513,6 +1518,20 @@ async def _stream_completion(
                 )
             if not stop_buffer.triggered:
                 for emission in parser.finish():
+                    if isinstance(emission, ToolCallEmission):
+                        saw_tool_call = True
+                        yield _sse(
+                            _chunk_for_emission(
+                                request_id,
+                                created,
+                                model,
+                                emission,
+                                include_usage=include_usage,
+                                tool_call_index=tool_call_index,
+                            )
+                        )
+                        tool_call_index += 1
+                        continue
                     text = stop_buffer.feed(emission.text)
                     if text:
                         chunk_payload = text_chunk(text)
@@ -1549,7 +1568,12 @@ async def _stream_completion(
                 yield _sse(_usage_chunk(request_id, created, model, usage))
         except ProtocolError as exc:
             outcome = "error"
-            log_warning("chat.failed", stream=True, error_type="factory_protocol_error")
+            log_warning(
+                "chat.failed",
+                stream=True,
+                error_type="factory_protocol_error",
+                reason=str(exc),
+            )
             yield _sse(_error_body(str(exc), "factory_protocol_error"))
         except RunnerError as exc:
             outcome = "timeout" if exc.error_type == "factory_droid_timeout" else "error"

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 from factory_droid_openai.attachments import AttachmentSet, extract_attachments
 from factory_droid_openai.errors import ProtocolError, RequestTooLargeError
+from factory_droid_openai.logs import debug as log_debug
+from factory_droid_openai.logs import trace as log_trace
 
 if TYPE_CHECKING:
     from factory_droid_openai.models import ChatCompletionRequest, ToolDefinition
@@ -15,6 +17,12 @@ if TYPE_CHECKING:
 TOOL_CALL_OPEN = "<tool_call>"
 TOOL_CALL_CLOSE = "</tool_call>"
 _MAX_TOOL_PAYLOAD_BYTES = 1_000_000
+_ARG_KEY_OPEN = "<arg_key>"
+_ARG_KEY_CLOSE = "</arg_key>"
+_ARG_VALUE_OPEN = "<arg_value>"
+_ARG_VALUE_CLOSE = "</arg_value>"
+_ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
+_UNPARSED_HEAD_CHARS = 64
 
 __all__ = [
     "TOOL_CALL_CLOSE",
@@ -151,6 +159,9 @@ def build_prompt(
             f"{TOOL_CALL_OPEN}"
             '{"name":"allowed_tool_name","arguments":{"key":"value"}}'
             f"{TOOL_CALL_CLOSE}. "
+            "Between the markers emit exactly one JSON object with the keys "
+            '"name" and "arguments"; never emit <arg_key>/<arg_value> blocks, '
+            "a code fence, or two objects inside one marker pair. "
             f"Do not call Droid-native tools. {trailing_rule}"
         )
         if require_tool_call:
@@ -259,11 +270,14 @@ class ToolCallStreamParser:
             return self._consume_tool_payload(chunk)
         return self._consume_text(chunk)
 
-    def finish(self) -> list[TextEmission]:
-        """Flushes buffered text. A tool call can only complete inside ``feed``."""
+    def finish(self) -> list[ProtocolEmission]:
+        """Flushes buffered text and any tool call left without a close marker."""
+        emissions: list[ProtocolEmission] = []
         if self._capturing:
-            raise ProtocolError("incomplete tool-call marker")
-        emissions: list[TextEmission] = []
+            recovered = self._recover_unclosed_tool_call()
+            if recovered is None:
+                raise ProtocolError("incomplete tool-call marker")
+            emissions.extend(self._emit_tool_calls(recovered))
         if self._text_tail:
             # After a tool call only whitespace may separate further calls; any
             # residual non-whitespace is trailing output and must fail closed.
@@ -328,17 +342,15 @@ class ToolCallStreamParser:
         self._append_payload(payload, payload_bytes)
         trailing = value[close_index + len(TOOL_CALL_CLOSE) :]
         complete_payload = "".join(self._payload_chunks)
-        emission = self._parse_tool_payload(complete_payload)
+        payload_objects = self._tool_payload_objects(complete_payload)
         self._payload_chunks.clear()
         # The size limit is per payload, so the bounded call count is what caps
         # the total bytes a single turn can buffer.
         self._payload_bytes = 0
         self._close_tail = ""
         self._capturing = False
-        self._saw_tool_call = True
-        self._tool_call_count += 1
 
-        emissions: list[ProtocolEmission] = [emission]
+        emissions: list[ProtocolEmission] = list(self._emit_tool_calls(payload_objects))
         if self._tool_call_count >= self._max_tool_calls:
             self._done = True
             if trailing.strip():
@@ -346,6 +358,29 @@ class ToolCallStreamParser:
             return emissions
         if trailing:
             emissions.extend(self._consume_text(trailing))
+        return emissions
+
+    def _recover_unclosed_tool_call(self) -> list[dict[str, Any]] | None:
+        """Repairs a tool call whose closing marker never arrived."""
+        payload = "".join(self._payload_chunks) + self._close_tail
+        try:
+            objects = self._tool_payload_objects(payload)
+        except ProtocolError:
+            return None
+        self._payload_chunks.clear()
+        self._payload_bytes = 0
+        self._close_tail = ""
+        self._capturing = False
+        return objects
+
+    def _emit_tool_calls(self, payload_objects: list[dict[str, Any]]) -> list[ToolCallEmission]:
+        emissions: list[ToolCallEmission] = []
+        for value in payload_objects:
+            if self._tool_call_count >= self._max_tool_calls:
+                raise ProtocolError("more tool calls than the configured maximum")
+            emissions.append(self._tool_call_from_object(value))
+            self._saw_tool_call = True
+            self._tool_call_count += 1
         return emissions
 
     def _append_payload(self, value: str, value_bytes: int | None = None) -> None:
@@ -358,18 +393,45 @@ class ToolCallStreamParser:
             raise ProtocolError("tool-call payload is too large")
         self._payload_chunks.append(value)
 
-    def _parse_tool_payload(self, payload: str) -> ToolCallEmission:
+    def _tool_payload_objects(self, payload: str) -> list[dict[str, Any]]:
+        """Returns the tool-call objects a marker payload carries.
+
+        Strict JSON first. Models that ignore the single-object contract are
+        repaired into the same shape, because a fenced block, an ``<arg_key>``
+        list or two objects packed into one marker pair is a formatting slip,
+        not a request the bridge should drop. Names, argument types and
+        duplicate keys stay validated in :meth:`_tool_call_from_object`.
+        """
         if not self._allowed_tool_names:
             raise ProtocolError("the model requested a tool when none are available")
+        body = _strip_code_fence(payload.strip())
         try:
-            parsed = parse_strict_json(payload)
+            values = _decode_json_values(body)
         except (json.JSONDecodeError, ValueError) as exc:
-            raise ProtocolError(f"invalid tool-call JSON: {exc}") from exc
-        if not isinstance(parsed, dict):
-            raise ProtocolError("tool-call payload must be a JSON object")
+            repaired = _repair_tool_payload(body, self._allowed_tool_names)
+            if repaired is None:
+                log_trace(
+                    "tool_call.unparsed",
+                    head=body[:_UNPARSED_HEAD_CHARS],
+                    payload_bytes=len(body.encode("utf-8")),
+                )
+                raise ProtocolError(f"invalid tool-call JSON: {exc}") from exc
+            log_debug("tool_call.repaired", variant=repaired.variant)
+            values = [repaired.value]
+        if not values:
+            raise ProtocolError("invalid tool-call JSON: the payload is empty")
+        objects: list[dict[str, Any]] = []
+        for value in values:
+            if not isinstance(value, dict):
+                raise ProtocolError("tool-call payload must be a JSON object")
+            objects.append(value)
+        if len(objects) > 1:
+            log_debug("tool_call.repaired", variant="packed_objects")
+        return objects
 
+    def _tool_call_from_object(self, parsed: dict[str, Any]) -> ToolCallEmission:
         name = parsed.get("name")
-        arguments = parsed.get("arguments")
+        arguments = _tool_arguments(parsed)
         if not isinstance(name, str) or not name:
             raise ProtocolError("tool-call name must be a non-empty string")
         if name not in self._allowed_tool_names:
@@ -447,6 +509,120 @@ def parse_strict_json(text: str) -> Any:
         parse_constant=_reject_non_json_constant,
         parse_float=_parse_finite_float,
     )
+
+
+@dataclass(frozen=True, slots=True)
+class _RepairedPayload:
+    variant: str
+    value: dict[str, Any]
+
+
+def _decode_json_values(text: str) -> list[Any]:
+    """Decodes the JSON values a payload holds, back to back.
+
+    A model that packs several tool calls into one marker pair produces
+    ``{...}{...}``, which ``json.loads`` rejects as trailing data.
+    """
+    decoder = json.JSONDecoder(
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_json_constant,
+        parse_float=_parse_finite_float,
+    )
+    values: list[Any] = []
+    index = 0
+    while True:
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if index >= len(text):
+            return values
+        value, index = decoder.raw_decode(text, index)
+        values.append(value)
+
+
+def _strip_code_fence(payload: str) -> str:
+    if not payload.startswith("```"):
+        return payload
+    newline = payload.find("\n")
+    if newline < 0:
+        return payload
+    body = payload[newline + 1 :]
+    closing = body.rfind("```")
+    return body[:closing].strip() if closing >= 0 else body.strip()
+
+
+def _repair_tool_payload(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> _RepairedPayload | None:
+    if _ARG_KEY_OPEN in body:
+        repaired = _repair_arg_key_payload(body)
+        if repaired is not None:
+            return _RepairedPayload("arg_key_value", repaired)
+    repaired = _repair_named_payload(body, allowed_tool_names)
+    if repaired is not None:
+        return _RepairedPayload("bare_name", repaired)
+    return None
+
+
+def _repair_arg_key_payload(body: str) -> dict[str, Any] | None:
+    """Rebuilds GLM's ``name<arg_key>k</arg_key><arg_value>v</arg_value>`` form."""
+    index = body.find(_ARG_KEY_OPEN)
+    name = body[:index].strip()
+    if not name:
+        return None
+    arguments: dict[str, Any] = {}
+    while index >= 0:
+        key_end = body.find(_ARG_KEY_CLOSE, index)
+        if key_end < 0:
+            return None
+        key = body[index + len(_ARG_KEY_OPEN) : key_end].strip()
+        value_start = body.find(_ARG_VALUE_OPEN, key_end)
+        if not key or key in arguments or value_start < 0:
+            return None
+        value_end = body.find(_ARG_VALUE_CLOSE, value_start)
+        if value_end < 0:
+            # A truncated value would silently drop data, so fail closed.
+            return None
+        raw = body[value_start + len(_ARG_VALUE_OPEN) : value_end].strip()
+        arguments[key] = _coerce_arg_value(raw)
+        index = body.find(_ARG_KEY_OPEN, value_end)
+    return {"name": name, "arguments": arguments}
+
+
+def _coerce_arg_value(raw: str) -> Any:
+    try:
+        parsed = parse_strict_json(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+    return parsed
+
+
+def _repair_named_payload(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> dict[str, Any] | None:
+    """Rebuilds a payload that names the tool outside the JSON object."""
+    head, _, tail = body.partition("\n")
+    name = head.strip()
+    if name not in allowed_tool_names:
+        return None
+    remainder = tail.strip()
+    if not remainder:
+        return {"name": name, "arguments": {}}
+    try:
+        arguments = parse_strict_json(remainder)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(arguments, dict):
+        return None
+    return {"name": name, "arguments": arguments}
+
+
+def _tool_arguments(parsed: dict[str, Any]) -> Any:
+    for key in _ARGUMENT_KEYS:
+        if key in parsed:
+            return parsed[key]
+    return None
 
 
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -545,6 +545,39 @@ async def test_non_streaming_tool_call(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_recovers_tool_call_without_close_marker(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and not line.endswith("[DONE]")
+    ]
+    tool_calls = [
+        call for event in events for call in event["choices"][0]["delta"].get("tool_calls", [])
+    ]
+    assert len(tool_calls) == 1
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "Hel"}
+    assert events[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.asyncio
 async def test_streaming_chat_completion_uses_openai_sse(tmp_path: Path) -> None:
     usage = Usage(8, 3, 1, 0)
     runner = FakeRunner(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -469,6 +469,191 @@ def test_stream_parser_rejects_invalid_payloads(
         parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
 
 
+def test_stream_parser_repairs_arg_key_value_payload() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}weather\n"
+        f"{'<arg_key>'}city{'</arg_key>'}\n"
+        f"{'<arg_value>'}Gdańsk{'</arg_value>'}\n"
+        f"{'<arg_key>'}days{'</arg_key>'}\n"
+        f"{'<arg_value>'}3{'</arg_value>'}\n"
+        f"{TOOL_CALL_CLOSE}"
+    )
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Gdańsk", "days": 3}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "weather<arg_key>city",
+        "weather<arg_key>city</arg_key>",
+        "weather<arg_key>city</arg_key><arg_value>Gdansk",
+        "weather<arg_key></arg_key><arg_value>Gdansk</arg_value>",
+        "weather<arg_key>city</arg_key><arg_value>A</arg_value>"
+        "<arg_key>city</arg_key><arg_value>B</arg_value>",
+        "<arg_key>city</arg_key><arg_value>Gdansk</arg_value>",
+    ],
+)
+def test_stream_parser_rejects_unrepairable_arg_key_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_repairs_fenced_payload() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}```json\n"
+        '{"name":"weather","arguments":{"city":"Sopot"}}\n'
+        f"```{TOOL_CALL_CLOSE}"
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Sopot"}
+
+
+def test_stream_parser_repairs_unterminated_fence() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}```\n{{"name":"weather","arguments":{{"city":"Sopot"}}}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+
+
+def test_stream_parser_keeps_single_line_fence_unrepaired() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}```json{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_accepts_objects_packed_in_one_marker_pair() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}"
+        '{"name":"weather","arguments":{"city":"Gdansk"}}\n '
+        '{"name":"weather","arguments":{"city":"Sopot"}}'
+        f"{TOOL_CALL_CLOSE}"
+    )
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Gdansk", "Sopot"]
+
+
+def test_stream_parser_rejects_packed_objects_past_the_cap() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+
+    with pytest.raises(ProtocolError, match="more tool calls than the configured maximum"):
+        parser.feed(
+            f"{TOOL_CALL_OPEN}"
+            '{"name":"weather","arguments":{}}'
+            '{"name":"weather","arguments":{}}'
+            f"{TOOL_CALL_CLOSE}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("weather", {}),
+        ('weather\n{"city":"Gdansk"}', {"city": "Gdansk"}),
+    ],
+)
+def test_stream_parser_repairs_name_outside_the_json_object(
+    payload: str,
+    expected: dict[str, str],
+) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == expected
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "shell",
+        'shell\n{"cmd":"ls"}',
+        "weather\nnot-json",
+        "weather\n[]",
+    ],
+)
+def test_stream_parser_refuses_to_repair_unnamed_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_rejects_empty_payload() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="the payload is empty"):
+        parser.feed(f"{TOOL_CALL_OPEN}   {TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_reads_argument_key_aliases() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}{{"name":"weather","parameters":{{"city":"Hel"}}}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+def test_stream_parser_requires_an_arguments_key() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="arguments must be a JSON object"):
+        parser.feed(f'{TOOL_CALL_OPEN}{{"name":"weather"}}{TOOL_CALL_CLOSE}')
+
+
+def test_stream_parser_recovers_tool_call_without_close_marker() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    assert parser.feed(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}') == []
+    emissions = parser.finish()
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+def test_recovered_tool_call_satisfies_a_required_tool_call() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), require_tool_call=True)
+    parser.feed(f'{TOOL_CALL_OPEN}weather\n{{"city":"Hel"}}')
+
+    emissions = parser.finish()
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+
+
+def test_unclosed_marker_without_tools_still_fails() -> None:
+    parser = ToolCallStreamParser(frozenset())
+    parser.feed(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}')
+
+    with pytest.raises(ProtocolError, match="incomplete tool-call marker"):
+        parser.finish()
+
+
 def test_stream_parser_rejects_oversized_payload() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 


### PR DESCRIPTION
## Summary

Some models ignore the single-JSON-object contract between `<tool_call>` and `</tool_call>`, and the bridge failed the entire turn with `factory_protocol_error`. Observed live with `glm-5.2` behind a tool-calling agent:

```
invalid tool-call JSON: Expecting value: line 1 column 1 (char 0)
invalid tool-call JSON: Extra data: line 1 column 374 (char 373)
incomplete tool-call marker
```

Clients see a stream that stops without `finish_reason`, treat it as a mid-stream network drop, and burn retries on a continuation loop.

`ToolCallStreamParser` now runs a repair pass when strict parsing fails, covering the drift seen in the wild:

- GLM's `name<arg_key>k</arg_key><arg_value>v</arg_value>` argument list
- several JSON objects packed into one marker pair (bounded by `max_tool_calls`)
- a fenced JSON block
- the tool name emitted outside the JSON object, including a bare name with no arguments
- `parameters` / `args` / `input` used instead of `arguments`
- a tool call whose closing marker never arrived, now recovered in `finish()`

The prompt also states the payload contract explicitly, so the repair pass is a fallback rather than the primary path.

## Compatibility impact

Streaming and non-streaming response shapes are unchanged. Tool calls recovered in `finish()` are emitted as ordinary `tool_calls` deltas followed by `finish_reason=tool_calls`, so clients see one well-formed turn instead of a truncated stream.

## Security impact

No validation was relaxed. Duplicate keys, non-object `arguments` (including a JSON-encoded string), unknown tool names, tools requested when none are available, payload byte limits, `NaN`/`Infinity`/non-finite numbers and trailing output after a tool call all still fail closed. A truncated `<arg_value>` is refused rather than silently shortened, and the name-outside-JSON repair only applies when the name is already in the allowed set. New `more tool calls than the configured maximum` error keeps the per-turn cap enforced when a single marker pair carries too many objects.

Failures now log `reason=<protocol message>` and repairs log `event=tool_call.repaired variant=...` at debug. The unrepaired payload head is logged at trace only, which is off by default.

## Tests added or updated

- `tests/test_protocol.py`: 25 cases across every repair variant plus the unrepairable counterparts (missing `</arg_value>`, duplicate `<arg_key>`, empty payload, name not allowed, fence without a body, cap exceeded)
- `tests/test_app.py`: SSE test asserting a tool call recovered without a closing marker is streamed with `finish_reason=tool_calls`

Coverage: 98.34% total, `protocol.py` at 99%.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

`openapi.json` is unchanged: no routes or schemas moved, and local regeneration only produces dependency-version churn (`0` to `0.0`, reordered keys).

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
