### PR TITLE
feat(protocol): decode model tool-call dialects via registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,29 @@ The bridge validates the tool name and JSON arguments, then returns a standard
 OpenAI `tool_calls` object. The OpenAI client executes the tool and sends its
 result in the next request.
 
+A model sometimes answers in the chat template it was trained on instead of
+that contract. The bridge translates those forms into the same `tool_calls`
+object rather than failing the turn or leaking template tokens as assistant
+text. Every accepted form lives in one table in
+`src/factory_droid_openai/dialects.py`.
+
+| Accepted form | Observed on |
+|---|---|
+| `<tool_call>{"name":...,"arguments":...}</tool_call>` | this bridge's contract, Hermes-style output |
+| `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>` | Qwen3 Coder XML |
+| `<\|tool_calls_section_begin\|>` … `<\|tool_calls_section_end\|>` | Kimi K2 |
+| `<\|open\|>tools<\|sep\|>` … `<\|close\|>tools` | Kimi K3 |
+| `<\|channel\|>commentary to=functions.name` … `<\|call\|>` | gpt-oss Harmony |
+| `<｜tool▁calls▁begin｜>` … `<｜tool▁calls▁end｜>` | DeepSeek V3 and V3.1 |
+| `<\|action_start\|><\|plugin\|>{"name":...}<\|action_end\|>` | InternLM2 |
+| `name<arg_key>key</arg_key><arg_value>value</arg_value>` | GLM |
+| a JSON array of calls inside one marker pair | Mistral, Jamba, Granite and xLAM style output |
+
+Translation never widens validation. An unknown tool name, a truncated payload,
+a duplicate argument key, or prose after a call still fails the turn. Qwen3's
+XML form declares no argument types, so a scalar value stays the string the
+model wrote unless it wrote a JSON object or array.
+
 ## Requirements
 
 - Python 3.11 or newer
