### PR TITLE
fix(attachments): remove ReDoS in data URI parameter parsing

### DIFF
--- a/src/factory_droid_openai/attachments.py
+++ b/src/factory_droid_openai/attachments.py
@@ -23,7 +23,9 @@ DOCUMENT_MEDIA_TYPES = frozenset(
     }
 )
 
-_DATA_URI = re.compile(r"^data:([\w.+-]+/[\w.+-]+)((?:;[^,]*)*),(.*)$", re.DOTALL)
+# Parameter segments exclude ';' so the repetition has one unambiguous split per
+# input; '[^,]*' let a segment swallow separators and backtrack exponentially.
+_DATA_URI = re.compile(r"^data:([\w.+-]+/[\w.+-]+)((?:;[^;,]*)*),(.*)$", re.DOTALL)
 
 
 class AttachmentError(ProtocolError):

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import time
 from typing import Any
 
 import pytest
@@ -118,6 +119,24 @@ def test_non_base64_image_data_uri_is_rejected() -> None:
 
     with pytest.raises(AttachmentError, match="must be base64 encoded"):
         _extract(payload)
+
+
+def test_data_uri_parameters_before_base64_are_accepted() -> None:
+    payload = _image_message(f"data:image/png;charset=utf-8;base64,{PNG_B64}")
+
+    _, collected = _extract(payload)
+
+    assert collected.images[0].data == PNG_B64
+
+
+def test_data_uri_without_comma_is_rejected_without_backtracking() -> None:
+    payload = _image_message("data:image/png" + ";" * 40)
+
+    started = time.perf_counter()
+    with pytest.raises(AttachmentError, match="remote image URLs are not supported"):
+        _extract(payload)
+
+    assert time.perf_counter() - started < 1.0
 
 
 def test_pdf_file_part_becomes_document_attachment() -> None:


### PR DESCRIPTION
## Summary

Fixes CodeQL alert no.2 (`py/redos`, high) in `src/factory_droid_openai/attachments.py:26`.

The data URI parameter repetition was `(?:;[^,]*)*`. `[^,]` also matches `;`, so a
parameter segment could swallow separators and the same input had exponentially many
valid decompositions. A data URI with many semicolons and no comma forces the engine
to try all of them before the match can fail. Measured on the old pattern: 22 semicolons
takes 79 ms, and each extra semicolon doubles it, so 40 semicolons is hours of CPU inside
a request. Any client-supplied `image_url` or `file_data` string reaches this regex.

Parameter segments now exclude `;` as well: `(?:;[^;,]*)*`. Same accepted language and
same capture groups (verified against the old pattern), one unambiguous split per input,
linear time - 40 semicolons takes 12 us.

Tests added:

- `test_data_uri_parameters_before_base64_are_accepted` - `;charset=utf-8;base64` still parses.
- `test_data_uri_without_comma_is_rejected_without_backtracking` - pathological input fails fast.

CodeQL alert no.1 (`py/stack-trace-exposure`, medium) was dismissed as a false positive:
the flagged values are curated bridge-owned error strings from `ProtocolError`,
`RequestTooLargeError` and `RunnerError`. No traceback, frame, or exception-type data
reaches the response body, and OpenAI-compatible clients rely on that validation detail.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` (369 passed, 98.34%)
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

`openapi.json` is unchanged: no route or schema change.

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.