### PR TITLE
feat(api): serve retrieve-model and version probes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -132,7 +132,7 @@
           },
           "n": {
             "default": 1,
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "N",
             "type": "integer"
           },
@@ -212,7 +212,7 @@
           "timeout": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
@@ -977,6 +977,19 @@
         ],
         "title": "UsageResponse",
         "type": "object"
+      },
+      "VersionResponse": {
+        "properties": {
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version"
+        ],
+        "title": "VersionResponse",
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -1087,6 +1100,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1116,16 +1139,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1192,6 +1205,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1221,16 +1244,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1305,6 +1318,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1334,16 +1357,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1420,6 +1433,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1449,16 +1472,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1525,6 +1538,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1554,16 +1577,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1630,6 +1643,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1659,16 +1682,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1722,6 +1735,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1751,16 +1774,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1771,6 +1784,140 @@
         "summary": "List available Factory Droid models",
         "tags": [
           "OpenAI compatibility"
+        ]
+      }
+    },
+    "/v1/models/{model_id}": {
+      "get": {
+        "operationId": "retrieve_model_v1_models__model_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model_id",
+            "required": true,
+            "schema": {
+              "title": "Model Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelInfo"
+                }
+              }
+            },
+            "description": "The bridge alias or one discovered Droid model.",
+            "headers": {
+              "x-factory-droid-model-discovery": {
+                "description": "Set to 'degraded' when discovery failed and the bridge served the last known catalog, or the alias alone.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested model is unknown to this bridge."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The bounded Droid request queue is full.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid SDK, process, or bridge protocol failure."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid executable unavailable."
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Droid request timeout."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Retrieve one available Factory Droid model",
+        "tags": [
+          "OpenAI compatibility"
+        ]
+      }
+    },
+    "/version": {
+      "get": {
+        "operationId": "version_version_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Read the bridge version",
+        "tags": [
+          "Service"
         ]
       }
     }

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -44,6 +44,7 @@ from factory_droid_openai.models import (
     RenameSessionRequest,
     SessionContextResponse,
     SessionOperationResponse,
+    VersionResponse,
 )
 from factory_droid_openai.pool import BackgroundReaper, WarmSessionPool
 from factory_droid_openai.protocol import (
@@ -167,6 +168,22 @@ MODEL_LIST_RESPONSES: dict[int | str, dict[str, Any]] = {
         status: response
         for status, response in FACTORY_OPERATION_RESPONSES.items()
         if status != 404
+    },
+}
+MODEL_RETRIEVE_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        "model": ModelInfo,
+        "description": "The bridge alias or one discovered Droid model.",
+        "headers": MODEL_LIST_RESPONSES[200]["headers"],
+    },
+    **{
+        status: response
+        for status, response in FACTORY_OPERATION_RESPONSES.items()
+        if status != 404
+    },
+    404: {
+        "model": ErrorResponse,
+        "description": "The requested model is unknown to this bridge.",
     },
 }
 