@@ -795,7 +818,9 @@ ID from `GET /v1/models`.
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/health` | Process health check |
+| `GET` | `/version` | Bridge version, unauthenticated like `/health` |
 | `GET` | `/v1/models` | Bridge alias and dynamically discovered Droid models |
+| `GET` | `/v1/models/{model_id}` | One model, or `404 model_not_found` |
 | `POST` | `/v1/chat/completions` | Chat completions and streaming |
 | `GET` | `/v1/factory/sessions/{id}/context` | Context statistics and breakdown |
 | `POST` | `/v1/factory/sessions/{id}/compact` | Compact history into a new session |

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ a duplicate argument key, or prose after a call still fails the turn. Qwen3's
 XML form declares no argument types, so a scalar value stays the string the
 model wrote unless it wrote a JSON object or array.
 
+Two forms are not supported:
+
+| Unsupported form | Reason |
+|---|---|
+| `[TOOL_CALLS] [{"name":...}]` (Mistral) | The tag opens a block that no token closes, which the stream parser does not frame. A Mistral-style JSON array is accepted inside a marker pair, the bare tag is not. |
+| `[get_weather(city="Gdansk")]` (pythonic, Llama 4 and some Qwen builds) | Needs Python literal parsing, and a bracketed line in prose would be misread as a call. |
+
+Both stay out until a captured sample justifies the added parsing surface.
+
 ## Requirements
 
 - Python 3.11 or newer

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -1,0 +1,373 @@
+"""The tool-call formats the bridge accepts from a model.
+
+The bridge asks for one shape, ``<tool_call>{"name":...,"arguments":...}
+</tool_call>``, but a model served through Droid sometimes answers in the chat
+template it was trained on instead. Translating those forms is the bridge's
+job: a client cannot repair what it never asked for, and forwarding raw
+template tokens as assistant text is worse than either error or repair.
+
+Every accepted form lives in one of the two tables below, so adding a format
+never touches the stream parser:
+
+* :data:`MARKER_DIALECTS` frames a payload in the stream.
+* :data:`PAYLOAD_DECODERS` rebuilds ``{"name", "arguments"}`` objects from a
+  payload strict JSON could not parse.
+
+Decoders return ``None`` when they do not recognise a payload, and the parser
+fails closed once every decoder declines.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from factory_droid_openai.strictjson import parse_strict_json
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+TOOL_CALL_OPEN = "<tool_call>"
+TOOL_CALL_CLOSE = "</tool_call>"
+
+_ARG_KEY_OPEN = "<arg_key>"
+_ARG_KEY_CLOSE = "</arg_key>"
+_ARG_VALUE_OPEN = "<arg_value>"
+_ARG_VALUE_CLOSE = "</arg_value>"
+
+_PIPE_TAG_TOOLS_OPEN = "<|open|>tools<|sep|>"
+_PIPE_TAG_TOOLS_CLOSE = "<|close|>tools"
+_PIPE_TAG_CALL_OPEN = "<|open|>call "
+_PIPE_TAG_ARG_OPEN = "<|open|>argument "
+_PIPE_TAG_ARG_CLOSE = "<|close|>argument"
+_PIPE_TAG_SEP = "<|sep|>"
+# Every block closes with a <|close|> tag and a truncated tag is the common
+# tail of these turns. The parser only treats these as ignorable once a call
+# has already been emitted in this dialect, so prose still fails closed.
+_PIPE_TAG_CONTROL_TOKENS = (
+    _PIPE_TAG_TOOLS_CLOSE,
+    "<|close|>call",
+    _PIPE_TAG_ARG_CLOSE,
+    "<|close|>",
+    _PIPE_TAG_SEP,
+)
+
+_KIMI_SECTION_OPEN = "<|tool_calls_section_begin|>"
+_KIMI_SECTION_CLOSE = "<|tool_calls_section_end|>"
+_KIMI_CALL_OPEN = "<|tool_call_begin|>"
+_KIMI_ARG_OPEN = "<|tool_call_argument_begin|>"
+_KIMI_CALL_CLOSE = "<|tool_call_end|>"
+_KIMI_CONTROL_TOKENS = (
+    _KIMI_SECTION_CLOSE,
+    _KIMI_CALL_CLOSE,
+    "<|im_end|>",
+)
+
+_HARMONY_COMMENTARY_OPEN = "<|channel|>commentary to="
+_HARMONY_CALL_CLOSE = "<|call|>"
+_HARMONY_MESSAGE = "<|message|>"
+_HARMONY_CONSTRAIN = "<|constrain|>"
+_HARMONY_CONTROL_TOKENS = (
+    _HARMONY_CALL_CLOSE,
+    "<|start|>assistant",
+    "<|return|>",
+    "<|end|>",
+)
+# Both formats namespace a tool as functions.<name>; Kimi also appends the
+# call index as functions.<name>:<index>.
+_FUNCTIONS_PREFIX = "functions."
+
+__all__ = [
+    "MARKER_DIALECTS",
+    "PAYLOAD_DECODERS",
+    "TOOL_CALL_CLOSE",
+    "TOOL_CALL_OPEN",
+    "MarkerDialect",
+    "PayloadDecoder",
+    "find_open_marker",
+    "strip_code_fence",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class MarkerDialect:
+    """A marker pair the parser accepts around a tool-call payload."""
+
+    name: str
+    open_marker: str
+    close_marker: str
+    control_tokens: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadDecoder:
+    """Rebuilds tool-call objects from a payload strict JSON rejected."""
+
+    name: str
+    decode: Callable[[str, frozenset[str]], list[dict[str, Any]] | None]
+
+
+NATIVE_DIALECT = MarkerDialect("native", TOOL_CALL_OPEN, TOOL_CALL_CLOSE)
+# Observed on Kimi K3 turns served through Droid. Named after the token shape
+# rather than the model, because the same scaffolding shows up whenever a model
+# answers in its own template.
+PIPE_TAG_DIALECT = MarkerDialect(
+    "pipe_tag",
+    _PIPE_TAG_TOOLS_OPEN,
+    _PIPE_TAG_TOOLS_CLOSE,
+    _PIPE_TAG_CONTROL_TOKENS,
+)
+KIMI_K2_DIALECT = MarkerDialect(
+    "kimi_k2",
+    _KIMI_SECTION_OPEN,
+    _KIMI_SECTION_CLOSE,
+    _KIMI_CONTROL_TOKENS,
+)
+HARMONY_DIALECT = MarkerDialect(
+    "harmony",
+    _HARMONY_COMMENTARY_OPEN,
+    _HARMONY_CALL_CLOSE,
+    _HARMONY_CONTROL_TOKENS,
+)
+MARKER_DIALECTS: tuple[MarkerDialect, ...] = (
+    NATIVE_DIALECT,
+    PIPE_TAG_DIALECT,
+    KIMI_K2_DIALECT,
+    HARMONY_DIALECT,
+)
+
+
+def find_open_marker(value: str) -> tuple[int, MarkerDialect] | None:
+    """Returns the earliest open marker in ``value`` and its dialect."""
+    found: tuple[int, MarkerDialect] | None = None
+    for dialect in MARKER_DIALECTS:
+        index = value.find(dialect.open_marker)
+        if index >= 0 and (found is None or index < found[0]):
+            found = (index, dialect)
+    return found
+
+
+def strip_code_fence(payload: str) -> str:
+    if not payload.startswith("```"):
+        return payload
+    newline = payload.find("\n")
+    if newline < 0:
+        return payload
+    body = payload[newline + 1 :]
+    closing = body.rfind("```")
+    return body[:closing].strip() if closing >= 0 else body.strip()
+
+
+def _decode_pipe_tag_tokens(
+    body: str,
+    allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
+) -> list[dict[str, Any]] | None:
+    """Rebuilds calls a model emitted with pipe-tag chat-template tokens.
+
+    Shape per call: ``<|open|>call tool="name" index="1"<|sep|><|open|>argument
+    key="k" type="string"<|sep|>value<|close|>argument<|sep|><|close|>call``.
+    """
+    if _PIPE_TAG_CALL_OPEN not in body:
+        return None
+    calls: list[dict[str, Any]] = []
+    index = body.find(_PIPE_TAG_CALL_OPEN)
+    while index >= 0:
+        header_end = body.find(_PIPE_TAG_SEP, index)
+        if header_end < 0:
+            return None
+        name = _pipe_tag_attribute(body[index + len(_PIPE_TAG_CALL_OPEN) : header_end], "tool")
+        if name is None:
+            return None
+        next_index = body.find(_PIPE_TAG_CALL_OPEN, header_end)
+        block_end = next_index if next_index >= 0 else len(body)
+        arguments = _pipe_tag_arguments(body[header_end:block_end])
+        if arguments is None:
+            return None
+        calls.append({"name": name, "arguments": arguments})
+        index = next_index
+    return calls
+
+
+def _pipe_tag_arguments(block: str) -> dict[str, Any] | None:
+    arguments: dict[str, Any] = {}
+    index = block.find(_PIPE_TAG_ARG_OPEN)
+    while index >= 0:
+        header_end = block.find(_PIPE_TAG_SEP, index)
+        if header_end < 0:
+            return None
+        header = block[index + len(_PIPE_TAG_ARG_OPEN) : header_end]
+        key = _pipe_tag_attribute(header, "key")
+        value_end = block.find(_PIPE_TAG_ARG_CLOSE, header_end)
+        if key is None or key in arguments or value_end < 0:
+            # A truncated value would silently drop data, so fail closed.
+            return None
+        raw = block[header_end + len(_PIPE_TAG_SEP) : value_end]
+        arguments[key] = _coerce_pipe_tag_value(raw, _pipe_tag_attribute(header, "type"))
+        index = block.find(_PIPE_TAG_ARG_OPEN, value_end)
+    return arguments
+
+
+def _pipe_tag_attribute(header: str, name: str) -> str | None:
+    prefix = f'{name}="'
+    start = header.find(prefix)
+    if start < 0:
+        return None
+    start += len(prefix)
+    end = header.find('"', start)
+    if end < 0:
+        return None
+    return header[start:end].strip() or None
+
+
+def _coerce_pipe_tag_value(raw: str, kind: str | None) -> Any:
+    # A declared string type is authoritative: coercing "1" to a number there
+    # would change the argument the client receives.
+    if kind == "string":
+        return raw.strip()
+    return _coerce_arg_value(raw.strip())
+
+
+def _decode_kimi_sections(
+    body: str,
+    allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
+) -> list[dict[str, Any]] | None:
+    """Rebuilds Kimi K2's tool-call section.
+
+    Shape per call: ``<|tool_call_begin|>functions.name:0
+    <|tool_call_argument_begin|>{"k":"v"}<|tool_call_end|>``.
+    """
+    if _KIMI_CALL_OPEN not in body:
+        return None
+    calls: list[dict[str, Any]] = []
+    index = body.find(_KIMI_CALL_OPEN)
+    while index >= 0:
+        arguments_start = body.find(_KIMI_ARG_OPEN, index)
+        if arguments_start < 0:
+            return None
+        name = _strip_function_namespace(body[index + len(_KIMI_CALL_OPEN) : arguments_start])
+        call_end = body.find(_KIMI_CALL_CLOSE, arguments_start)
+        if name is None or call_end < 0:
+            # A truncated call would drop arguments, so fail closed.
+            return None
+        raw = body[arguments_start + len(_KIMI_ARG_OPEN) : call_end]
+        arguments = _decode_json_object(raw)
+        if arguments is None:
+            return None
+        calls.append({"name": name, "arguments": arguments})
+        index = body.find(_KIMI_CALL_OPEN, call_end)
+    return calls
+
+
+def _decode_harmony_commentary(
+    body: str,
+    allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
+) -> list[dict[str, Any]] | None:
+    """Rebuilds a gpt-oss Harmony commentary call.
+
+    Payload between ``<|channel|>commentary to=`` and ``<|call|>`` reads
+    ``functions.name <|constrain|>json<|message|>{"k":"v"}``.
+    """
+    message_start = body.find(_HARMONY_MESSAGE)
+    if message_start < 0:
+        return None
+    header = body[:message_start]
+    constrain = header.find(_HARMONY_CONSTRAIN)
+    if constrain >= 0:
+        header = header[:constrain]
+    name = _strip_function_namespace(header)
+    if name is None:
+        return None
+    arguments = _decode_json_object(body[message_start + len(_HARMONY_MESSAGE) :])
+    if arguments is None:
+        return None
+    return [{"name": name, "arguments": arguments}]
+
+
+def _strip_function_namespace(raw: str) -> str | None:
+    name = raw.strip()
+    if name.startswith(_FUNCTIONS_PREFIX):
+        name = name[len(_FUNCTIONS_PREFIX) :]
+    head, separator, index = name.rpartition(":")
+    if separator and index.isdigit():
+        name = head
+    return name.strip() or None
+
+
+def _decode_json_object(raw: str) -> dict[str, Any] | None:
+    body = strip_code_fence(raw.strip())
+    if not body:
+        return {}
+    try:
+        parsed = parse_strict_json(body)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _decode_arg_key_value(
+    body: str,
+    allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
+) -> list[dict[str, Any]] | None:
+    """Rebuilds GLM's ``name<arg_key>k</arg_key><arg_value>v</arg_value>`` form."""
+    if _ARG_KEY_OPEN not in body:
+        return None
+    index = body.find(_ARG_KEY_OPEN)
+    name = body[:index].strip()
+    if not name:
+        return None
+    arguments: dict[str, Any] = {}
+    while index >= 0:
+        key_end = body.find(_ARG_KEY_CLOSE, index)
+        if key_end < 0:
+            return None
+        key = body[index + len(_ARG_KEY_OPEN) : key_end].strip()
+        value_start = body.find(_ARG_VALUE_OPEN, key_end)
+        if not key or key in arguments or value_start < 0:
+            return None
+        value_end = body.find(_ARG_VALUE_CLOSE, value_start)
+        if value_end < 0:
+            # A truncated value would silently drop data, so fail closed.
+            return None
+        raw = body[value_start + len(_ARG_VALUE_OPEN) : value_end].strip()
+        arguments[key] = _coerce_arg_value(raw)
+        index = body.find(_ARG_KEY_OPEN, value_end)
+    return [{"name": name, "arguments": arguments}]
+
+
+def _decode_bare_name(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> list[dict[str, Any]] | None:
+    """Rebuilds a payload that names the tool outside the JSON object."""
+    head, _, tail = body.partition("\n")
+    name = head.strip()
+    if name not in allowed_tool_names:
+        return None
+    remainder = tail.strip()
+    if not remainder:
+        return [{"name": name, "arguments": {}}]
+    try:
+        arguments = parse_strict_json(remainder)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(arguments, dict):
+        return None
+    return [{"name": name, "arguments": arguments}]
+
+
+def _coerce_arg_value(raw: str) -> Any:
+    try:
+        parsed = parse_strict_json(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+    return parsed
+
+
+PAYLOAD_DECODERS: tuple[PayloadDecoder, ...] = (
+    PayloadDecoder("pipe_tag_tokens", _decode_pipe_tag_tokens),
+    PayloadDecoder("kimi_sections", _decode_kimi_sections),
+    PayloadDecoder("harmony_commentary", _decode_harmony_commentary),
+    PayloadDecoder("arg_key_value", _decode_arg_key_value),
+    PayloadDecoder("bare_name", _decode_bare_name),
+)

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -64,6 +64,39 @@ _KIMI_CONTROL_TOKENS = (
     "<|im_end|>",
 )
 
+_INTERNLM_ACTION_OPEN = "<|action_start|><|plugin|>"
+_INTERNLM_ACTION_CLOSE = "<|action_end|>"
+_INTERNLM_CONTROL_TOKENS = (
+    _INTERNLM_ACTION_CLOSE,
+    "<|im_end|>",
+)
+
+# DeepSeek builds these tokens from a fullwidth vertical line (U+FF5C) and a
+# lower one eighth block (U+2581), not from ASCII "|" and "_". Spelling them as
+# escapes keeps the exact codepoints visible and unambiguous in review.
+_FULLWIDTH_BAR = "\uff5c"
+_LOWER_BLOCK = "\u2581"
+_DEEPSEEK_SECTION_OPEN = (
+    f"<{_FULLWIDTH_BAR}tool{_LOWER_BLOCK}calls{_LOWER_BLOCK}begin{_FULLWIDTH_BAR}>"
+)
+_DEEPSEEK_SECTION_CLOSE = (
+    f"<{_FULLWIDTH_BAR}tool{_LOWER_BLOCK}calls{_LOWER_BLOCK}end{_FULLWIDTH_BAR}>"
+)
+_DEEPSEEK_CALL_OPEN = f"<{_FULLWIDTH_BAR}tool{_LOWER_BLOCK}call{_LOWER_BLOCK}begin{_FULLWIDTH_BAR}>"
+_DEEPSEEK_CALL_CLOSE = f"<{_FULLWIDTH_BAR}tool{_LOWER_BLOCK}call{_LOWER_BLOCK}end{_FULLWIDTH_BAR}>"
+_DEEPSEEK_SEP = f"<{_FULLWIDTH_BAR}tool{_LOWER_BLOCK}sep{_FULLWIDTH_BAR}>"
+_DEEPSEEK_EOS = f"<{_FULLWIDTH_BAR}end{_LOWER_BLOCK}of{_LOWER_BLOCK}sentence{_FULLWIDTH_BAR}>"
+_DEEPSEEK_CONTROL_TOKENS = (
+    _DEEPSEEK_SECTION_CLOSE,
+    _DEEPSEEK_CALL_CLOSE,
+    _DEEPSEEK_EOS,
+)
+
+_QWEN_FUNCTION_OPEN = "<function="
+_QWEN_FUNCTION_CLOSE = "</function>"
+_QWEN_PARAMETER_OPEN = "<parameter="
+_QWEN_PARAMETER_CLOSE = "</parameter>"
+
 _HARMONY_COMMENTARY_OPEN = "<|channel|>commentary to="
 _HARMONY_CALL_CLOSE = "<|call|>"
 _HARMONY_MESSAGE = "<|message|>"
@@ -130,11 +163,28 @@ HARMONY_DIALECT = MarkerDialect(
     _HARMONY_CALL_CLOSE,
     _HARMONY_CONTROL_TOKENS,
 )
+DEEPSEEK_DIALECT = MarkerDialect(
+    "deepseek",
+    _DEEPSEEK_SECTION_OPEN,
+    _DEEPSEEK_SECTION_CLOSE,
+    _DEEPSEEK_CONTROL_TOKENS,
+)
+# The InternLM2 template selects a target right after the opening token, so the
+# tool form is the two-token sequence rather than <|action_start|> alone; the
+# <|interpreter|> target is a different feature and stays unsupported.
+INTERNLM2_DIALECT = MarkerDialect(
+    "internlm2",
+    _INTERNLM_ACTION_OPEN,
+    _INTERNLM_ACTION_CLOSE,
+    _INTERNLM_CONTROL_TOKENS,
+)
 MARKER_DIALECTS: tuple[MarkerDialect, ...] = (
     NATIVE_DIALECT,
     PIPE_TAG_DIALECT,
     KIMI_K2_DIALECT,
     HARMONY_DIALECT,
+    DEEPSEEK_DIALECT,
+    INTERNLM2_DIALECT,
 )
 
 
@@ -284,6 +334,133 @@ def _decode_harmony_commentary(
     return [{"name": name, "arguments": arguments}]
 
 
+def _decode_deepseek_calls(
+    body: str,
+    allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
+) -> list[dict[str, Any]] | None:
+    """Rebuilds DeepSeek's tool-call section.
+
+    V3 shape per call: ``<..call begin..>function<..sep..>name`` then the
+    arguments in a ```json fence. V3.1 drops both the type field and the fence:
+    ``<..call begin..>name<..sep..>{"k":"v"}``. Calls follow each other with no
+    separator, optionally with a newline between them.
+    """
+    if _DEEPSEEK_CALL_OPEN not in body:
+        return None
+    calls: list[dict[str, Any]] = []
+    index = body.find(_DEEPSEEK_CALL_OPEN)
+    while index >= 0:
+        start = index + len(_DEEPSEEK_CALL_OPEN)
+        call_end = body.find(_DEEPSEEK_CALL_CLOSE, start)
+        separator = body.find(_DEEPSEEK_SEP, start)
+        if call_end < 0 or separator < 0 or separator > call_end:
+            # A call without its own closing token is truncated, and dropping
+            # its arguments silently would change what the client executes.
+            return None
+        name, raw = _split_deepseek_call(
+            body[start:separator],
+            body[separator + len(_DEEPSEEK_SEP) : call_end],
+        )
+        arguments = _decode_json_object(raw) if name else None
+        if name is None or arguments is None:
+            return None
+        calls.append({"name": name, "arguments": arguments})
+        index = body.find(_DEEPSEEK_CALL_OPEN, call_end)
+    return calls
+
+
+def _split_deepseek_call(head: str, rest: str) -> tuple[str | None, str]:
+    name, newline, arguments = rest.partition("\n")
+    named_first_line = bool(newline) and arguments.lstrip().startswith(("```", "{"))
+    if named_first_line and not rest.lstrip().startswith("{"):
+        # V3 spends the field before the separator on the tool type and puts the
+        # name on the first line after it.
+        return name.strip() or None, arguments
+    return head.strip() or None, rest
+
+
+def _decode_function_parameter_tags(
+    body: str,
+    allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
+) -> list[dict[str, Any]] | None:
+    """Rebuilds Qwen3's XML-shaped call.
+
+    Shape: ``<function=name><parameter=key>value</parameter></function>``, with
+    one newline of markup around each value.
+
+    The value body is never fed to an XML parser, because a parameter may
+    legally carry XML-looking text that must survive unchanged.
+    """
+    if _QWEN_FUNCTION_OPEN not in body:
+        return None
+    calls: list[dict[str, Any]] = []
+    index = body.find(_QWEN_FUNCTION_OPEN)
+    while index >= 0:
+        name_end = body.find(">", index)
+        if name_end < 0:
+            return None
+        name = body[index + len(_QWEN_FUNCTION_OPEN) : name_end].strip()
+        next_index = body.find(_QWEN_FUNCTION_OPEN, name_end)
+        arguments = _qwen_parameters(
+            body[name_end : _qwen_block_end(body, name_end, next_index)],
+        )
+        if not name or arguments is None:
+            return None
+        calls.append({"name": name, "arguments": arguments})
+        index = next_index
+    return calls
+
+
+def _qwen_block_end(body: str, name_end: int, next_index: int) -> int:
+    close = body.find(_QWEN_FUNCTION_CLOSE, name_end)
+    candidates = [value for value in (close, next_index) if value >= 0]
+    return min(candidates) if candidates else len(body)
+
+
+def _qwen_parameters(block: str) -> dict[str, Any] | None:
+    arguments: dict[str, Any] = {}
+    index = block.find(_QWEN_PARAMETER_OPEN)
+    while index >= 0:
+        key_end = block.find(">", index)
+        if key_end < 0:
+            return None
+        key = block[index + len(_QWEN_PARAMETER_OPEN) : key_end].strip()
+        next_index = block.find(_QWEN_PARAMETER_OPEN, key_end)
+        value_end = _qwen_value_end(block, key_end, next_index)
+        if not key or key in arguments or value_end < 0:
+            return None
+        arguments[key] = _qwen_value(block[key_end + 1 : value_end])
+        index = next_index
+    return arguments
+
+
+def _qwen_value_end(block: str, key_end: int, next_index: int) -> int:
+    """Returns where a parameter value ends, or ``-1`` when it is truncated.
+
+    A model that drops ``</parameter>`` still delimits the value with the next
+    parameter tag, but a value with no delimiter at all was cut off.
+    """
+    close = block.find(_QWEN_PARAMETER_CLOSE, key_end)
+    if close >= 0 and (next_index < 0 or close < next_index):
+        return close
+    return next_index
+
+
+def _qwen_value(raw: str) -> Any:
+    value = raw.removeprefix("\n").removesuffix("\n")
+    candidate = value.strip()
+    if candidate.startswith(("{", "[")):
+        # The template serializes mappings and sequences as JSON, so those are
+        # recoverable. A scalar carries no type on the wire: only the tool
+        # schema knows whether 2 meant a number, so it stays the text the model
+        # wrote instead of being guessed into another type.
+        try:
+            return parse_strict_json(candidate)
+        except (json.JSONDecodeError, ValueError):
+            return value
+    return value
+
+
 def _strip_function_namespace(raw: str) -> str | None:
     name = raw.strip()
     if name.startswith(_FUNCTIONS_PREFIX):
@@ -368,6 +545,8 @@ PAYLOAD_DECODERS: tuple[PayloadDecoder, ...] = (
     PayloadDecoder("pipe_tag_tokens", _decode_pipe_tag_tokens),
     PayloadDecoder("kimi_sections", _decode_kimi_sections),
     PayloadDecoder("harmony_commentary", _decode_harmony_commentary),
+    PayloadDecoder("deepseek_calls", _decode_deepseek_calls),
+    PayloadDecoder("function_parameter_tags", _decode_function_parameter_tags),
     PayloadDecoder("arg_key_value", _decode_arg_key_value),
     PayloadDecoder("bare_name", _decode_bare_name),
 )

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -1,26 +1,29 @@
 from __future__ import annotations
 
 import json
-import math
 import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from factory_droid_openai.attachments import AttachmentSet, extract_attachments
+from factory_droid_openai.dialects import (
+    MARKER_DIALECTS,
+    NATIVE_DIALECT,
+    PAYLOAD_DECODERS,
+    TOOL_CALL_CLOSE,
+    TOOL_CALL_OPEN,
+    find_open_marker,
+    strip_code_fence,
+)
 from factory_droid_openai.errors import ProtocolError, RequestTooLargeError
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import trace as log_trace
+from factory_droid_openai.strictjson import decode_json_values, parse_strict_json
 
 if TYPE_CHECKING:
     from factory_droid_openai.models import ChatCompletionRequest, ToolDefinition
 
-TOOL_CALL_OPEN = "<tool_call>"
-TOOL_CALL_CLOSE = "</tool_call>"
 _MAX_TOOL_PAYLOAD_BYTES = 1_000_000
-_ARG_KEY_OPEN = "<arg_key>"
-_ARG_KEY_CLOSE = "</arg_key>"
-_ARG_VALUE_OPEN = "<arg_value>"
-_ARG_VALUE_CLOSE = "</arg_value>"
 _ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
 _UNPARSED_HEAD_CHARS = 64
 
@@ -258,13 +261,18 @@ class ToolCallStreamParser:
         self._done = False
         self._saw_tool_call = False
         self._tool_call_count = 0
+        self._dialect = NATIVE_DIALECT
 
     def feed(self, chunk: str) -> list[ProtocolEmission]:
         if not chunk:
             return []
         if self._done:
-            if chunk.strip():
+            self._text_tail += chunk
+            if self._residual(self._text_tail).strip():
                 raise ProtocolError("unexpected text after tool call")
+            # Everything left is verified noise except a control token the next
+            # chunk still has to complete.
+            self._text_tail = self._trailing_partial(self._text_tail)
             return []
         if self._capturing:
             return self._consume_tool_payload(chunk)
@@ -282,7 +290,7 @@ class ToolCallStreamParser:
             # After a tool call only whitespace may separate further calls; any
             # residual non-whitespace is trailing output and must fail closed.
             if self._saw_tool_call:
-                if self._text_tail.strip():
+                if self._residual(self._text_tail).strip():
                     raise ProtocolError("unexpected text after tool call")
             else:
                 emissions.append(TextEmission(self._text_tail))
@@ -294,19 +302,23 @@ class ToolCallStreamParser:
     def _consume_text(self, chunk: str) -> list[ProtocolEmission]:
         value = self._text_tail + chunk
         self._text_tail = ""
-        marker_index = value.find(TOOL_CALL_OPEN)
-        if marker_index >= 0:
+        found = find_open_marker(value)
+        if found is not None:
+            marker_index, dialect = found
             emissions: list[ProtocolEmission] = []
             prefix = value[:marker_index]
             if prefix:
                 emissions.extend(self._emit_text_before_marker(prefix))
             self._capturing = True
+            self._dialect = dialect
             emissions.extend(
-                self._consume_tool_payload(value[marker_index + len(TOOL_CALL_OPEN) :])
+                self._consume_tool_payload(value[marker_index + len(dialect.open_marker) :])
             )
             return emissions
 
-        held = _partial_marker_suffix_length(value, TOOL_CALL_OPEN)
+        held = max(
+            _partial_marker_suffix_length(value, dialect.open_marker) for dialect in MARKER_DIALECTS
+        )
         emit_length = len(value) - held
         if emit_length <= 0:
             self._text_tail = value
@@ -318,15 +330,39 @@ class ToolCallStreamParser:
     def _emit_text_before_marker(self, text: str) -> list[ProtocolEmission]:
         if not self._saw_tool_call:
             return [TextEmission(text)]
-        if text.strip():
+        if self._residual(text).strip():
             raise ProtocolError("unexpected text after tool call")
         return []
 
+    def _residual(self, text: str) -> str:
+        """Drops the control tokens the active dialect frames its calls with.
+
+        Only template scaffolding disappears here; prose still counts as
+        trailing output and keeps failing closed. A token split across two
+        stream chunks ends the text as a partial match, so its prefix is
+        dropped as well.
+        """
+        tokens = self._dialect.control_tokens
+        if not tokens:
+            return text
+        for token in tokens:
+            text = text.replace(token, "")
+        held = max(_partial_marker_suffix_length(text, token) for token in tokens)
+        return text[: len(text) - held] if held else text
+
+    def _trailing_partial(self, text: str) -> str:
+        tokens = self._dialect.control_tokens
+        if not tokens:
+            return ""
+        held = max(_partial_marker_suffix_length(text, token) for token in tokens)
+        return text[len(text) - held :] if held else ""
+
     def _consume_tool_payload(self, chunk: str) -> list[ProtocolEmission]:
+        close_marker = self._dialect.close_marker
         value = self._close_tail + chunk
-        close_index = value.find(TOOL_CALL_CLOSE)
+        close_index = value.find(close_marker)
         if close_index < 0:
-            held = _partial_marker_suffix_length(value, TOOL_CALL_CLOSE)
+            held = _partial_marker_suffix_length(value, close_marker)
             committed = value[:-held] if held else value
             committed_bytes = len(self._close_tail) + len(chunk.encode("utf-8")) - held
             self._append_payload(committed, committed_bytes)
@@ -340,7 +376,7 @@ class ToolCallStreamParser:
             chunk_payload = chunk[: close_index - len(self._close_tail)]
             payload_bytes = tail_bytes + len(chunk_payload.encode("utf-8"))
         self._append_payload(payload, payload_bytes)
-        trailing = value[close_index + len(TOOL_CALL_CLOSE) :]
+        trailing = value[close_index + len(close_marker) :]
         complete_payload = "".join(self._payload_chunks)
         payload_objects = self._tool_payload_objects(complete_payload)
         self._payload_chunks.clear()
@@ -353,8 +389,9 @@ class ToolCallStreamParser:
         emissions: list[ProtocolEmission] = list(self._emit_tool_calls(payload_objects))
         if self._tool_call_count >= self._max_tool_calls:
             self._done = True
-            if trailing.strip():
+            if self._residual(trailing).strip():
                 raise ProtocolError("unexpected text after tool call")
+            self._text_tail = self._trailing_partial(trailing)
             return emissions
         if trailing:
             emissions.extend(self._consume_text(trailing))
@@ -396,38 +433,54 @@ class ToolCallStreamParser:
     def _tool_payload_objects(self, payload: str) -> list[dict[str, Any]]:
         """Returns the tool-call objects a marker payload carries.
 
-        Strict JSON first. Models that ignore the single-object contract are
-        repaired into the same shape, because a fenced block, an ``<arg_key>``
-        list or two objects packed into one marker pair is a formatting slip,
-        not a request the bridge should drop. Names, argument types and
-        duplicate keys stay validated in :meth:`_tool_call_from_object`.
+        Strict JSON first, then the decoders in
+        :data:`~factory_droid_openai.dialects.PAYLOAD_DECODERS`, because a
+        fenced block, a template-token block or two objects packed into one
+        marker pair is a formatting slip, not a request the bridge should drop.
+        Names, argument types and duplicate keys stay validated in
+        :meth:`_tool_call_from_object`.
         """
         if not self._allowed_tool_names:
             raise ProtocolError("the model requested a tool when none are available")
-        body = _strip_code_fence(payload.strip())
+        body = strip_code_fence(payload.strip())
         try:
-            values = _decode_json_values(body)
+            values = decode_json_values(body)
         except (json.JSONDecodeError, ValueError) as exc:
-            repaired = _repair_tool_payload(body, self._allowed_tool_names)
-            if repaired is None:
+            decoded = self._decode_payload(body)
+            if decoded is None:
                 log_trace(
                     "tool_call.unparsed",
                     head=body[:_UNPARSED_HEAD_CHARS],
                     payload_bytes=len(body.encode("utf-8")),
                 )
                 raise ProtocolError(f"invalid tool-call JSON: {exc}") from exc
-            log_debug("tool_call.repaired", variant=repaired.variant)
-            values = [repaired.value]
+            values = decoded
         if not values:
             raise ProtocolError("invalid tool-call JSON: the payload is empty")
         objects: list[dict[str, Any]] = []
         for value in values:
+            if isinstance(value, list):
+                # Mistral, Jamba, Granite and xLAM pack their calls into one
+                # JSON array instead of one object per marker pair.
+                if not value or not all(isinstance(item, dict) for item in value):
+                    raise ProtocolError("tool-call payload must be a JSON object")
+                log_debug("tool_call.repaired", variant="json_array")
+                objects.extend(value)
+                continue
             if not isinstance(value, dict):
                 raise ProtocolError("tool-call payload must be a JSON object")
             objects.append(value)
         if len(objects) > 1:
             log_debug("tool_call.repaired", variant="packed_objects")
         return objects
+
+    def _decode_payload(self, body: str) -> list[Any] | None:
+        for decoder in PAYLOAD_DECODERS:
+            decoded = decoder.decode(body, self._allowed_tool_names)
+            if decoded is not None:
+                log_debug("tool_call.repaired", variant=decoder.name)
+                return list(decoded)
+        return None
 
     def _tool_call_from_object(self, parsed: dict[str, Any]) -> ToolCallEmission:
         name = parsed.get("name")
@@ -496,153 +549,11 @@ class StopSequenceBuffer:
         return held
 
 
-def parse_strict_json(text: str) -> Any:
-    """Parses model-generated JSON, rejecting everything outside RFC 8259.
-
-    Duplicate keys, ``NaN``/``Infinity`` literals and numbers that overflow to
-    a non-finite float are all refused, so a caller never forwards a value a
-    strict JSON parser on the client side would reject.
-    """
-    return json.loads(
-        text,
-        object_pairs_hook=_reject_duplicate_keys,
-        parse_constant=_reject_non_json_constant,
-        parse_float=_parse_finite_float,
-    )
-
-
-@dataclass(frozen=True, slots=True)
-class _RepairedPayload:
-    variant: str
-    value: dict[str, Any]
-
-
-def _decode_json_values(text: str) -> list[Any]:
-    """Decodes the JSON values a payload holds, back to back.
-
-    A model that packs several tool calls into one marker pair produces
-    ``{...}{...}``, which ``json.loads`` rejects as trailing data.
-    """
-    decoder = json.JSONDecoder(
-        object_pairs_hook=_reject_duplicate_keys,
-        parse_constant=_reject_non_json_constant,
-        parse_float=_parse_finite_float,
-    )
-    values: list[Any] = []
-    index = 0
-    while True:
-        while index < len(text) and text[index].isspace():
-            index += 1
-        if index >= len(text):
-            return values
-        value, index = decoder.raw_decode(text, index)
-        values.append(value)
-
-
-def _strip_code_fence(payload: str) -> str:
-    if not payload.startswith("```"):
-        return payload
-    newline = payload.find("\n")
-    if newline < 0:
-        return payload
-    body = payload[newline + 1 :]
-    closing = body.rfind("```")
-    return body[:closing].strip() if closing >= 0 else body.strip()
-
-
-def _repair_tool_payload(
-    body: str,
-    allowed_tool_names: frozenset[str],
-) -> _RepairedPayload | None:
-    if _ARG_KEY_OPEN in body:
-        repaired = _repair_arg_key_payload(body)
-        if repaired is not None:
-            return _RepairedPayload("arg_key_value", repaired)
-    repaired = _repair_named_payload(body, allowed_tool_names)
-    if repaired is not None:
-        return _RepairedPayload("bare_name", repaired)
-    return None
-
-
-def _repair_arg_key_payload(body: str) -> dict[str, Any] | None:
-    """Rebuilds GLM's ``name<arg_key>k</arg_key><arg_value>v</arg_value>`` form."""
-    index = body.find(_ARG_KEY_OPEN)
-    name = body[:index].strip()
-    if not name:
-        return None
-    arguments: dict[str, Any] = {}
-    while index >= 0:
-        key_end = body.find(_ARG_KEY_CLOSE, index)
-        if key_end < 0:
-            return None
-        key = body[index + len(_ARG_KEY_OPEN) : key_end].strip()
-        value_start = body.find(_ARG_VALUE_OPEN, key_end)
-        if not key or key in arguments or value_start < 0:
-            return None
-        value_end = body.find(_ARG_VALUE_CLOSE, value_start)
-        if value_end < 0:
-            # A truncated value would silently drop data, so fail closed.
-            return None
-        raw = body[value_start + len(_ARG_VALUE_OPEN) : value_end].strip()
-        arguments[key] = _coerce_arg_value(raw)
-        index = body.find(_ARG_KEY_OPEN, value_end)
-    return {"name": name, "arguments": arguments}
-
-
-def _coerce_arg_value(raw: str) -> Any:
-    try:
-        parsed = parse_strict_json(raw)
-    except (json.JSONDecodeError, ValueError):
-        return raw
-    return parsed
-
-
-def _repair_named_payload(
-    body: str,
-    allowed_tool_names: frozenset[str],
-) -> dict[str, Any] | None:
-    """Rebuilds a payload that names the tool outside the JSON object."""
-    head, _, tail = body.partition("\n")
-    name = head.strip()
-    if name not in allowed_tool_names:
-        return None
-    remainder = tail.strip()
-    if not remainder:
-        return {"name": name, "arguments": {}}
-    try:
-        arguments = parse_strict_json(remainder)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    if not isinstance(arguments, dict):
-        return None
-    return {"name": name, "arguments": arguments}
-
-
 def _tool_arguments(parsed: dict[str, Any]) -> Any:
     for key in _ARGUMENT_KEYS:
         if key in parsed:
             return parsed[key]
     return None
-
-
-def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ValueError(f"duplicate key '{key}'")
-        result[key] = value
-    return result
-
-
-def _reject_non_json_constant(value: str) -> None:
-    raise ValueError(f"non-JSON numeric constant '{value}'")
-
-
-def _parse_finite_float(value: str) -> float:
-    parsed = float(value)
-    if not math.isfinite(parsed):
-        raise ValueError(f"non-finite number '{value}'")
-    return parsed
 
 
 def _serialize_json(value: Any) -> tuple[str, int]:

--- a/src/factory_droid_openai/strictjson.py
+++ b/src/factory_droid_openai/strictjson.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+__all__ = [
+    "decode_json_values",
+    "parse_strict_json",
+]
+
+
+def parse_strict_json(text: str) -> Any:
+    """Parses model-generated JSON, rejecting everything outside RFC 8259.
+
+    Duplicate keys, ``NaN``/``Infinity`` literals and numbers that overflow to
+    a non-finite float are all refused, so a caller never forwards a value a
+    strict JSON parser on the client side would reject.
+    """
+    return json.loads(
+        text,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_json_constant,
+        parse_float=_parse_finite_float,
+    )
+
+
+def decode_json_values(text: str) -> list[Any]:
+    """Decodes the JSON values a payload holds, back to back.
+
+    A model that packs several tool calls into one marker pair produces
+    ``{...}{...}``, which ``json.loads`` rejects as trailing data.
+    """
+    decoder = json.JSONDecoder(
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_json_constant,
+        parse_float=_parse_finite_float,
+    )
+    values: list[Any] = []
+    index = 0
+    while True:
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if index >= len(text):
+            return values
+        value, index = decoder.raw_decode(text, index)
+        values.append(value)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key '{key}'")
+        result[key] = value
+    return result
+
+
+def _reject_non_json_constant(value: str) -> None:
+    raise ValueError(f"non-JSON numeric constant '{value}'")
+
+
+def _parse_finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite number '{value}'")
+    return parsed

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -920,6 +920,351 @@ def test_stream_parser_rejects_unrepairable_harmony_payloads(payload: str) -> No
         parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
 
 
+# DeepSeek spells these with U+FF5C fullwidth vertical line and U+2581 lower one
+# eighth block, never ASCII "|" or "_". Samples below are verbatim from
+# vllm/tests/tool_parsers/test_deepseekv3_tool_parser.py and
+# test_deepseekv31_tool_parser.py at vLLM bb3b61f2fd2333ab165ebaba13f133db4210b9f2,
+# cross-checked against the chat_template of deepseek-ai/DeepSeek-V3 (e815299)
+# and DeepSeek-V3.1 (c0781d0).
+_DS_BAR = "\uff5c"
+_DS_BLOCK = "\u2581"
+_DEEPSEEK_OPEN = f"<{_DS_BAR}tool{_DS_BLOCK}calls{_DS_BLOCK}begin{_DS_BAR}>"
+_DEEPSEEK_CLOSE = f"<{_DS_BAR}tool{_DS_BLOCK}calls{_DS_BLOCK}end{_DS_BAR}>"
+_DEEPSEEK_CALL_OPEN = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}begin{_DS_BAR}>"
+_DEEPSEEK_CALL_CLOSE = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}end{_DS_BAR}>"
+_DEEPSEEK_SEP = f"<{_DS_BAR}tool{_DS_BLOCK}sep{_DS_BAR}>"
+_DEEPSEEK_V3_CALL = (
+    f"{_DEEPSEEK_CALL_OPEN}function{_DEEPSEEK_SEP}get_weather\n"
+    '```json\n{"city": "Tokyo", "unit": "celsius"}\n```'
+    f"{_DEEPSEEK_CALL_CLOSE}"
+)
+_DEEPSEEK_V31_CALL = (
+    f'{_DEEPSEEK_CALL_OPEN}get_weather{_DEEPSEEK_SEP}{{"city": "Tokyo"}}{_DEEPSEEK_CALL_CLOSE}'
+)
+
+
+def test_stream_parser_translates_a_deepseek_v3_fenced_call() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+
+    emissions = parser.feed(f"{_DEEPSEEK_OPEN}{_DEEPSEEK_V3_CALL}{_DEEPSEEK_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "get_weather"
+    assert json.loads(emissions[0].arguments) == {"city": "Tokyo", "unit": "celsius"}
+
+
+def test_stream_parser_translates_a_deepseek_v31_call_after_prose() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+
+    emissions = parser.feed(f"normal text{_DEEPSEEK_OPEN}{_DEEPSEEK_V31_CALL}{_DEEPSEEK_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [TextEmission, ToolCallEmission]
+    assert isinstance(emissions[1], ToolCallEmission)
+    assert emissions[1].name == "get_weather"
+    assert json.loads(emissions[1].arguments) == {"city": "Tokyo"}
+
+
+@pytest.mark.parametrize("separator", ["", "\n"])
+def test_stream_parser_translates_parallel_deepseek_calls(separator: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather", "search_hotels"}), max_tool_calls=2)
+    second = (
+        f"{_DEEPSEEK_CALL_OPEN}function{_DEEPSEEK_SEP}search_hotels\n"
+        '```json\n{"location": "Tokyo"}\n```'
+        f"{_DEEPSEEK_CALL_CLOSE}"
+    )
+
+    emissions = parser.feed(
+        f"{_DEEPSEEK_OPEN}{_DEEPSEEK_V3_CALL}{separator}{second}{_DEEPSEEK_CLOSE}"
+    )
+    emissions.extend(parser.finish())
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [call.name for call in calls] == ["get_weather", "search_hotels"]
+
+
+def test_stream_parser_translates_a_deepseek_call_with_empty_arguments() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_current_time"}))
+
+    emissions = parser.feed(
+        f"{_DEEPSEEK_OPEN}{_DEEPSEEK_CALL_OPEN}function{_DEEPSEEK_SEP}get_current_time\n"
+        "```json\n{}\n```"
+        f"{_DEEPSEEK_CALL_CLOSE}{_DEEPSEEK_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {}
+
+
+def test_stream_parser_recovers_a_deepseek_section_without_its_close() -> None:
+    # The V3 template only emits the section close for parallel calls, so a
+    # single call ends at EOS instead.
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+
+    emissions = parser.feed(f"{_DEEPSEEK_OPEN}{_DEEPSEEK_V3_CALL}")
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+def test_stream_parser_translates_deepseek_calls_across_chunks() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+    stream = (
+        f"{_DEEPSEEK_OPEN}{_DEEPSEEK_V31_CALL}{_DEEPSEEK_CLOSE}"
+        f"<{_DS_BAR}end{_DS_BLOCK}of{_DS_BLOCK}sentence{_DS_BAR}>"
+    )
+
+    emissions: list[object] = []
+    for start in range(0, len(stream), 5):
+        emissions.extend(parser.feed(stream[start : start + 5]))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+def test_stream_parser_rejects_prose_after_a_deepseek_section() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+
+    with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+        parser.feed(
+            f"{_DEEPSEEK_OPEN}{_DEEPSEEK_V31_CALL}{_DEEPSEEK_CLOSE} some suffix text",
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        f"{_DEEPSEEK_CALL_OPEN}function{_DEEPSEEK_SEP}get_weather\n"
+        '```json\n{"city": "Tokyo"\n```'
+        f"{_DEEPSEEK_CALL_CLOSE}",
+        f'function{_DEEPSEEK_SEP}get_weather\n```json\n{{"city": "Tokyo"}}\n```',
+        f'{_DEEPSEEK_CALL_OPEN}get_weather{_DEEPSEEK_SEP}{{"city": "Tokyo"}}',
+        f'{_DEEPSEEK_CALL_OPEN}get_weather{{"city": "Tokyo"}}{_DEEPSEEK_CALL_CLOSE}',
+        f'{_DEEPSEEK_CALL_OPEN}{_DEEPSEEK_SEP}{{"city": "Tokyo"}}{_DEEPSEEK_CALL_CLOSE}',
+        f"{_DEEPSEEK_CALL_OPEN}get_weather{_DEEPSEEK_SEP}[1]{_DEEPSEEK_CALL_CLOSE}",
+    ],
+)
+def test_stream_parser_rejects_unrepairable_deepseek_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_rejects_a_deepseek_call_to_an_unknown_tool() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+
+    with pytest.raises(ProtocolError, match="tool 'shell' is not available"):
+        parser.feed(
+            f"{_DEEPSEEK_OPEN}{_DEEPSEEK_CALL_OPEN}shell{_DEEPSEEK_SEP}{{}}"
+            f"{_DEEPSEEK_CALL_CLOSE}{_DEEPSEEK_CLOSE}"
+        )
+
+
+# Verbatim from vllm/tests/tool_parsers/test_qwen3coder_tool_parser.py at
+# bb3b61f, matching the chat_template of Qwen/Qwen3-Coder-480B-A35B-Instruct
+# (9d90cf8), which documents this exact skeleton.
+_QWEN_CALL = (
+    "\n<function=get_current_weather>\n"
+    "<parameter=city>\nDallas\n</parameter>\n"
+    "<parameter=state>\nTX\n</parameter>\n"
+    "<parameter=unit>\nfahrenheit\n</parameter>\n"
+    "</function>\n"
+)
+
+
+def test_stream_parser_translates_qwen_parameter_tags() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_current_weather"}))
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{_QWEN_CALL}{TOOL_CALL_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "get_current_weather"
+    assert json.loads(emissions[0].arguments) == {
+        "city": "Dallas",
+        "state": "TX",
+        "unit": "fahrenheit",
+    }
+
+
+def test_stream_parser_translates_two_qwen_blocks() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_current_weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}{_QWEN_CALL}{TOOL_CALL_CLOSE}\n"
+        f"{TOOL_CALL_OPEN}"
+        "\n<function=get_current_weather>\n<parameter=city>\nOrlando\n</parameter>\n</function>\n"
+        f"{TOOL_CALL_CLOSE}"
+    )
+    emissions.extend(parser.finish())
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Dallas", "Orlando"]
+
+
+def test_stream_parser_decodes_only_structured_qwen_values() -> None:
+    # A scalar carries no type on the wire, so "2" stays text; the template
+    # serializes mappings and sequences as JSON, so those are recovered.
+    parser = ToolCallStreamParser(frozenset({"calculate_area"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}\n<function=calculate_area>\n"
+        "<parameter=shape>\nrectangle\n</parameter>\n"
+        '<parameter=dimensions>\n{"width": 10, \n "height": 20}\n</parameter>\n'
+        "<parameter=precision>\n2\n</parameter>\n"
+        f"</function>\n{TOOL_CALL_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {
+        "shape": "rectangle",
+        "dimensions": {"width": 10, "height": 20},
+        "precision": "2",
+    }
+
+
+def test_stream_parser_preserves_qwen_parameter_whitespace() -> None:
+    parser = ToolCallStreamParser(frozenset({"write_file"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}\n<function=write_file>\n"
+        "<parameter=content>\n    def foo():\n        return 1\n\n</parameter>\n"
+        f"</function>\n{TOOL_CALL_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"content": "    def foo():\n        return 1\n"}
+
+
+def test_stream_parser_keeps_a_qwen_value_that_only_looks_like_json() -> None:
+    parser = ToolCallStreamParser(frozenset({"write_file"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}\n<function=write_file>\n"
+        "<parameter=content>\n{oops}\n</parameter>\n"
+        f"</function>\n{TOOL_CALL_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"content": "{oops}"}
+
+
+def test_stream_parser_preserves_xml_shaped_qwen_values() -> None:
+    parser = ToolCallStreamParser(frozenset({"write_file"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}\n<function=write_file>\n"
+        '<parameter=content>\n<div class="test"><span>Hello</span></div>\n</parameter>\n'
+        f"</function>\n{TOOL_CALL_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {
+        "content": '<div class="test"><span>Hello</span></div>'
+    }
+
+
+def test_stream_parser_recovers_a_qwen_parameter_without_its_close_tag() -> None:
+    # The next parameter tag still delimits the value, so the call survives.
+    parser = ToolCallStreamParser(frozenset({"get_current_weather"}))
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}\n<function=get_current_weather>\n"
+        "<parameter=city>\nDallas\n<parameter=state>\nTX\n</parameter>\n"
+        f"</function>\n{TOOL_CALL_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Dallas", "state": "TX"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "<function=>\n<parameter=city>\nDallas\n</parameter>\n</function>",
+        "<function=get_current_weather>\n<parameter=city>\nDallas\n</function>",
+        "<function=get_current_weather>\n<parameter=>\nDallas\n</parameter>\n</function>",
+        "<function=get_current_weather>\n<parameter=city>\nA\n</parameter>\n"
+        "<parameter=city>\nB\n</parameter>\n</function>",
+        "<function=get_current_weather",
+        "<function=get_current_weather>\n<parameter=city\nDallas\n</function>",
+    ],
+)
+def test_stream_parser_rejects_unrepairable_qwen_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"get_current_weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+# Verbatim from InternLM/InternLM chat/chat_format.md (68fdc71) and
+# vllm/tests/tool_parsers/test_internlm2_tool_parser.py (bb3b61f). Token names
+# match the added_tokens_decoder of internlm/internlm2-chat-7b (c2ba644).
+_INTERNLM_OPEN = "<|action_start|><|plugin|>"
+_INTERNLM_CLOSE = "<|action_end|>"
+
+
+def test_stream_parser_translates_an_internlm2_plugin_call() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_current_weather"}))
+
+    emissions = parser.feed(
+        "Sure, I will search for the weather of Shanghai."
+        f'{_INTERNLM_OPEN}\n{{"name": "get_current_weather", '
+        f'"parameters": {{"location": "Shanghai"}}}}{_INTERNLM_CLOSE}<|im_end|>'
+    )
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [TextEmission, ToolCallEmission]
+    assert isinstance(emissions[1], ToolCallEmission)
+    assert emissions[1].name == "get_current_weather"
+    assert json.loads(emissions[1].arguments) == {"location": "Shanghai"}
+
+
+def test_stream_parser_translates_two_internlm2_plugin_calls() -> None:
+    # The reference parser splits on the opening token and crashes on a second
+    # block; marker framing handles repeats.
+    parser = ToolCallStreamParser(frozenset({"get_weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f'{_INTERNLM_OPEN}{{"name": "get_weather", "parameters": {{"city": "Tokyo"}}}}'
+        f"{_INTERNLM_CLOSE}"
+        f'{_INTERNLM_OPEN}{{"name": "get_weather", "parameters": {{"city": "Osaka"}}}}'
+        f"{_INTERNLM_CLOSE}"
+    )
+    emissions.extend(parser.finish())
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Tokyo", "Osaka"]
+
+
+def test_stream_parser_rejects_internlm2_arguments_that_are_not_an_object() -> None:
+    parser = ToolCallStreamParser(frozenset({"func"}))
+
+    with pytest.raises(ProtocolError, match="tool-call arguments must be a JSON object"):
+        parser.feed(
+            f'{_INTERNLM_OPEN}{{"name": "func", "parameters": "not a dict"}}{_INTERNLM_CLOSE}'
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"name": "func", "parameters": {',
+        "not json",
+        "",
+    ],
+)
+def test_stream_parser_rejects_unrepairable_internlm2_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"func"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{_INTERNLM_OPEN}{payload}{_INTERNLM_CLOSE}")
+
+
 def test_stream_parser_accepts_a_json_array_of_calls() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -10,6 +10,7 @@ from factory_droid_openai.protocol import (
     TOOL_CALL_CLOSE,
     TOOL_CALL_OPEN,
     ProtocolError,
+    RequestTooLargeError,
     StopSequenceBuffer,
     TextEmission,
     ToolCallEmission,
@@ -227,6 +228,16 @@ def test_build_prompt_enforces_utf8_transcript_byte_boundary() -> None:
 
     with pytest.raises(ProtocolError, match=f"maximum of {transcript_bytes - 1} bytes"):
         build_prompt(request, max_transcript_bytes=transcript_bytes - 1)
+
+
+def test_build_prompt_enforces_message_depth() -> None:
+    request = _request(
+        tools=[],
+        messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+    )
+
+    with pytest.raises(RequestTooLargeError, match="message exceeds maximum JSON depth of 2"):
+        build_prompt(request, max_json_depth=2)
 
 
 def test_build_prompt_enforces_tool_schema_depth_boundary() -> None:
@@ -772,6 +783,18 @@ def test_stream_parser_ignores_pipe_tag_control_tokens_after_the_call() -> None:
 
     emissions = parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}")
     emissions.extend(parser.feed("<|close|><|sep|>\n"))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+def test_stream_parser_flushes_a_held_control_token_tail() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}")
+    # The trailing "<|" could still open another marker, so it stays buffered
+    # until finish decides it was only scaffolding.
+    emissions.extend(parser.feed("<|sep|>\n<|"))
     emissions.extend(parser.finish())
 
     assert [type(emission) for emission in emissions] == [ToolCallEmission]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -456,6 +456,7 @@ def test_stream_parser_rejects_invalid_marker_sequences(
     [
         ("not-json", "invalid tool-call JSON"),
         ("[]", "must be a JSON object"),
+        ("7", "must be a JSON object"),
         ('{"name":"","arguments":{}}', "non-empty string"),
     ],
 )
@@ -597,6 +598,324 @@ def test_stream_parser_refuses_to_repair_unnamed_payloads(payload: str) -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 
     with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+_PIPE_TAG_OPEN = "<|open|>tools<|sep|>"
+_PIPE_TAG_CLOSE = "<|close|>tools<|sep|>"
+_PIPE_TAG_CALL = (
+    '<|open|>call tool="weather" index="1"<|sep|>'
+    '<|open|>argument key="city" type="string"<|sep|>Gdańsk<|close|>argument<|sep|>'
+    "<|close|>call<|sep|>"
+)
+
+
+def test_stream_parser_translates_pipe_tag_template_tokens() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "weather"
+    assert json.loads(emissions[0].arguments) == {"city": "Gdańsk"}
+
+
+def test_stream_parser_translates_pipe_tag_tokens_inside_markers() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{_PIPE_TAG_CALL}{TOOL_CALL_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Gdańsk"}
+
+
+def test_stream_parser_keeps_text_before_pipe_tag_tokens() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"Checking now. {_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [TextEmission, ToolCallEmission]
+    assert isinstance(emissions[0], TextEmission)
+    assert emissions[0].text == "Checking now. "
+
+
+def test_stream_parser_translates_pipe_tag_tokens_across_chunks() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    stream = f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}"
+
+    emissions: list[object] = []
+    for start in range(0, len(stream), 5):
+        emissions.extend(parser.feed(stream[start : start + 5]))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+def test_stream_parser_translates_multiple_pipe_tag_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{_PIPE_TAG_OPEN}"
+        '<|open|>call tool="weather" index="1"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Gdansk<|close|>argument<|sep|>'
+        "<|close|>call<|sep|>"
+        '<|open|>call tool="weather" index="2"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Sopot<|close|>argument<|sep|>'
+        "<|close|>call<|sep|>"
+        f"{_PIPE_TAG_CLOSE}"
+    )
+    emissions.extend(parser.finish())
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Gdansk", "Sopot"]
+
+
+def test_stream_parser_recovers_pipe_tag_call_without_close_marker() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}")
+    emissions = parser.finish()
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+
+
+@pytest.mark.parametrize(
+    ("declared_type", "raw", "expected"),
+    [
+        ('key="city" type="string"', "123", "123"),
+        ('key="days" type="number"', "3", 3),
+        ('key="metric" type="boolean"', "true", True),
+        ('key="filter" type="object"', '{"unit":"c"}', {"unit": "c"}),
+        ('key="days"', "7", 7),
+    ],
+)
+def test_stream_parser_coerces_pipe_tag_argument_values(
+    declared_type: str,
+    raw: str,
+    expected: object,
+) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f"{_PIPE_TAG_OPEN}"
+        '<|open|>call tool="weather" index="1"<|sep|>'
+        f"<|open|>argument {declared_type}<|sep|>{raw}<|close|>argument<|sep|>"
+        "<|close|>call<|sep|>"
+        f"{_PIPE_TAG_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert list(json.loads(emissions[0].arguments).values()) == [expected]
+
+
+def test_stream_parser_accepts_pipe_tag_call_without_arguments() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f"{_PIPE_TAG_OPEN}"
+        '<|open|>call tool="weather" index="1"<|sep|><|close|>call<|sep|>'
+        f"{_PIPE_TAG_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {}
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        '<|open|>call tool="weather" index="1"',
+        '<|open|>call index="1"<|sep|><|close|>call',
+        '<|open|>call tool=""<|sep|><|close|>call',
+        '<|open|>call tool="weather<|sep|><|close|>call',
+        '<|open|>call tool="weather"<|sep|><|open|>argument key="city" type="string"',
+        '<|open|>call tool="weather"<|sep|><|open|>argument key="city" type="string"<|sep|>Gdansk',
+        '<|open|>call tool="weather"<|sep|><|open|>argument key=""<|sep|>Gdansk<|close|>argument',
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument key="city"<|sep|>A<|close|>argument'
+        '<|open|>argument key="city"<|sep|>B<|close|>argument',
+    ],
+)
+def test_stream_parser_rejects_unrepairable_pipe_tag_payloads(call: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{call}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_rejects_pipe_tag_call_to_unknown_tool() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="tool 'shell' is not available"):
+        parser.feed(
+            f"{_PIPE_TAG_OPEN}"
+            '<|open|>call tool="shell" index="1"<|sep|><|close|>call<|sep|>'
+            f"{_PIPE_TAG_CLOSE}"
+        )
+
+
+def test_stream_parser_rejects_prose_after_pipe_tag_call() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+        parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE} and done")
+
+
+def test_stream_parser_ignores_pipe_tag_control_tokens_after_the_call() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}")
+    emissions.extend(parser.feed("<|close|><|sep|>\n"))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+_KIMI_SECTION_OPEN = "<|tool_calls_section_begin|>"
+_KIMI_SECTION_CLOSE = "<|tool_calls_section_end|>"
+_KIMI_CALL = (
+    '<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{"city":"Gdansk"}'
+    "<|tool_call_end|>"
+)
+_HARMONY_OPEN = "<|channel|>commentary to="
+
+
+def test_stream_parser_translates_kimi_sections() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"{_KIMI_SECTION_OPEN}{_KIMI_CALL}{_KIMI_SECTION_CLOSE}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "weather"
+    assert json.loads(emissions[0].arguments) == {"city": "Gdansk"}
+
+
+def test_stream_parser_translates_multiple_kimi_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{_KIMI_SECTION_OPEN}{_KIMI_CALL}"
+        '<|tool_call_begin|>functions.weather:1<|tool_call_argument_begin|>{"city":"Sopot"}'
+        f"<|tool_call_end|>{_KIMI_SECTION_CLOSE}"
+    )
+    emissions.extend(parser.finish())
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Gdansk", "Sopot"]
+
+
+def test_stream_parser_translates_kimi_sections_across_chunks() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    stream = f"{_KIMI_SECTION_OPEN}{_KIMI_CALL}{_KIMI_SECTION_CLOSE}<|im_end|>"
+
+    emissions: list[object] = []
+    for start in range(0, len(stream), 7):
+        emissions.extend(parser.feed(stream[start : start + 7]))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        "<|tool_call_begin|>functions.weather:0",
+        '<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{"city":"X"}',
+        "<|tool_call_begin|>functions.:0<|tool_call_argument_begin|>{}<|tool_call_end|>",
+        "<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>[]<|tool_call_end|>",
+        "<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{oops}<|tool_call_end|>",
+    ],
+)
+def test_stream_parser_rejects_unrepairable_kimi_payloads(call: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{call}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_accepts_kimi_call_without_namespace_or_arguments() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f"{_KIMI_SECTION_OPEN}"
+        "<|tool_call_begin|>weather<|tool_call_argument_begin|><|tool_call_end|>"
+        f"{_KIMI_SECTION_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "weather"
+    assert json.loads(emissions[0].arguments) == {}
+
+
+def test_stream_parser_translates_harmony_commentary() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(
+        f'{_HARMONY_OPEN}functions.weather <|constrain|>json<|message|>{{"city":"Hel"}}<|call|>'
+    )
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "weather"
+    assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+def test_stream_parser_translates_harmony_without_constrain_tag() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    emissions = parser.feed(f"{_HARMONY_OPEN}functions.weather<|message|>{{}}<|call|>")
+    emissions.extend(parser.feed("<|end|>"))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "functions.weather",
+        'functions.<|message|>{"city":"X"}',
+        "functions.weather<|message|>[1]",
+        "functions.weather<|message|>{oops}",
+    ],
+)
+def test_stream_parser_rejects_unrepairable_harmony_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_accepts_a_json_array_of_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}"
+        '[{"name":"weather","arguments":{"city":"Gdansk"}},'
+        '{"name":"weather","arguments":{"city":"Sopot"}}]'
+        f"{TOOL_CALL_CLOSE}"
+    )
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Gdansk", "Sopot"]
+
+
+@pytest.mark.parametrize("payload", ["[]", '[{"name":"weather","arguments":{}},7]'])
+def test_stream_parser_rejects_invalid_json_arrays(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="must be a JSON object"):
         parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -460,6 +460,22 @@ async def test_runner_cleanup_uses_one_bounded_deadline(tmp_path: Path) -> None:
     assert time.perf_counter() - started < 0.5
 
 
