### PR TITLE
fix(protocol): harden model dialect decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,8 +713,12 @@ Setup walks through several prompts in order:
      /v1/models`:
 
 ```bash
-uv run python scripts/generate_vscode_models.py --all-models --verify
+CONFIG=/absolute/path/to/chatLanguageModels.json
+uv run python scripts/generate_vscode_models.py --all-models --verify --output "$CONFIG"
 ```
+
+Set `CONFIG` to the file VS Code opened. Without `--output`, the generator
+updates the repository's ready example instead.
 
 `--all-models` includes every model the bridge exposes; `--verify` starts a
 Droid session for each one, drops the models Droid refuses (typically ones an
@@ -724,9 +728,9 @@ spawns Droid directly and takes roughly a minute for a full catalog. Narrower
 selections are possible:
 
 ```bash
-uv run python scripts/generate_vscode_models.py
-uv run python scripts/generate_vscode_models.py --all-models
-uv run python scripts/generate_vscode_models.py --model gpt-5.4 --model claude-opus-5
+uv run python scripts/generate_vscode_models.py --output "$CONFIG"
+uv run python scripts/generate_vscode_models.py --all-models --output "$CONFIG"
+uv run python scripts/generate_vscode_models.py --model gpt-5.4 --model claude-opus-5 --output "$CONFIG"
 ```
 
 `id` is the explicit Droid model ID. Replace it with another ID from

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -20,6 +20,7 @@ fails closed once every decoder declines.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -39,6 +40,7 @@ _ARG_VALUE_CLOSE = "</arg_value>"
 _PIPE_TAG_TOOLS_OPEN = "<|open|>tools<|sep|>"
 _PIPE_TAG_TOOLS_CLOSE = "<|close|>tools"
 _PIPE_TAG_CALL_OPEN = "<|open|>call "
+_PIPE_TAG_CALL_CLOSE = "<|close|>call"
 _PIPE_TAG_ARG_OPEN = "<|open|>argument "
 _PIPE_TAG_ARG_CLOSE = "<|close|>argument"
 _PIPE_TAG_SEP = "<|sep|>"
@@ -47,7 +49,7 @@ _PIPE_TAG_SEP = "<|sep|>"
 # has already been emitted in this dialect, so prose still fails closed.
 _PIPE_TAG_CONTROL_TOKENS = (
     _PIPE_TAG_TOOLS_CLOSE,
-    "<|close|>call",
+    _PIPE_TAG_CALL_CLOSE,
     _PIPE_TAG_ARG_CLOSE,
     "<|close|>",
     _PIPE_TAG_SEP,
@@ -96,6 +98,7 @@ _QWEN_FUNCTION_OPEN = "<function="
 _QWEN_FUNCTION_CLOSE = "</function>"
 _QWEN_PARAMETER_OPEN = "<parameter="
 _QWEN_PARAMETER_CLOSE = "</parameter>"
+_QWEN_PARAMETER_TOKEN = re.compile(r"</parameter>|<parameter=")
 
 _HARMONY_COMMENTARY_OPEN = "<|channel|>commentary to="
 _HARMONY_CALL_CLOSE = "<|call|>"
@@ -222,17 +225,27 @@ def _decode_pipe_tag_tokens(
         return None
     calls: list[dict[str, Any]] = []
     index = body.find(_PIPE_TAG_CALL_OPEN)
+    if body[:index].strip():
+        return None
     while index >= 0:
         header_end = body.find(_PIPE_TAG_SEP, index)
         if header_end < 0:
             return None
-        name = _pipe_tag_attribute(body[index + len(_PIPE_TAG_CALL_OPEN) : header_end], "tool")
+        attributes = _pipe_tag_attributes(
+            body[index + len(_PIPE_TAG_CALL_OPEN) : header_end],
+            frozenset({"tool", "index"}),
+        )
+        name = attributes.get("tool") if attributes is not None else None
         if name is None:
             return None
-        next_index = body.find(_PIPE_TAG_CALL_OPEN, header_end)
+        call_end = body.find(_PIPE_TAG_CALL_CLOSE, header_end)
+        if call_end < 0:
+            return None
+        next_index = body.find(_PIPE_TAG_CALL_OPEN, call_end + len(_PIPE_TAG_CALL_CLOSE))
         block_end = next_index if next_index >= 0 else len(body)
-        arguments = _pipe_tag_arguments(body[header_end:block_end])
-        if arguments is None:
+        arguments = _pipe_tag_arguments(body[header_end:call_end])
+        trailing = body[call_end + len(_PIPE_TAG_CALL_CLOSE) : block_end]
+        if arguments is None or not _pipe_tag_noise_only(trailing):
             return None
         calls.append({"name": name, "arguments": arguments})
         index = next_index
@@ -242,39 +255,60 @@ def _decode_pipe_tag_tokens(
 def _pipe_tag_arguments(block: str) -> dict[str, Any] | None:
     arguments: dict[str, Any] = {}
     index = block.find(_PIPE_TAG_ARG_OPEN)
+    if index < 0:
+        return arguments if _pipe_tag_noise_only(block) else None
+    if not _pipe_tag_noise_only(block[:index]):
+        return None
     while index >= 0:
         header_end = block.find(_PIPE_TAG_SEP, index)
         if header_end < 0:
             return None
         header = block[index + len(_PIPE_TAG_ARG_OPEN) : header_end]
-        key = _pipe_tag_attribute(header, "key")
+        attributes = _pipe_tag_attributes(header, frozenset({"key", "type"}))
+        if attributes is None:
+            return None
+        key = attributes.get("key")
         value_end = block.find(_PIPE_TAG_ARG_CLOSE, header_end)
         if key is None or key in arguments or value_end < 0:
             # A truncated value would silently drop data, so fail closed.
             return None
         raw = block[header_end + len(_PIPE_TAG_SEP) : value_end]
-        arguments[key] = _coerce_pipe_tag_value(raw, _pipe_tag_attribute(header, "type"))
-        index = block.find(_PIPE_TAG_ARG_OPEN, value_end)
+        arguments[key] = _coerce_pipe_tag_value(raw, attributes.get("type"))
+        next_index = block.find(_PIPE_TAG_ARG_OPEN, value_end + len(_PIPE_TAG_ARG_CLOSE))
+        trailing_end = next_index if next_index >= 0 else len(block)
+        if not _pipe_tag_noise_only(block[value_end + len(_PIPE_TAG_ARG_CLOSE) : trailing_end]):
+            return None
+        index = next_index
     return arguments
 
 
-def _pipe_tag_attribute(header: str, name: str) -> str | None:
-    prefix = f'{name}="'
-    start = header.find(prefix)
-    if start < 0:
-        return None
-    start += len(prefix)
-    end = header.find('"', start)
-    if end < 0:
-        return None
-    return header[start:end].strip() or None
+def _pipe_tag_noise_only(value: str) -> bool:
+    return not value.replace(_PIPE_TAG_SEP, "").strip()
+
+
+def _pipe_tag_attributes(
+    header: str,
+    allowed: frozenset[str],
+) -> dict[str, str] | None:
+    attributes: dict[str, str] = {}
+    cursor = 0
+    for match in re.finditer(r'([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"', header):
+        name, raw = match.groups()
+        value = raw.strip()
+        if header[cursor : match.start()].strip():
+            return None
+        if name not in allowed or name in attributes or not value:
+            return None
+        attributes[name] = value
+        cursor = match.end()
+    return attributes if not header[cursor:].strip() else None
 
 
 def _coerce_pipe_tag_value(raw: str, kind: str | None) -> Any:
     # A declared string type is authoritative: coercing "1" to a number there
     # would change the argument the client receives.
     if kind == "string":
-        return raw.strip()
+        return raw
     return _coerce_arg_value(raw.strip())
 
 
@@ -291,6 +325,8 @@ def _decode_kimi_sections(
         return None
     calls: list[dict[str, Any]] = []
     index = body.find(_KIMI_CALL_OPEN)
+    if body[:index].strip():
+        return None
     while index >= 0:
         arguments_start = body.find(_KIMI_ARG_OPEN, index)
         if arguments_start < 0:
@@ -305,7 +341,12 @@ def _decode_kimi_sections(
         if arguments is None:
             return None
         calls.append({"name": name, "arguments": arguments})
-        index = body.find(_KIMI_CALL_OPEN, call_end)
+        call_end += len(_KIMI_CALL_CLOSE)
+        next_index = body.find(_KIMI_CALL_OPEN, call_end)
+        trailing_end = next_index if next_index >= 0 else len(body)
+        if body[call_end:trailing_end].strip():
+            return None
+        index = next_index
     return calls
 
 
@@ -349,6 +390,8 @@ def _decode_deepseek_calls(
         return None
     calls: list[dict[str, Any]] = []
     index = body.find(_DEEPSEEK_CALL_OPEN)
+    if body[:index].strip():
+        return None
     while index >= 0:
         start = index + len(_DEEPSEEK_CALL_OPEN)
         call_end = body.find(_DEEPSEEK_CALL_CLOSE, start)
@@ -365,7 +408,12 @@ def _decode_deepseek_calls(
         if name is None or arguments is None:
             return None
         calls.append({"name": name, "arguments": arguments})
-        index = body.find(_DEEPSEEK_CALL_OPEN, call_end)
+        call_end += len(_DEEPSEEK_CALL_CLOSE)
+        next_index = body.find(_DEEPSEEK_CALL_OPEN, call_end)
+        trailing_end = next_index if next_index >= 0 else len(body)
+        if body[call_end:trailing_end].strip():
+            return None
+        index = next_index
     return calls
 
 
@@ -395,55 +443,51 @@ def _decode_function_parameter_tags(
         return None
     calls: list[dict[str, Any]] = []
     index = body.find(_QWEN_FUNCTION_OPEN)
+    if body[:index].strip():
+        return None
     while index >= 0:
         name_end = body.find(">", index)
         if name_end < 0:
             return None
+        parsed = _qwen_call(body, name_end)
+        if parsed is None:
+            return None
+        close, arguments = parsed
         name = body[index + len(_QWEN_FUNCTION_OPEN) : name_end].strip()
-        next_index = body.find(_QWEN_FUNCTION_OPEN, name_end)
-        arguments = _qwen_parameters(
-            body[name_end : _qwen_block_end(body, name_end, next_index)],
-        )
-        if not name or arguments is None:
+        next_index = body.find(_QWEN_FUNCTION_OPEN, close + len(_QWEN_FUNCTION_CLOSE))
+        trailing_end = next_index if next_index >= 0 else len(body)
+        if not name:
+            return None
+        if body[close + len(_QWEN_FUNCTION_CLOSE) : trailing_end].strip():
             return None
         calls.append({"name": name, "arguments": arguments})
         index = next_index
     return calls
 
 
-def _qwen_block_end(body: str, name_end: int, next_index: int) -> int:
-    close = body.find(_QWEN_FUNCTION_CLOSE, name_end)
-    candidates = [value for value in (close, next_index) if value >= 0]
-    return min(candidates) if candidates else len(body)
-
-
-def _qwen_parameters(block: str) -> dict[str, Any] | None:
+def _qwen_call(body: str, name_end: int) -> tuple[int, dict[str, Any]] | None:
     arguments: dict[str, Any] = {}
-    index = block.find(_QWEN_PARAMETER_OPEN)
-    while index >= 0:
-        key_end = block.find(">", index)
+    cursor = name_end + 1
+    while True:
+        close = body.find(_QWEN_FUNCTION_CLOSE, cursor)
+        parameter_index = body.find(_QWEN_PARAMETER_OPEN, cursor)
+        if close >= 0 and (parameter_index < 0 or close < parameter_index):
+            return (close, arguments) if not body[cursor:close].strip() else None
+        if parameter_index < 0 or body[cursor:parameter_index].strip():
+            return None
+        key_end = body.find(">", parameter_index)
         if key_end < 0:
             return None
-        key = block[index + len(_QWEN_PARAMETER_OPEN) : key_end].strip()
-        next_index = block.find(_QWEN_PARAMETER_OPEN, key_end)
-        value_end = _qwen_value_end(block, key_end, next_index)
-        if not key or key in arguments or value_end < 0:
+        key = body[parameter_index + len(_QWEN_PARAMETER_OPEN) : key_end].strip()
+        parameter_token = _QWEN_PARAMETER_TOKEN.search(body, key_end + 1)
+        if parameter_token is None or not key or key in arguments:
             return None
-        arguments[key] = _qwen_value(block[key_end + 1 : value_end])
-        index = next_index
-    return arguments
-
-
-def _qwen_value_end(block: str, key_end: int, next_index: int) -> int:
-    """Returns where a parameter value ends, or ``-1`` when it is truncated.
-
-    A model that drops ``</parameter>`` still delimits the value with the next
-    parameter tag, but a value with no delimiter at all was cut off.
-    """
-    close = block.find(_QWEN_PARAMETER_CLOSE, key_end)
-    if close >= 0 and (next_index < 0 or close < next_index):
-        return close
-    return next_index
+        arguments[key] = _qwen_value(body[key_end + 1 : parameter_token.start()])
+        cursor = (
+            parameter_token.end()
+            if parameter_token.group() == _QWEN_PARAMETER_CLOSE
+            else parameter_token.start()
+        )
 
 
 def _qwen_value(raw: str) -> Any:

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -319,6 +319,8 @@ class ToolCallStreamParser:
         held = max(
             _partial_marker_suffix_length(value, dialect.open_marker) for dialect in MARKER_DIALECTS
         )
+        if self._saw_tool_call:
+            held = max(held, len(self._trailing_partial(value)))
         emit_length = len(value) - held
         if emit_length <= 0:
             self._text_tail = value
@@ -364,18 +366,12 @@ class ToolCallStreamParser:
         if close_index < 0:
             held = _partial_marker_suffix_length(value, close_marker)
             committed = value[:-held] if held else value
-            committed_bytes = len(self._close_tail) + len(chunk.encode("utf-8")) - held
-            self._append_payload(committed, committed_bytes)
+            self._append_payload(committed)
             self._close_tail = value[-held:] if held else ""
             return []
 
         payload = value[:close_index]
-        payload_bytes = 0
-        if payload:
-            tail_bytes = len(self._close_tail)
-            chunk_payload = chunk[: close_index - len(self._close_tail)]
-            payload_bytes = tail_bytes + len(chunk_payload.encode("utf-8"))
-        self._append_payload(payload, payload_bytes)
+        self._append_payload(payload)
         trailing = value[close_index + len(close_marker) :]
         complete_payload = "".join(self._payload_chunks)
         payload_objects = self._tool_payload_objects(complete_payload)
@@ -420,12 +416,10 @@ class ToolCallStreamParser:
             self._tool_call_count += 1
         return emissions
 
-    def _append_payload(self, value: str, value_bytes: int | None = None) -> None:
+    def _append_payload(self, value: str) -> None:
         if not value:
             return
-        self._payload_bytes += (
-            value_bytes if value_bytes is not None else len(value.encode("utf-8"))
-        )
+        self._payload_bytes += len(value.encode("utf-8"))
         if self._payload_bytes > _MAX_TOOL_PAYLOAD_BYTES:
             raise ProtocolError("tool-call payload is too large")
         self._payload_chunks.append(value)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -324,6 +324,27 @@ async def test_retrieve_model_serves_the_alias_when_droid_is_unavailable(
 
 
 @pytest.mark.asyncio
+async def test_retrieve_model_withholds_a_quarantined_model(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [],
+        error=RunnerError(
+            "Model 'gpt-5.4' is not available for this Factory account",
+            status_code=404,
+            error_type="model_not_found",
+        ),
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        rejected = await client.post("/v1/chat/completions", json=_payload(model="gpt-5.4"))
+        retrieved = await client.get("/v1/models/gpt-5.4")
+        alias = await client.get("/v1/models/factory-droid")
+
+    assert rejected.status_code == 404
+    assert retrieved.status_code == 404
+    assert retrieved.json()["error"]["type"] == "model_not_found"
+    assert alias.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_chat_quarantines_a_model_droid_refuses(tmp_path: Path) -> None:
     runner = FakeRunner(
         [],
@@ -733,10 +754,24 @@ async def test_optional_bearer_auth(tmp_path: Path) -> None:
             "/v1/models",
             headers={"Authorization": "Bearer secret"},
         )
+        retrieve_missing = await client.get("/v1/models/factory-droid")
+        retrieve_invalid = await client.get(
+            "/v1/models/factory-droid",
+            headers={"Authorization": "Bearer wrong"},
+        )
+        retrieve_valid = await client.get(
+            "/v1/models/factory-droid",
+            headers={"Authorization": "Bearer secret"},
+        )
+        version = await client.get("/version")
 
     assert missing.status_code == 401
     assert invalid.status_code == 401
     assert valid.status_code == 200
+    assert retrieve_missing.status_code == 401
+    assert retrieve_invalid.status_code == 401
+    assert retrieve_valid.status_code == 200
+    assert version.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -110,12 +110,15 @@ async def test_official_openai_client_parses_completion_and_models(
     client, http_client = _sdk_client(tmp_path, runner)
     async with http_client:
         models = await client.models.list()
+        model = await client.models.retrieve("gpt-5.4")
         completion = await client.chat.completions.create(
             model="factory-droid",
             messages=[{"role": "user", "content": "Hello"}],
         )
 
     assert models.data[0].id == "factory-droid"
+    assert model.id == "gpt-5.4"
+    assert model.object == "model"
     assert completion.object == "chat.completion"
     assert completion.choices[0].finish_reason == "stop"
     assert completion.choices[0].message.content == "Hello from Droid"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -725,6 +725,22 @@ def test_stream_parser_coerces_pipe_tag_argument_values(
     assert list(json.loads(emissions[0].arguments).values()) == [expected]
 
 
+def test_stream_parser_preserves_pipe_tag_string_whitespace() -> None:
+    parser = ToolCallStreamParser(frozenset({"write_file"}))
+
+    emissions = parser.feed(
+        f"{_PIPE_TAG_OPEN}"
+        '<|open|>call tool="write_file" index="1"<|sep|>'
+        '<|open|>argument key="file content" type="string"<|sep|>'
+        "  indented  "
+        "<|close|>argument<|sep|><|close|>call<|sep|>"
+        f"{_PIPE_TAG_CLOSE}"
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"file content": "  indented  "}
+
+
 def test_stream_parser_accepts_pipe_tag_call_without_arguments() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 
@@ -751,6 +767,28 @@ def test_stream_parser_accepts_pipe_tag_call_without_arguments() -> None:
         '<|open|>call tool="weather"<|sep|>'
         '<|open|>argument key="city"<|sep|>A<|close|>argument'
         '<|open|>argument key="city"<|sep|>B<|close|>argument',
+        'garbage<|open|>call tool="weather"<|sep|><|close|>call',
+        '<|open|>call nottool="weather"<|sep|><|close|>call',
+        '<|open|>call tool="weather" tool="weather"<|sep|><|close|>call',
+        '<|open|>call tool="weather" mode="fast"<|sep|><|close|>call',
+        '<|open|>call tool="weather" garbage index="1"<|sep|><|close|>call',
+        '<|open|>call tool="weather"<|sep|>',
+        '<|open|>call tool="weather"<|sep|>garbage<|close|>call',
+        '<|open|>call tool="weather"<|sep|><|close|>call<|sep|>garbage',
+        '<|open|>call tool="weather"<|sep|>garbage'
+        '<|open|>argument key="city"<|sep|>Gdansk<|close|>argument'
+        "<|close|>call",
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument key="city"<|close|>argument<|close|>call',
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument bogus="city"<|sep|>Gdansk<|close|>argument'
+        "<|close|>call",
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument type="string"<|sep|>Gdansk<|close|>argument'
+        "<|close|>call",
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument key="city"<|sep|>Gdansk<|close|>argument'
+        "garbage<|close|>call",
     ],
 )
 def test_stream_parser_rejects_unrepairable_pipe_tag_payloads(call: str) -> None:
@@ -795,6 +833,16 @@ def test_stream_parser_flushes_a_held_control_token_tail() -> None:
     # The trailing "<|" could still open another marker, so it stays buffered
     # until finish decides it was only scaffolding.
     emissions.extend(parser.feed("<|sep|>\n<|"))
+    emissions.extend(parser.finish())
+
+    assert [type(emission) for emission in emissions] == [ToolCallEmission]
+
+
+def test_stream_parser_buffers_a_split_control_token_between_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE}<|se")
+    emissions.extend(parser.feed("p|>"))
     emissions.extend(parser.finish())
 
     assert [type(emission) for emission in emissions] == [ToolCallEmission]
@@ -855,6 +903,8 @@ def test_stream_parser_translates_kimi_sections_across_chunks() -> None:
         "<|tool_call_begin|>functions.:0<|tool_call_argument_begin|>{}<|tool_call_end|>",
         "<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>[]<|tool_call_end|>",
         "<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{oops}<|tool_call_end|>",
+        f"garbage{_KIMI_CALL}",
+        f"{_KIMI_CALL}garbage",
     ],
 )
 def test_stream_parser_rejects_unrepairable_kimi_payloads(call: str) -> None:
@@ -1044,6 +1094,8 @@ def test_stream_parser_rejects_prose_after_a_deepseek_section() -> None:
         f'{_DEEPSEEK_CALL_OPEN}get_weather{{"city": "Tokyo"}}{_DEEPSEEK_CALL_CLOSE}',
         f'{_DEEPSEEK_CALL_OPEN}{_DEEPSEEK_SEP}{{"city": "Tokyo"}}{_DEEPSEEK_CALL_CLOSE}',
         f"{_DEEPSEEK_CALL_OPEN}get_weather{_DEEPSEEK_SEP}[1]{_DEEPSEEK_CALL_CLOSE}",
+        f"garbage{_DEEPSEEK_V31_CALL}",
+        f"{_DEEPSEEK_V31_CALL}garbage",
     ],
 )
 def test_stream_parser_rejects_unrepairable_deepseek_payloads(payload: str) -> None:
@@ -1101,6 +1153,19 @@ def test_stream_parser_translates_two_qwen_blocks() -> None:
         f"{TOOL_CALL_CLOSE}"
     )
     emissions.extend(parser.finish())
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments)["city"] for call in calls] == ["Dallas", "Orlando"]
+
+
+def test_stream_parser_translates_two_qwen_blocks_inside_one_marker() -> None:
+    parser = ToolCallStreamParser(frozenset({"get_current_weather"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}{_QWEN_CALL}"
+        "\n<function=get_current_weather>\n<parameter=city>\nOrlando\n</parameter>\n</function>\n"
+        f"{TOOL_CALL_CLOSE}"
+    )
 
     calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
     assert [json.loads(call.arguments)["city"] for call in calls] == ["Dallas", "Orlando"]
@@ -1168,6 +1233,23 @@ def test_stream_parser_preserves_xml_shaped_qwen_values() -> None:
     }
 
 
+def test_stream_parser_preserves_qwen_function_tags_inside_values() -> None:
+    parser = ToolCallStreamParser(frozenset({"write_file", "delete_file"}), max_tool_calls=2)
+
+    emissions = parser.feed(
+        f"{TOOL_CALL_OPEN}\n<function=write_file>\n"
+        "<parameter=content>\nsafe<function=delete_file></function>\n</parameter>\n"
+        f"</function>\n{TOOL_CALL_CLOSE}"
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "write_file"
+    assert json.loads(emissions[0].arguments) == {
+        "content": "safe<function=delete_file></function>"
+    }
+
+
 def test_stream_parser_recovers_a_qwen_parameter_without_its_close_tag() -> None:
     # The next parameter tag still delimits the value, so the call survives.
     parser = ToolCallStreamParser(frozenset({"get_current_weather"}))
@@ -1191,7 +1273,14 @@ def test_stream_parser_recovers_a_qwen_parameter_without_its_close_tag() -> None
         "<function=get_current_weather>\n<parameter=city>\nA\n</parameter>\n"
         "<parameter=city>\nB\n</parameter>\n</function>",
         "<function=get_current_weather",
+        "<function=get_current_weather><parameter=city",
         "<function=get_current_weather>\n<parameter=city\nDallas\n</function>",
+        "<function=get_current_weather>",
+        "garbage<function=get_current_weather></function>",
+        "<function=get_current_weather></function>garbage",
+        "<function=get_current_weather>garbage</function>",
+        "<function=get_current_weather>garbage<parameter=city>\nDallas\n</parameter></function>",
+        "<function=get_current_weather><parameter=city>\nDallas\n</parameter>garbage</function>",
     ],
 )
 def test_stream_parser_rejects_unrepairable_qwen_payloads(payload: str) -> None:
@@ -1368,6 +1457,23 @@ def test_stream_parser_enforces_unicode_payload_byte_boundary() -> None:
     assert parser.feed(f"{TOOL_CALL_OPEN}{payload}") == []
     with pytest.raises(ProtocolError, match="too large"):
         parser.feed("x")
+
+
+def test_stream_parser_excludes_multibyte_close_prefix_from_payload_limit() -> None:
+    prefix = f'{_DEEPSEEK_CALL_OPEN}get_weather{_DEEPSEEK_SEP}{{"value":"'
+    suffix = f'"}}{_DEEPSEEK_CALL_CLOSE}'
+    fixed_bytes = len((prefix + suffix).encode("utf-8"))
+    filler = "x" * (_MAX_TOOL_PAYLOAD_BYTES - fixed_bytes)
+    payload = f"{prefix}{filler}{suffix}"
+    assert len(payload.encode("utf-8")) == _MAX_TOOL_PAYLOAD_BYTES
+
+    parser = ToolCallStreamParser(frozenset({"get_weather"}))
+    assert parser.feed(f"{_DEEPSEEK_OPEN}{payload}{_DEEPSEEK_CLOSE[:2]}") == []
+    emissions = parser.feed(_DEEPSEEK_CLOSE[2:])
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"value": filler}
 
 
 def test_stream_parser_handles_large_chunked_payload() -> None:


### PR DESCRIPTION
## Summary
- fail closed on malformed or partially consumed pipe-tag, Kimi, DeepSeek, and Qwen payloads
- preserve pipe-tag string whitespace, nested Qwen value markup, split control tokens, and exact UTF-8 payload limits
- cover model retrieval auth, quarantine behavior, official OpenAI client retrieval, and parser regressions
- make VS Code generator output destination explicit

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` (492 passed, 98.60% total; dialects and protocol 100%)
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`