@@ -784,6 +801,15 @@ def create_app(
     async def health() -> HealthResponse:
         return HealthResponse(status="ok")
 
+    @application.get(
+        "/version",
+        response_model=VersionResponse,
+        tags=["Service"],
+        summary="Read the bridge version",
+    )
+    async def version() -> VersionResponse:
+        return VersionResponse(version=application.version)
+
     @application.get("/metrics", include_in_schema=False)
     async def service_metrics() -> PlainTextResponse:
         return PlainTextResponse(
@@ -821,6 +847,36 @@ def create_app(
                 available,
                 created=bridge_created,
             )
+        )
+
+    @application.get(
+        "/v1/models/{model_id}",
+        response_model=ModelInfo,
+        response_model_exclude_none=True,
+        dependencies=[Depends(require_auth)],
+        responses=MODEL_RETRIEVE_RESPONSES,
+        tags=["OpenAI compatibility"],
+        summary="Retrieve one available Factory Droid model",
+    )
+    async def retrieve_model(model_id: str, response: Response) -> ModelInfo:
+        discovered, degraded = await model_catalog.get()
+        if degraded:
+            metrics.increment_model_discovery_failures()
+            log_warning("models.discovery_degraded", cached=len(discovered))
+            response.headers["x-factory-droid-model-discovery"] = "degraded"
+        available = tuple(model for model in discovered if quarantine.allows(model.id))
+        catalog = _model_list(
+            resolved_settings.model_alias,
+            available,
+            created=bridge_created,
+        )
+        for model in catalog:
+            if model.id == model_id:
+                return model
+        raise BridgeHTTPError(
+            f"Model '{model_id}' is not available on this bridge.",
+            status_code=404,
+            error_type="model_not_found",
         )
 
     @application.get(

--- a/src/factory_droid_openai/models.py
+++ b/src/factory_droid_openai/models.py
@@ -49,6 +49,10 @@ class HealthResponse(BaseModel):
     status: Literal["ok"]
 
 
+class VersionResponse(BaseModel):
+    version: str
+
+
 class ModelInfo(BaseModel):
     id: str
     object: Literal["model"] = "model"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.metadata
 import json
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
@@ -252,6 +253,74 @@ async def test_health_and_models(tmp_path: Path) -> None:
         "factory_droid_supports_images": True,
         "factory_droid_supports_pdfs": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_version_reports_the_bridge_package_version(tmp_path: Path) -> None:
+    runner = FakeRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.get("/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "version": importlib.metadata.version("factory-droid-openai"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_retrieve_model_matches_the_list_entry(tmp_path: Path) -> None:
+    runner = FakeRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        listed = await client.get("/v1/models")
+        alias = await client.get("/v1/models/factory-droid")
+        discovered = await client.get("/v1/models/gpt-5.4")
+
+    entries = {model["id"]: model for model in listed.json()["data"]}
+    assert alias.status_code == 200
+    assert alias.json() == entries["factory-droid"]
+    assert discovered.status_code == 200
+    assert discovered.json() == entries["gpt-5.4"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_model_rejects_an_unknown_model(tmp_path: Path) -> None:
+    runner = FakeRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.get("/v1/models/kimi-k3")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "message": "Model 'kimi-k3' is not available on this bridge.",
+            "type": "model_not_found",
+            "param": None,
+            "code": None,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_retrieve_model_serves_the_alias_when_droid_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    class UnavailableRunner(FakeRunner):
+        async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
+            del timeout_seconds
+            raise RunnerError(
+                "Droid missing",
+                status_code=503,
+                error_type="factory_droid_unavailable",
+            )
+
+    runner = UnavailableRunner([])
+    async with _client(_app(tmp_path, runner)) as client:
+        alias = await client.get("/v1/models/factory-droid")
+        missing = await client.get("/v1/models/gpt-5.4")
+
+    assert alias.status_code == 200
+    assert alias.json()["id"] == "factory-droid"
+    assert alias.headers["x-factory-droid-model-discovery"] == "degraded"
+    assert missing.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -25,7 +25,9 @@ def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> Non
 
     assert set(paths) == {
         "/health",
+        "/version",
         "/v1/models",
+        "/v1/models/{model_id}",
         "/v1/chat/completions",
         "/v1/factory/sessions/{session_id}",
         "/v1/factory/sessions/{session_id}/compact",
@@ -33,7 +35,9 @@ def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> Non
         "/v1/factory/sessions/{session_id}/fork",
     }
     assert "security" not in paths["/health"]["get"]
+    assert "security" not in paths["/version"]["get"]
     assert paths["/v1/models"]["get"]["security"] == [{"HTTPBearer": []}]
+    assert paths["/v1/models/{model_id}"]["get"]["security"] == [{"HTTPBearer": []}]
 
     chat = paths["/v1/chat/completions"]["post"]
     assert chat["security"] == [{"HTTPBearer": []}]


### PR DESCRIPTION
## Problem

Clients probe discovery endpoints before their first chat request. Container logs show them failing:

```
GET /v1/models/kimi-k3 HTTP/1.1  404 Not Found
GET /version HTTP/1.1            404 Not Found
```

`GET /v1/models/{model_id}` is a standard OpenAI endpoint the bridge simply did not implement, so a client that retrieves a single model before use had to guess from the list route or give up. `/version` is the cheapest capability probe a client has.

## Intended behavior

- `GET /v1/models/{model_id}` returns the same object as the matching `GET /v1/models` entry, byte for byte, including `response_model_exclude_none`. It reuses the existing catalog, alias handling, quarantine filter and the `x-factory-droid-model-discovery: degraded` header path, and is guarded by the same `require_auth` dependency as the list route. An unknown or quarantined id returns 404 in the standard error envelope:

```json
{"error":{"message":"Model 'kimi-k3' is not available on this bridge.","type":"model_not_found","param":null,"code":null}}
```

- `GET /version` returns `{"version": "1.3.4"}` from the release-please managed application version. Unauthenticated, like `/health`, because clients read it before they hold a key.

Ollama and llama.cpp probe paths (`/api/tags`, `/api/show`, `/props`, `/v1/props`) stay 404 on purpose. The bridge does not advertise API families it does not implement; those clients fall back to the OpenAI surface, which works.

## Compatibility impact

- Purely additive. No existing route, schema or response shape changes.
- `openapi.json` regenerated: it documents both new paths, the `VersionResponse` schema and the 404 response for retrieve-model.
- Note on diff size: the generator on this machine also rewrites unrelated existing entries (`"minimum": 1` becomes `1.0`, and per-path error response keys shuffle between `502`, `503`, `4XX` and `504`). That drift comes from the local fastapi and pydantic versions, not from this change, and the file was not hand-edited. `tests/test_openapi.py` passes both before and after.

## Security impact

- Retrieve-model is authenticated exactly like the list route and exposes no field the list route does not already expose. Quarantined models stay hidden and answer 404.
- `/version` returns only the package version, which is already published on PyPI and in release tags. No build paths, dependency versions or environment data.
- No new dependency, no credential handling, no user content in logs.

## Tests

`tests/test_app.py`:

- `test_version_reports_the_bridge_package_version`
- `test_retrieve_model_matches_the_list_entry`
- `test_retrieve_model_rejects_an_unknown_model`
- `test_retrieve_model_serves_the_alias_when_droid_is_unavailable`

`tests/test_openapi.py`: the path-set contract test now covers both new routes plus their security expectations, `/version` unauthenticated and retrieve-model bearer-guarded.

Coverage: total 98.40 percent, `app.py` 97 percent.

## Validation

```
uv run ruff check .                  All checks passed
uv run ruff format --check .         41 files already formatted
uv run mypy                          Success: no issues found
uv run pytest                        383 passed (1 known runner timing flake deselected)
uv run python scripts/generate_openapi.py
uv run openapi-spec-validator        openapi.json: OK
prs validate / prs check             OK
```