+async def _spawned_droid_pid(pid_file: Path, *, timeout: float = 15.0) -> int:
+    """Waits until the fake droid reports its pid.
+
+    Spawning a real interpreter takes seconds on a loaded machine, so the wait
+    runs against a deadline rather than a fixed iteration count, and an
+    already-created but still empty file counts as not ready.
+    """
+    deadline = time.perf_counter() + timeout
+    while time.perf_counter() < deadline:
+        raw = pid_file.read_text(encoding="utf-8").strip() if pid_file.exists() else ""
+        if raw.isdigit():
+            return int(raw)
+        await asyncio.sleep(0.01)
+    raise AssertionError("the fake droid never reported its pid")
+
+
 def _sigterm_ignoring_droid(tmp_path: Path) -> Path:
     executable = tmp_path / "fake-droid"
     pid_file = tmp_path / "child.pid"
@@ -501,16 +517,11 @@ async def test_runner_kills_and_reaps_process_ignoring_sigterm(
     )
 
     task = asyncio.create_task(_collect(runner, _request(timeout_seconds=10)))
-    for _ in range(100):
-        if pid_file.exists():
-            break
-        await asyncio.sleep(0.01)
-    assert pid_file.exists()
+    pid = await _spawned_droid_pid(pid_file)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    pid = int(pid_file.read_text(encoding="utf-8"))
     with pytest.raises(ProcessLookupError):
         os.kill(pid, 0)
     assert "factory_droid_openai_forced_kills_total 1" in metrics.render()
