### PR TITLE
fix(config): reasoning effort override, teardown grace, dialect in protocol error

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ tool calls through the official `openai` Python client.
 | `factory_droid_session_id` | Yes | Bridge-specific session continuation, disabled by default |
 | `factory_droid_status` | Yes | Bridge-specific Droid working-state SSE events |
 | `reasoning_effort` | Yes | Mapped to Droid reasoning effort |
-| `factory_droid_reasoning_effort` | Yes | Bridge-specific override |
+| `factory_droid_reasoning_effort` | Yes | Bridge-specific override, wins over `reasoning_effort` |
 | `timeout` | Yes | Per-request value capped by server timeout |
 | `temperature`, `top_p`, penalties, `seed` | No | Accepted but ignored |
 | `max_tokens`, `max_completion_tokens` | No | Accepted but ignored |
@@ -896,6 +896,20 @@ tool calls through the official `openai` Python client.
 | Unknown fields | Accepted | Ignored by the bridge |
 
 The bridge currently returns one choice with index `0`.
+
+### Reasoning effort
+
+Requests select an effort with `factory_droid_reasoning_effort`, falling back to
+`reasoning_effort`. Valid values are `none`, `dynamic`, `off`, `minimal`, `low`,
+`medium`, `high`, `xhigh` and `max`; anything else is rejected with `400`.
+
+`FACTORY_DROID_OPENAI_REASONING_EFFORT` overrides both request fields, so
+clients that pin their own value (agent frameworks often send `medium`) get the
+effort the operator chose instead. The override applies to every model, and the
+bridge does not check it against the per-model
+`factory_droid_supported_reasoning_efforts` list from `GET /v1/models`, so an
+effort a model does not support fails that request at the Droid layer. Leave the
+variable unset to let clients choose.
 
 ### Model selection
 
@@ -1113,8 +1127,8 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES` | `1048576` | Serialized tool schema size limit |
 | `FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES` | `1048576` | Buffered structured output size limit |
 | `FACTORY_DROID_OPENAI_MAX_JSON_DEPTH` | `32` | Request JSON nesting limit |
-| `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` | `2` | Wait before killing a Droid process |
-| `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` | `4` | Total budget for session cleanup |
+| `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` | `5` | Wait before killing a Droid process |
+| `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` | `10` | Total budget for session cleanup |
 | `FACTORY_DROID_OPENAI_UVICORN_LIMIT_CONCURRENCY` | `64` | Uvicorn connection limit |
 | `FACTORY_DROID_OPENAI_UVICORN_BACKLOG` | `128` | Uvicorn listen backlog |
 | `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `8` | Tool calls accepted per Droid turn |