@@ -550,16 +561,11 @@ async def test_runner_does_not_count_sigterm_death_as_forced_kill(
     )
 
     task = asyncio.create_task(_collect(runner, _request(timeout_seconds=10)))
-    for _ in range(100):
-        if pid_file.exists():
-            break
-        await asyncio.sleep(0.01)
-    assert pid_file.exists()
+    pid = await _spawned_droid_pid(pid_file)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    pid = int(pid_file.read_text(encoding="utf-8"))
     with pytest.raises(ProcessLookupError):
         os.kill(pid, 0)
     assert "factory_droid_openai_forced_kills_total 0" in metrics.render()
@@ -831,16 +837,11 @@ async def test_cleanup_force_reaps_when_client_close_never_returns(
     )
 
     task = asyncio.create_task(_collect(runner, _request(timeout_seconds=10)))
-    for _ in range(100):
-        if pid_file.exists():
-            break
-        await asyncio.sleep(0.01)
-    assert pid_file.exists()
+    pid = await _spawned_droid_pid(pid_file)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    pid = int(pid_file.read_text(encoding="utf-8"))
     with pytest.raises(ProcessLookupError):
         os.kill(pid, 0)
     assert "factory_droid_openai_forced_kills_total 1" in metrics.render()


### PR DESCRIPTION
## Problem

Models served through Droid sometimes answer in the chat template they were trained on instead of the bridge marker contract. Two failure modes showed up in production logs:

```
event=chat.failed error_type=factory_protocol_error reason="incomplete tool-call marker"
event=chat.failed error_type=factory_protocol_error reason="invalid tool-call JSON: Expecting value: line 1 column 96"
```

and, when the template block never touched a `<tool_call>` marker, raw scaffolding reached the client as assistant text:

```
<|open|>tools<|sep|><|open|>call tool="terminal" index="1"<|sep|><|open|>argument key="command" type="string"<|sep|>pwd<|close|>argument<|sep|><|close|>call<|sep|>
```

A client cannot repair a format it never asked for, so translation belongs in the bridge. A prompt-side fix was rejected: it is probabilistic and leaks model-specific detail into the request contract.

## Intended behavior

`dialects.py` holds two tables, so adding a format never touches the stream parser:

- `MARKER_DIALECTS` frames a payload in the stream: `native`, `pipe_tag`, `kimi_k2`, `harmony`, `deepseek`, `internlm2`.
- `PAYLOAD_DECODERS` rebuilds `{"name", "arguments"}` when strict JSON declines: `pipe_tag_tokens`, `kimi_sections`, `harmony_commentary`, `deepseek_calls`, `function_parameter_tags`, `arg_key_value`, `bare_name`.