@@ -1127,6 +1141,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_WORKTREE` | unset | Run Droid in a git worktree |
 | `FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE` | unset | File appended to the Droid system prompt |
 | `FACTORY_DROID_OPENAI_MODEL_ALIAS` | `factory-droid` | Alias using Droid default model |
+| `FACTORY_DROID_OPENAI_REASONING_EFFORT` | unset | Reasoning effort forced on every request |
 | `FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS` | `300` | `GET /v1/models` catalog cache lifetime |
 | `FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS` | `900` | How long a refused model stays withheld |
 | `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` | `0` | MCP initialization window before tool discovery |
@@ -1190,8 +1205,9 @@ surface.
 
 `forced_kills_total` counts processes that had to be killed with a signal
 because they did not exit within `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS`.
-`droid exec` shuts down cleanly in about a second, so a rising counter means
-stuck processes, not ordinary traffic.
+A session that just served a full turn stays busy for a few seconds past
+`SIGTERM`, so raise the grace period on a slow host before reading a rising
+counter as stuck processes.
 
 Serve `/metrics` on a loopback interface or behind your own access control;
 it carries no prompt content, but it does expose traffic shape.
@@ -1410,7 +1426,7 @@ alternate between models faster than the pool refills.
 
 ### Every request logs a forced kill
 
-Not expected any more. `droid exec` exits cleanly in about a second, so raise
+A session torn down right after a turn needs a few seconds to exit, so raise
 `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` if teardown is being cut short on
 a slower host; `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` must stay above
 it. With detached cleanup the kill happens after the response, so it costs the

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -627,7 +627,12 @@ def create_app(
     @contextlib.asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         pool.start(
-            initial_key=SessionKey(model_id=None, reasoning_effort=None),
+            # Warm with the configured effort override so clamped requests
+            # reuse the session instead of paying for a retune.
+            initial_key=SessionKey(
+                model_id=None,
+                reasoning_effort=resolved_settings.reasoning_effort,
+            ),
         )
         log_info(
             "bridge.started",
@@ -1099,7 +1104,14 @@ def create_app(
             prompt_ms=timeline.mark("prompt_ms"),
         )
 
-        reasoning_effort = payload.factory_droid_reasoning_effort or payload.reasoning_effort
+        # A configured effort is an override: clients that send their own
+        # value (e.g. agent frameworks defaulting to medium) get clamped to
+        # what the bridge operator chose.
+        reasoning_effort = (
+            resolved_settings.reasoning_effort
+            or payload.factory_droid_reasoning_effort
+            or payload.reasoning_effort
+        )
         try:
             reasoning_effort = normalize_reasoning_effort(reasoning_effort)
         except RunnerError as exc:

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -639,6 +639,7 @@ def create_app(
             warm_sessions=resolved_settings.warm_session_count(),
             max_concurrency=resolved_settings.max_concurrency,
             detached_cleanup=resolved_settings.detached_cleanup,
+            reasoning_effort=resolved_settings.reasoning_effort,
         )
         try:
             yield
@@ -1040,7 +1041,8 @@ def create_app(
             messages=len(payload.messages),
             tools=len(payload.tools or ()),
             timeout_s=round(timeout_seconds, 1),
-            reasoning_effort=payload.factory_droid_reasoning_effort or payload.reasoning_effort,
+            reasoning_effort=_effective_reasoning_effort(payload, resolved_settings),
+            reasoning_effort_overridden=resolved_settings.reasoning_effort is not None,
             continuation=payload.factory_droid_session_id is not None,
         )
 
@@ -1104,14 +1106,7 @@ def create_app(
             prompt_ms=timeline.mark("prompt_ms"),
         )
 
-        # A configured effort is an override: clients that send their own
-        # value (e.g. agent frameworks defaulting to medium) get clamped to
-        # what the bridge operator chose.
-        reasoning_effort = (
-            resolved_settings.reasoning_effort
-            or payload.factory_droid_reasoning_effort
-            or payload.reasoning_effort
-        )
+        reasoning_effort = _effective_reasoning_effort(payload, resolved_settings)
         try:
             reasoning_effort = normalize_reasoning_effort(reasoning_effort)
         except RunnerError as exc:
@@ -1800,6 +1795,22 @@ def _usage_chunk(
         "choices": [],
         "usage": _usage_dict(usage),
     }
+
+
+def _effective_reasoning_effort(
+    payload: ChatCompletionRequest,
+    settings: Settings,
+) -> str | None:
+    """A configured effort overrides whatever effort the request carries.
+
+    Agent frameworks pin their own value (often ``medium``), so the operator
+    setting has to win for the bridge to hold a chosen effort.
+    """
+    return (
+        settings.reasoning_effort
+        or payload.factory_droid_reasoning_effort
+        or payload.reasoning_effort
+    )
 
 
 def _validate_options(

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -5,7 +5,11 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from droid_sdk.schemas.enums import ReasoningEffort
+
 from factory_droid_openai.logs import LOG_FORMATS, LOG_LEVELS
+
+_REASONING_EFFORTS: tuple[str, ...] = tuple(effort.value for effort in ReasoningEffort)
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,8 +31,8 @@ class Settings:
     max_structured_output_bytes: int = 1_048_576
     max_json_depth: int = 32
     retry_after_seconds: int = 1
-    process_grace_seconds: float = 2.0
-    cleanup_timeout_seconds: float = 4.0
+    process_grace_seconds: float = 5.0
+    cleanup_timeout_seconds: float = 10.0
     server_limit_concurrency: int = 64
     server_backlog: int = 128
     max_tool_calls: int = 8
@@ -44,6 +48,8 @@ class Settings:
     worktree: str | None = None
     append_system_prompt_file: Path | None = None
     model_alias: str = "factory-droid"
+    # Overrides any reasoning_effort a request carries when set.
+    reasoning_effort: str | None = None
     log_level: str = "info"
     log_format: str = "text"
     warm_sessions: int = -1
@@ -125,13 +131,14 @@ class Settings:
         )
         process_grace_seconds = _positive_float(
             "FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS",
-            # droid shuts down cleanly in about a second, so a shorter grace
-            # period turns every teardown into a SIGKILL.
-            default=2.0,
+            # Teardown after a full turn keeps droid busy for seconds past
+            # SIGTERM, so a shorter grace period turns every cleanup into a
+            # SIGKILL.
+            default=5.0,
         )
         cleanup_timeout_seconds = _positive_float(
             "FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS",
-            default=4.0,
+            default=10.0,
         )
         if cleanup_timeout_seconds <= process_grace_seconds:
             raise ValueError(
@@ -192,6 +199,10 @@ class Settings:
         append_system_prompt_file = _optional_file(
             "FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE",
         )
+        reasoning_effort = _optional_choice(
+            "FACTORY_DROID_OPENAI_REASONING_EFFORT",
+            allowed=_REASONING_EFFORTS,
+        )
         log_level = _choice(
             "FACTORY_DROID_OPENAI_LOG_LEVEL",
             default="info",
@@ -240,6 +251,7 @@ class Settings:
             worktree=worktree,
             append_system_prompt_file=append_system_prompt_file,
             model_alias=os.getenv("FACTORY_DROID_OPENAI_MODEL_ALIAS", "factory-droid"),
+            reasoning_effort=reasoning_effort,
             log_level=log_level,
             log_format=log_format,
             warm_sessions=warm_sessions,
@@ -297,6 +309,17 @@ def _choice(name: str, *, default: str, allowed: tuple[str, ...]) -> str:
     raw = os.getenv(name)
     if raw is None or not raw.strip():
         return default
+    value = raw.strip().lower()
+    if value not in allowed:
+        raise ValueError(f"{name} must be one of: {', '.join(allowed)}")
+    return value
+
+
+def _optional_choice(name: str, *, allowed: tuple[str, ...]) -> str | None:
+    """Return the configured value, or ``None`` when the variable is unset."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return None
     value = raw.strip().lower()
     if value not in allowed:
         raise ValueError(f"{name} must be one of: {', '.join(allowed)}")

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -56,6 +56,20 @@ class Settings:
     warm_session_ttl_seconds: float = 600.0
     detached_cleanup: bool = True
 
+    def __post_init__(self) -> None:
+        # The warm pool keys sessions by this value, so it has to match the
+        # normalized effort the request path sends to Droid, and a bad value
+        # has to fail at construction instead of on every request.
+        if self.reasoning_effort is None:
+            return
+        value = self.reasoning_effort.strip().lower()
+        if not value:
+            object.__setattr__(self, "reasoning_effort", None)
+            return
+        if value not in _REASONING_EFFORTS:
+            raise ValueError(f"reasoning_effort must be one of: {', '.join(_REASONING_EFFORTS)}")
+        object.__setattr__(self, "reasoning_effort", value)
+
     def warm_session_count(self) -> int:
         """Warm sessions to keep ready; ``-1`` keeps one spare per concurrency slot.
 

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -269,7 +269,9 @@ class ToolCallStreamParser:
         if self._done:
             self._text_tail += chunk
             if self._residual(self._text_tail).strip():
-                raise ProtocolError("unexpected text after tool call")
+                raise ProtocolError(
+                    f"unexpected text after tool call ({self._dialect.name} dialect)"
+                )
             # Everything left is verified noise except a control token the next
             # chunk still has to complete.
             self._text_tail = self._trailing_partial(self._text_tail)
@@ -291,7 +293,9 @@ class ToolCallStreamParser:
             # residual non-whitespace is trailing output and must fail closed.
             if self._saw_tool_call:
                 if self._residual(self._text_tail).strip():
-                    raise ProtocolError("unexpected text after tool call")
+                    raise ProtocolError(
+                        f"unexpected text after tool call ({self._dialect.name} dialect)"
+                    )
             else:
                 emissions.append(TextEmission(self._text_tail))
             self._text_tail = ""
@@ -333,7 +337,7 @@ class ToolCallStreamParser:
         if not self._saw_tool_call:
             return [TextEmission(text)]
         if self._residual(text).strip():
-            raise ProtocolError("unexpected text after tool call")
+            raise ProtocolError(f"unexpected text after tool call ({self._dialect.name} dialect)")
         return []
 
     def _residual(self, text: str) -> str:
@@ -386,7 +390,9 @@ class ToolCallStreamParser:
         if self._tool_call_count >= self._max_tool_calls:
             self._done = True
             if self._residual(trailing).strip():
-                raise ProtocolError("unexpected text after tool call")
+                raise ProtocolError(
+                    f"unexpected text after tool call ({self._dialect.name} dialect)"
+                )
             self._text_tail = self._trailing_partial(trailing)
             return emissions
         if trailing:

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -269,9 +269,7 @@ class ToolCallStreamParser:
         if self._done:
             self._text_tail += chunk
             if self._residual(self._text_tail).strip():
-                raise ProtocolError(
-                    f"unexpected text after tool call ({self._dialect.name} dialect)"
-                )
+                raise self._trailing_output_error()
             # Everything left is verified noise except a control token the next
             # chunk still has to complete.
             self._text_tail = self._trailing_partial(self._text_tail)
@@ -293,9 +291,7 @@ class ToolCallStreamParser:
             # residual non-whitespace is trailing output and must fail closed.
             if self._saw_tool_call:
                 if self._residual(self._text_tail).strip():
-                    raise ProtocolError(
-                        f"unexpected text after tool call ({self._dialect.name} dialect)"
-                    )
+                    raise self._trailing_output_error()
             else:
                 emissions.append(TextEmission(self._text_tail))
             self._text_tail = ""
@@ -337,8 +333,12 @@ class ToolCallStreamParser:
         if not self._saw_tool_call:
             return [TextEmission(text)]
         if self._residual(text).strip():
-            raise ProtocolError(f"unexpected text after tool call ({self._dialect.name} dialect)")
+            raise self._trailing_output_error()
         return []
+
+    def _trailing_output_error(self) -> ProtocolError:
+        """Names the dialect so logs show which marker format produced the text."""
+        return ProtocolError(f"unexpected text after tool call ({self._dialect.name} dialect)")
 
     def _residual(self, text: str) -> str:
         """Drops the control tokens the active dialect frames its calls with.
@@ -390,9 +390,7 @@ class ToolCallStreamParser:
         if self._tool_call_count >= self._max_tool_calls:
             self._done = True
             if self._residual(trailing).strip():
-                raise ProtocolError(
-                    f"unexpected text after tool call ({self._dialect.name} dialect)"
-                )
+                raise self._trailing_output_error()
             self._text_tail = self._trailing_partial(trailing)
             return emissions
         if trailing:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -880,6 +880,24 @@ async def test_request_options_map_to_runner_request(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_configured_reasoning_effort_overrides_request(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    settings = Settings(
+        droid_path="droid",
+        workdir=tmp_path,
+        timeout_seconds=30.0,
+        reasoning_effort="low",
+    )
+    app = create_app(settings, runner_factory=cast("RunnerFactory", lambda: runner))
+    payload = _payload(reasoning_effort="high", factory_droid_reasoning_effort="medium")
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert runner.requests[0].reasoning_effort == "low"
+
+
+@pytest.mark.asyncio
 async def test_bounded_queue_rejects_overload_before_stream_headers(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2384,6 +2384,31 @@ async def test_chat_completion_uses_a_warm_session(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_warm_session_key_follows_the_configured_reasoning_effort(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("hi"), RunComplete(Usage())])
+    settings = Settings(
+        droid_path="droid",
+        workdir=tmp_path,
+        timeout_seconds=30.0,
+        reasoning_effort="low",
+    )
+    app = create_app(settings, runner_factory=cast("RunnerFactory", lambda: runner))
+    key = SessionKey(model_id=None, reasoning_effort="low")
+    app.state.pool.note(key)
+    app.state.pool.offer(_warm_session(key))
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(reasoning_effort="high"),
+        )
+
+    assert response.status_code == 200
+    assert runner.requests[0].warm_session is not None
+    assert "factory_droid_openai_warm_session_hits_total 1" in app.state.metrics.render()
+
+
+@pytest.mark.asyncio
 async def test_extra_choices_do_not_reuse_the_warm_session(tmp_path: Path) -> None:
     runner = FakeRunner([TextDelta("hi"), RunComplete(Usage())])
     app = _app(tmp_path, runner)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,7 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_UVICORN_LIMIT_CONCURRENCY",
     "FACTORY_DROID_OPENAI_UVICORN_BACKLOG",
     "FACTORY_DROID_OPENAI_MODEL_ALIAS",
+    "FACTORY_DROID_OPENAI_REASONING_EFFORT",
     "FACTORY_DROID_OPENAI_LOG_LEVEL",
     "FACTORY_DROID_OPENAI_LOG_FORMAT",
     "FACTORY_DROID_OPENAI_WARM_SESSIONS",
@@ -101,6 +102,23 @@ def test_settings_from_env_rejects_unknown_log_options(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv(name, value)
 
+    with pytest.raises(ValueError, match="must be one of"):
+        Settings.from_env()
+
+
+def test_settings_from_env_reads_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    assert Settings.from_env().reasoning_effort is None
+
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_REASONING_EFFORT", " LOW ")
+    assert Settings.from_env().reasoning_effort == "low"
+
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_REASONING_EFFORT", "extreme")
     with pytest.raises(ValueError, match="must be one of"):
         Settings.from_env()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,6 +123,15 @@ def test_settings_from_env_reads_reasoning_effort(
         Settings.from_env()
 
 
+def test_settings_normalize_reasoning_effort_on_construction() -> None:
+    assert Settings(reasoning_effort=" HIGH ").reasoning_effort == "high"
+    assert Settings(reasoning_effort="   ").reasoning_effort is None
+    assert Settings().reasoning_effort is None
+
+    with pytest.raises(ValueError, match="reasoning_effort must be one of"):
+        Settings(reasoning_effort="extreme")
+
+
 def test_warm_session_count_tracks_max_concurrency_unless_set(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -816,6 +816,16 @@ def test_stream_parser_rejects_prose_after_pipe_tag_call() -> None:
         parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE} and done")
 
 
+def test_stream_parser_names_the_dialect_in_trailing_text_error() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(
+        ProtocolError,
+        match=r"unexpected text after tool call \(pipe_tag dialect\)",
+    ):
+        parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE} and done")
+
+
 def test_stream_parser_ignores_pipe_tag_control_tokens_after_the_call() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -826,6 +826,30 @@ def test_stream_parser_names_the_dialect_in_trailing_text_error() -> None:
         parser.feed(f"{_PIPE_TAG_OPEN}{_PIPE_TAG_CALL}{_PIPE_TAG_CLOSE} and done")
 
 
+def test_every_trailing_text_error_names_the_native_dialect() -> None:
+    expected = r"unexpected text after tool call \(native dialect\)"
+
+    capped = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+    capped.feed(_tool_call("weather", "{}"))
+    with pytest.raises(ProtocolError, match=expected):
+        capped.feed("trailing")
+
+    over_cap = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+    with pytest.raises(ProtocolError, match=expected):
+        over_cap.feed(_tool_call("weather", "{}") + "trailing")
+
+    between = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=3)
+    between.feed(_tool_call("weather", "{}"))
+    with pytest.raises(ProtocolError, match=expected):
+        between.feed("and now some prose")
+
+    at_finish = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=3)
+    at_finish.feed(_tool_call("weather", "{}"))
+    at_finish.feed("  <tool")
+    with pytest.raises(ProtocolError, match=expected):
+        at_finish.finish()
+
+
 def test_stream_parser_ignores_pipe_tag_control_tokens_after_the_call() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 


### PR DESCRIPTION
## Why

Observed on a live bridge serving kimi-k3 through an agent client (Hermes):

- Turns took 118-244 s: the client sends `reasoning_effort=medium` and kimi-k3 spent the turn on ~6.3k thinking deltas before 32 tokens of output. Bridge overhead was ~10 ms; the thinking dominated.
- A stream died after 106 s with `factory_protocol_error: unexpected text after tool call` - the model answered in its own template and appended prose after the call. The log line gave no hint which dialect framed it.
- Every turn ended in `droid.forced_kill`: post-turn teardown stays busy seconds past SIGTERM, longer than the 2 s grace.

## What

- `FACTORY_DROID_OPENAI_REASONING_EFFORT` (env) now **overrides** any per-request effort, clamping agent clients to the operator's choice. Warm sessions adopt the override, so clamped requests skip the retune.
- The value is normalized and validated against the SDK's `ReasoningEffort` enum in `Settings.__post_init__`, so it fails at construction instead of on every request, and the warm-pool key always matches the effort sent to Droid.
- Default process grace 2s -> 5s and cleanup timeout 4s -> 10s, so graceful teardown no longer ends in SIGKILL.
- The fail-closed trailing-output error now names the marker dialect, e.g. `unexpected text after tool call (pipe_tag dialect)`, raised from one helper instead of four duplicated call sites.

## Observability

- `chat.received` logs the effective effort plus `reasoning_effort_overridden`, instead of the client value the bridge ignored.
- `bridge.started` logs the configured effort so the override is visible at boot.

## Docs

- README: new "Reasoning effort" section (valid values, override precedence over both request fields, no per-model support check), `FACTORY_DROID_OPENAI_REASONING_EFFORT` row, corrected grace/cleanup defaults, and removal of the stale "droid exec exits cleanly in about a second" claim that justified the old 2 s grace.

## Compatibility

- Response shapes unchanged; no route or schema change, so `openapi.json` is untouched.
- With the variable unset, behavior is identical to before. When set, clients lose per-request control, including via `factory_droid_reasoning_effort` - documented in the README.

## Validation

- ruff check, ruff format --check, strict mypy: clean
- pytest: 498 passed, coverage 98.62% (gate 95%)
- openapi-spec-validator, uv lock --check, uv build: OK