The pre-existing GLM `<arg_key>` repair and the bare-name repair move into that table, replacing three ad-hoc branches with one loop. Strict JSON parsing moves to `strictjson.py`, so the dialect layer carries no parser internals. `protocol.py` keeps no model names, and the three formats added last needed no parser change at all: two table rows and two decoders.

Also accepted now: a top-level JSON array of calls in one marker pair (`[{...},{...}]`), which is how Mistral, Jamba, Granite and xLAM style outputs arrive.

Accepted forms and where each was observed:

| Form | Observed on |
|---|---|
| `<tool_call>{"name":...,"arguments":...}</tool_call>` | this bridge's contract, Hermes-style output |
| `<tool_call><function=name><parameter=key>value</parameter></function></tool_call>` | Qwen3 Coder XML |
| `<\|tool_calls_section_begin\|>` … `<\|tool_calls_section_end\|>` | Kimi K2 |
| `<\|open\|>tools<\|sep\|>` … `<\|close\|>tools` | Kimi K3 |
| `<\|channel\|>commentary to=functions.name` … `<\|call\|>` | gpt-oss Harmony |
| `<｜tool▁calls▁begin｜>` … `<｜tool▁calls▁end｜>` | DeepSeek V3 and V3.1 |
| `<\|action_start\|><\|plugin\|>{"name":...}<\|action_end\|>` | InternLM2 |
| `name<arg_key>key</arg_key><arg_value>value</arg_value>` | GLM |

Naming note: the `<|open|>tools<|sep|>` dialect is named `pipe_tag` after its token shape, not after a model. It was observed on Kimi K3 turns. Calling it `hermes` would have been wrong, because the Hermes format is `<tool_call>{json}</tool_call>`, which is already this bridge's native contract.

### Evidence, not memory

Marker bytes and payload shapes were taken from two primary sources per family and cross-checked, with the source and revision cited next to each fixture in the tests:

- the published chat templates (`tokenizer_config.json`) of `deepseek-ai/DeepSeek-V3` (`e815299`), `DeepSeek-V3.1` (`c0781d0`), `internlm/internlm2-chat-7b` (`c2ba644`), `Qwen/Qwen3-Coder-480B-A35B-Instruct` (`9d90cf8`), plus `InternLM/InternLM` `chat/chat_format.md` (`68fdc71`)
- the reference parsers and their fixtures in vLLM at `bb3b61f`

This mattered: DeepSeek builds its tokens from U+FF5C fullwidth vertical line and U+2581 lower one eighth block, not ASCII `|` and `_`. A decoder typed from memory would never match. The source spells them as escapes so the codepoints stay visible in review.

Two deliberate divergences from the reference parsers, both toward failing closed:

- Trailing text after a call is rejected, where the DeepSeek parsers silently discard it.
- Two InternLM2 blocks in one turn are handled, where the reference parser raises on an unguarded 2-tuple unpack.

## Compatibility impact

- OpenAI request and response shapes unchanged. No route, schema or `openapi.json` change.
- Every previously accepted payload still parses; only formats that used to fail now succeed.
- Fail-closed behavior preserved: an unrecognised payload, an unknown tool name, a truncated argument, a duplicate key, an oversized payload or prose after a call still raise `ProtocolError`.
- One documented limitation: Qwen3's XML form declares no argument types. Only an object or an array is decoded; a scalar stays the string the model wrote rather than being guessed into a number. The reference implementation recovers types from the request tool schema, which the parser does not currently receive.

## Security impact

- No new dependency, no network access, no credential or prompt content in logs. Repair logging records the decoder name only; unparsed payloads keep their existing truncated-head trace.
- Trailing-output validation is not weakened. Control tokens are ignored only for the dialect that framed the call, and only after a call was already emitted; prose after a call still fails.
- Qwen3 parameter values are never handed to an XML parser, so no external entity or expat surface is introduced, and a parameter carrying XML-looking text survives byte for byte.
- Payload size cap, tool-name allowlist and duplicate-key rejection unchanged.

## Tests

`tests/test_protocol.py`, 74 new cases: pipe-tag, Kimi, Harmony, DeepSeek V3 and V3.1, InternLM2 and Qwen3 XML happy paths, parallel calls, chunk-split markers including a split across DeepSeek's non-ASCII tokens, chunk-split control tokens, recovery when a close marker never arrives, typed-value coercion, whitespace preservation, JSON array unpacking, and rejection matrices for truncated, unnamed, duplicate-key and unknown-tool variants.

`dialects.py`, `strictjson.py` and `protocol.py` are at 100 percent statement and branch coverage; total coverage 99 percent.

## Documentation

`README.md` gains the table of accepted forms, the note that translation never widens validation, the Qwen3 typing limitation, and the two endpoint rows that were missing after #27 merged.

## Validation

```
uv run ruff check .                  All checks passed
uv run ruff format --check .         43 files already formatted
uv run mypy                          Success: no issues found
uv run pytest                        461 passed (1 known runner timing flake deselected)
uv run openapi-spec-validator        openapi.json: OK
uv lock --check / uv build           OK
prs validate / prs check             OK
```

Still left out on purpose: the Mistral `[TOOL_CALLS]` tag, which needs a marker with no close token and therefore a stream-parser change, and the pythonic form `[f(a=1)]`, which needs Python literal parsing and would take a real captured sample plus an explicit decision on its false-positive risk before it belongs here.
