### PR TITLE
feat(logging): opt-in payload tracing to JSONL with redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,8 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` | `0` | MCP initialization window before tool discovery |
 | `FACTORY_DROID_OPENAI_LOG_LEVEL` | `info` | Bridge and Uvicorn log level |
 | `FACTORY_DROID_OPENAI_LOG_FORMAT` | `text` | Bridge log rendering: `text` or `json` |
+| `FACTORY_DROID_OPENAI_TRACE_PAYLOADS` | `off` | Payload tracing: `off`, `heads`, or `full` |
+| `FACTORY_DROID_OPENAI_TRACE_FILE` | unset | Trace destination, required unless tracing is `off` |
 
 Command-line options:
 
@@ -1311,6 +1313,35 @@ tasks such as title generation.
 
 Log lines carry no prompt or completion text: sizes, counts, timings, model
 IDs, and session IDs only.
+
+### Payload tracing
+
+Prompts and malformed tool-call payloads stay out of the log stream. When a
+protocol bug needs the actual bytes, opt into a separate JSONL trace file:
+
+```bash
+export FACTORY_DROID_OPENAI_TRACE_PAYLOADS=heads
+export FACTORY_DROID_OPENAI_TRACE_FILE="$HOME/.cache/factory-droid-openai/trace.jsonl"
+factory-droid-openai
+```
+
+| Mode | Recorded per event |
+|---|---|
+| `off` | Nothing; the file is never created |
+| `heads` | First 2048 and last 1024 characters of the payload |
+| `full` | Whole payload, capped at 1 MiB with `payload_truncated` set |
+
+Both variables are required together, and the destination must be an existing
+directory holding a regular non-symlink file path. The file is created mode
+`0600` and re-chmodded on every write.
+
+Every line is redacted before it is written: bearer and basic credentials,
+`sk-` keys, long base64 runs, and values of key, token, secret, password, and
+authorization fields, in both the payload and the event metadata. Redaction is
+best effort, `payload_bytes` counts the original payload, and
+`redacted_sha256` digests the redacted text. Traced prompts are still private
+user content, so keep the destination outside the Droid workdir, outside version
+control, and delete it when the investigation ends.
 
 ## Authentication
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,4 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "raise NotImplementedError",
 ]
+partial_branches = ["pragma: no branch"]

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -46,7 +46,7 @@ from factory_droid_openai.models import (
     SessionOperationResponse,
     VersionResponse,
 )
-from factory_droid_openai.payloadlog import configure_payload_tracing, trace_payload
+from factory_droid_openai.payloadlog import configure_payload_tracing
 from factory_droid_openai.pool import BackgroundReaper, WarmSessionPool
 from factory_droid_openai.protocol import (
     ProtocolEmission,
@@ -591,7 +591,7 @@ def create_app(
     runner_factory: RunnerFactory | None = None,
 ) -> FastAPI:
     resolved_settings = settings or Settings.from_env()
-    configure_payload_tracing(
+    payload_tracer = configure_payload_tracing(
         mode=resolved_settings.trace_payloads,
         path=resolved_settings.trace_payload_file,
     )
@@ -1116,7 +1116,7 @@ def create_app(
             documents=len(plan.attachments.documents),
             prompt_ms=timeline.mark("prompt_ms"),
         )
-        trace_payload("chat.prompt", plan.prompt, model=payload.model)
+        payload_tracer.trace("chat.prompt", plan.prompt, model=payload.model)
 
         reasoning_effort = _effective_reasoning_effort(payload, resolved_settings)
         try:
@@ -1193,6 +1193,7 @@ def create_app(
                     max_tool_calls=(
                         resolved_settings.max_tool_calls if payload.parallel_tool_calls else 1
                     ),
+                    trace_payload=payload_tracer.trace,
                 ),
                 runner=runner,
                 run_request=run_request,
@@ -1256,6 +1257,7 @@ def create_app(
                                 if payload.parallel_tool_calls
                                 else 1
                             ),
+                            trace_payload=payload_tracer.trace,
                         ),
                         metrics=metrics,
                         request_started_at=request_started_at,

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -46,6 +46,7 @@ from factory_droid_openai.models import (
     SessionOperationResponse,
     VersionResponse,
 )
+from factory_droid_openai.payloadlog import configure_payload_tracing, trace_payload
 from factory_droid_openai.pool import BackgroundReaper, WarmSessionPool
 from factory_droid_openai.protocol import (
     ProtocolEmission,
@@ -590,6 +591,10 @@ def create_app(
     runner_factory: RunnerFactory | None = None,
 ) -> FastAPI:
     resolved_settings = settings or Settings.from_env()
+    configure_payload_tracing(
+        mode=resolved_settings.trace_payloads,
+        path=resolved_settings.trace_payload_file,
+    )
     metrics = BridgeMetrics()
     reaper = BackgroundReaper(metrics=metrics)
     resolved_runner_factory = runner_factory or (
@@ -640,6 +645,12 @@ def create_app(
             max_concurrency=resolved_settings.max_concurrency,
             detached_cleanup=resolved_settings.detached_cleanup,
             reasoning_effort=resolved_settings.reasoning_effort,
+            trace_payloads=resolved_settings.trace_payloads,
+            trace_payload_file=(
+                str(resolved_settings.trace_payload_file)
+                if resolved_settings.trace_payload_file is not None
+                else None
+            ),
         )
         try:
             yield
@@ -1105,6 +1116,7 @@ def create_app(
             documents=len(plan.attachments.documents),
             prompt_ms=timeline.mark("prompt_ms"),
         )
+        trace_payload("chat.prompt", plan.prompt, model=payload.model)
 
         reasoning_effort = _effective_reasoning_effort(payload, resolved_settings)
         try:

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from droid_sdk.schemas.enums import ReasoningEffort
 
 from factory_droid_openai.logs import LOG_FORMATS, LOG_LEVELS
+from factory_droid_openai.payloadlog import PAYLOAD_TRACE_MODES
 
 _REASONING_EFFORTS: tuple[str, ...] = tuple(effort.value for effort in ReasoningEffort)
 
@@ -55,6 +56,9 @@ class Settings:
     warm_sessions: int = -1
     warm_session_ttl_seconds: float = 600.0
     detached_cleanup: bool = True
+    # Off by default: prompts and tool payloads are private user content.
+    trace_payloads: str = "off"
+    trace_payload_file: Path | None = None
 
     def __post_init__(self) -> None:
         # The warm pool keys sessions by this value, so it has to match the
@@ -227,6 +231,14 @@ class Settings:
             default="text",
             allowed=LOG_FORMATS,
         )
+        trace_payloads = _choice(
+            "FACTORY_DROID_OPENAI_TRACE_PAYLOADS",
+            default="off",
+            allowed=PAYLOAD_TRACE_MODES,
+        )
+        trace_payload_file = _optional_path("FACTORY_DROID_OPENAI_TRACE_FILE")
+        if trace_payloads != "off" and trace_payload_file is None:
+            trace_payload_file = workdir / "trace.jsonl"
         port = _positive_int("FACTORY_DROID_OPENAI_PORT", default=8787)
         if port > 65535:
             raise ValueError("FACTORY_DROID_OPENAI_PORT must be at most 65535")
@@ -271,6 +283,8 @@ class Settings:
             warm_sessions=warm_sessions,
             warm_session_ttl_seconds=warm_session_ttl_seconds,
             detached_cleanup=detached_cleanup,
+            trace_payloads=trace_payloads,
+            trace_payload_file=trace_payload_file,
         )
 
 
@@ -347,6 +361,17 @@ def _optional_file(name: str) -> Path | None:
     path = Path(raw).expanduser()
     if not path.is_file():
         raise ValueError(f"{name} does not point at a readable file: {path}")
+    return path.resolve()
+
+
+def _optional_path(name: str) -> Path | None:
+    """Return a path whose parent directory must exist; the file may not."""
+    raw = os.getenv(name)
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if not path.parent.is_dir():
+        raise ValueError(f"{name} parent directory does not exist: {path.parent}")
     return path.resolve()
 
 

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -238,7 +238,12 @@ class Settings:
         )
         trace_payload_file = _optional_path("FACTORY_DROID_OPENAI_TRACE_FILE")
         if trace_payloads != "off" and trace_payload_file is None:
-            trace_payload_file = workdir / "trace.jsonl"
+            # No implicit default: the Droid session runs with workdir as its cwd,
+            # so a trace file placed there would expose every prompt to the agent.
+            raise ValueError(
+                "FACTORY_DROID_OPENAI_TRACE_FILE is required when "
+                "FACTORY_DROID_OPENAI_TRACE_PAYLOADS is not 'off'",
+            )
         port = _positive_int("FACTORY_DROID_OPENAI_PORT", default=8787)
         if port > 65535:
             raise ValueError("FACTORY_DROID_OPENAI_PORT must be at most 65535")
@@ -365,13 +370,17 @@ def _optional_file(name: str) -> Path | None:
 
 
 def _optional_path(name: str) -> Path | None:
-    """Return a path whose parent directory must exist; the file may not."""
+    """Return an appendable file path; the parent must exist, the file need not."""
     raw = os.getenv(name)
     if not raw:
         return None
     path = Path(raw).expanduser()
     if not path.parent.is_dir():
         raise ValueError(f"{name} parent directory does not exist: {path.parent}")
+    if path.is_symlink():
+        raise ValueError(f"{name} must not be a symlink: {path}")
+    if path.exists() and not path.is_file():
+        raise ValueError(f"{name} must be a regular file: {path}")
     return path.resolve()
 
 

--- a/src/factory_droid_openai/payloadlog.py
+++ b/src/factory_droid_openai/payloadlog.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import stat
 import threading
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -11,85 +14,164 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from factory_droid_openai.logs import current_request_id
+from factory_droid_openai.logs import warning as log_warning
 
 PAYLOAD_TRACE_MODES: tuple[str, ...] = ("off", "heads", "full")
 _HEAD_CHARS = 2048
 _TAIL_CHARS = 1024
+_MAX_FULL_CHARS = 1 << 20
 _REDACTED = "[REDACTED]"
+_SENSITIVE_KEY = r"(?:api_?key|(?:access_)?token|(?:client_)?secret|password|authorization)"
+# Payloads are minified single-line JSON, so an unquoted `key: value` run has to
+# stop at structural delimiters; matching to end of line would let one redaction
+# swallow every remaining field of the record.
+_SENSITIVE_VALUE = r"[^\r\n\"',;&}\]]+"
 # Prompts and tool payloads can carry credentials pasted by users or tool
 # output, so every line written to the trace file passes through redaction
 # regardless of mode.
-_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"sk-[A-Za-z0-9_-]{8,}"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
-    re.compile(r"(?i)(\"(?:api_?key|token|secret|password|authorization)\"\s*:\s*\")[^\"]*(\")"),
-    re.compile(r"(?i)((?:api_?key|token|secret|password)=)\S+"),
-    re.compile(r"[A-Za-z0-9+/]{120,}={0,2}"),
+_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"sk-[A-Za-z0-9_-]{8,}"), _REDACTED),
+    (re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"), _REDACTED),
+    (re.compile(r"(?i)basic\s+[A-Za-z0-9+/]{4,}={0,2}"), _REDACTED),
+    (
+        re.compile(
+            rf'(?i)(?P<prefix>(?<!\\)(?P<escape>\\*)"{_SENSITIVE_KEY}(?P=escape)"'
+            rf'\s*:\s*(?P=escape)").*?(?P<suffix>(?<!\\)(?P=escape)")'
+        ),
+        rf"\g<prefix>{_REDACTED}\g<suffix>",
+    ),
+    (
+        # The separator run is possessive so the marker lookahead cannot be
+        # bypassed by giving whitespace back, which would re-redact a redaction.
+        re.compile(
+            rf"(?im)({_SENSITIVE_KEY}\s*(?:=|:)\s*+)(?!{re.escape(_REDACTED)}){_SENSITIVE_VALUE}",
+        ),
+        rf"\g<1>{_REDACTED}",
+    ),
+    (re.compile(r"[A-Za-z0-9+/]{120,}={0,2}"), _REDACTED),
 )
-
-_lock = threading.Lock()
-_mode: str = "off"
-_path: Path | None = None
-
-
-def configure_payload_tracing(*, mode: str, path: Path | None) -> None:
-    """Enable payload tracing to a JSONL file, replacing any previous setup."""
-    global _mode, _path
-    if mode not in PAYLOAD_TRACE_MODES:
-        raise ValueError(f"Unsupported payload trace mode: {mode}")
-    if mode != "off" and path is None:
-        raise ValueError("Payload tracing requires a destination file")
-    if path is not None and not path.parent.is_dir():
-        raise ValueError(f"Payload trace directory does not exist: {path.parent}")
-    with _lock:
-        _mode = mode
-        _path = path
-
-
-def reset_payload_tracing() -> None:
-    """Disable tracing; used by tests to isolate module state."""
-    configure_payload_tracing(mode="off", path=None)
-
-
-def payload_tracing_enabled() -> bool:
-    return _mode != "off"
 
 
 def redact(text: str) -> str:
-    for pattern in _REDACTION_PATTERNS:
-        if pattern.groups == 2:
-            text = pattern.sub(rf"\g<1>{_REDACTED}\g<2>", text)
-        elif pattern.groups == 1:
-            text = pattern.sub(rf"\g<1>{_REDACTED}", text)
-        else:
-            text = pattern.sub(_REDACTED, text)
+    for pattern, replacement in _REDACTION_PATTERNS:
+        text = pattern.sub(replacement, text)
     return text
 
 
-def trace_payload(event: str, payload: str, **fields: Any) -> None:
-    """Write one redacted payload event to the trace file; no-op when off."""
-    with _lock:
-        mode = _mode
-        path = _path
-    if mode == "off" or path is None:
-        return
-    encoded = payload.encode("utf-8")
-    record: dict[str, Any] = {
-        "ts": datetime.now(UTC).isoformat(),
-        "event": event,
-        "request_id": current_request_id(),
-        "mode": mode,
-        "payload_bytes": len(encoded),
-        "payload_sha256": hashlib.sha256(encoded).hexdigest(),
-        **{key: value for key, value in fields.items() if value is not None},
-    }
-    redacted = redact(payload)
-    if mode == "full":
-        record["payload"] = redacted
-    else:
-        record["payload_head"] = redacted[:_HEAD_CHARS]
-        if len(redacted) > _HEAD_CHARS:
-            record["payload_tail"] = redacted[-_TAIL_CHARS:]
-    line = json.dumps(record, ensure_ascii=False, default=str)
-    with _lock, path.open("a", encoding="utf-8") as handle:
-        handle.write(f"{line}\n")
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact(value)
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            rendered_key = str(key)
+            if re.fullmatch(_SENSITIVE_KEY, rendered_key, re.IGNORECASE):
+                redacted[rendered_key] = _REDACTED
+            else:
+                redacted[redact(rendered_key)] = _redact_value(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(item) for item in value)
+    return value
+
+
+def validate_trace_path(path: Path) -> None:
+    """Reject destinations that could never be appended to as a private regular file."""
+    if not path.parent.is_dir():
+        raise ValueError(f"Payload trace directory does not exist: {path.parent}")
+    if path.is_symlink():
+        raise ValueError(f"Payload trace file must not be a symlink: {path}")
+    if path.exists() and not path.is_file():
+        raise ValueError(f"Payload trace file must be a regular file: {path}")
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadTracer:
+    mode: str
+    path: Path | None
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        compare=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        if self.mode not in PAYLOAD_TRACE_MODES:
+            raise ValueError(f"Unsupported payload trace mode: {self.mode}")
+        if self.mode != "off" and self.path is None:
+            raise ValueError("Payload tracing requires a destination file")
+        if self.path is not None:
+            validate_trace_path(self.path)
+
+    def trace(self, event: str, payload: str, **fields: Any) -> None:
+        """Write one redacted payload event; logging failures never fail requests."""
+        path = self.path
+        if self.mode == "off" or path is None:
+            return
+        try:
+            encoded = payload.encode("utf-8")
+            redacted = redact(payload)
+            record: dict[str, Any] = {
+                **_redact_value({key: value for key, value in fields.items() if value is not None}),
+                "ts": datetime.now(UTC).isoformat(),
+                "event": redact(event),
+                "request_id": redact(current_request_id()),
+                "mode": self.mode,
+                "payload_bytes": len(encoded),
+                "redacted_sha256": hashlib.sha256(redacted.encode("utf-8")).hexdigest(),
+            }
+            if self.mode == "full":
+                record["payload"] = redacted[:_MAX_FULL_CHARS]
+                if len(redacted) > _MAX_FULL_CHARS:
+                    record["payload_truncated"] = True
+            else:
+                record["payload_head"] = redacted[:_HEAD_CHARS]
+                if len(redacted) > _HEAD_CHARS:
+                    record["payload_tail"] = redacted[-_TAIL_CHARS:]
+            line = json.dumps(
+                record,
+                ensure_ascii=True,
+                default=lambda value: redact(str(value)),
+            )
+            self._write_line(path, line)
+        except Exception as exc:
+            # Deliberately broad: a diagnostics writer must never fail a request.
+            log_warning("payload_trace.write_failed", error_type=type(exc).__name__)
+
+    def _write_line(self, path: Path, line: str) -> None:
+        # Written synchronously: the payload cap above bounds the cost, and an
+        # async writer would drop pending records when a request is cancelled.
+        flags = (
+            os.O_WRONLY
+            | os.O_APPEND
+            | os.O_CREAT
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        with self._lock:
+            descriptor = os.open(path, flags, stat.S_IRUSR | stat.S_IWUSR)
+            try:
+                if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                    raise OSError("Payload trace destination must be a regular file")
+                if os.name != "nt":
+                    os.fchmod(descriptor, stat.S_IRUSR | stat.S_IWUSR)
+                with os.fdopen(
+                    descriptor,
+                    "a",
+                    encoding="utf-8",
+                    closefd=False,
+                ) as handle:
+                    handle.write(f"{line}\n")
+            finally:
+                os.close(descriptor)
+
+
+def configure_payload_tracing(*, mode: str, path: Path | None) -> PayloadTracer:
+    """Build an independent payload tracer for one application instance."""
+    return PayloadTracer(mode=mode, path=path)
+
+
+NULL_PAYLOAD_TRACER = PayloadTracer(mode="off", path=None)

--- a/src/factory_droid_openai/payloadlog.py
+++ b/src/factory_droid_openai/payloadlog.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from factory_droid_openai.logs import current_request_id
+
+PAYLOAD_TRACE_MODES: tuple[str, ...] = ("off", "heads", "full")
+_HEAD_CHARS = 2048
+_TAIL_CHARS = 1024
+_REDACTED = "[REDACTED]"
+# Prompts and tool payloads can carry credentials pasted by users or tool
+# output, so every line written to the trace file passes through redaction
+# regardless of mode.
+_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sk-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)(\"(?:api_?key|token|secret|password|authorization)\"\s*:\s*\")[^\"]*(\")"),
+    re.compile(r"(?i)((?:api_?key|token|secret|password)=)\S+"),
+    re.compile(r"[A-Za-z0-9+/]{120,}={0,2}"),
+)
+
+_lock = threading.Lock()
+_mode: str = "off"
+_path: Path | None = None
+
+
+def configure_payload_tracing(*, mode: str, path: Path | None) -> None:
+    """Enable payload tracing to a JSONL file, replacing any previous setup."""
+    global _mode, _path
+    if mode not in PAYLOAD_TRACE_MODES:
+        raise ValueError(f"Unsupported payload trace mode: {mode}")
+    if mode != "off" and path is None:
+        raise ValueError("Payload tracing requires a destination file")
+    if path is not None and not path.parent.is_dir():
+        raise ValueError(f"Payload trace directory does not exist: {path.parent}")
+    with _lock:
+        _mode = mode
+        _path = path
+
+
+def reset_payload_tracing() -> None:
+    """Disable tracing; used by tests to isolate module state."""
+    configure_payload_tracing(mode="off", path=None)
+
+
+def payload_tracing_enabled() -> bool:
+    return _mode != "off"
+
+
+def redact(text: str) -> str:
+    for pattern in _REDACTION_PATTERNS:
+        if pattern.groups == 2:
+            text = pattern.sub(rf"\g<1>{_REDACTED}\g<2>", text)
+        elif pattern.groups == 1:
+            text = pattern.sub(rf"\g<1>{_REDACTED}", text)
+        else:
+            text = pattern.sub(_REDACTED, text)
+    return text
+
+
+def trace_payload(event: str, payload: str, **fields: Any) -> None:
+    """Write one redacted payload event to the trace file; no-op when off."""
+    with _lock:
+        mode = _mode
+        path = _path
+    if mode == "off" or path is None:
+        return
+    encoded = payload.encode("utf-8")
+    record: dict[str, Any] = {
+        "ts": datetime.now(UTC).isoformat(),
+        "event": event,
+        "request_id": current_request_id(),
+        "mode": mode,
+        "payload_bytes": len(encoded),
+        "payload_sha256": hashlib.sha256(encoded).hexdigest(),
+        **{key: value for key, value in fields.items() if value is not None},
+    }
+    redacted = redact(payload)
+    if mode == "full":
+        record["payload"] = redacted
+    else:
+        record["payload_head"] = redacted[:_HEAD_CHARS]
+        if len(redacted) > _HEAD_CHARS:
+            record["payload_tail"] = redacted[-_TAIL_CHARS:]
+    line = json.dumps(record, ensure_ascii=False, default=str)
+    with _lock, path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{line}\n")

--- a/src/factory_droid_openai/payloadlog.py
+++ b/src/factory_droid_openai/payloadlog.py
@@ -156,7 +156,7 @@ class PayloadTracer:
             try:
                 if not stat.S_ISREG(os.fstat(descriptor).st_mode):
                     raise OSError("Payload trace destination must be a regular file")
-                if os.name != "nt":
+                if os.name != "nt":  # pragma: no branch - fchmod is POSIX only
                     os.fchmod(descriptor, stat.S_IRUSR | stat.S_IWUSR)
                 with os.fdopen(
                     descriptor,

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -18,6 +18,7 @@ from factory_droid_openai.dialects import (
 from factory_droid_openai.errors import ProtocolError, RequestTooLargeError
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import trace as log_trace
+from factory_droid_openai.payloadlog import trace_payload
 from factory_droid_openai.strictjson import decode_json_values, parse_strict_json
 
 if TYPE_CHECKING:
@@ -451,6 +452,7 @@ class ToolCallStreamParser:
                     head=body[:_UNPARSED_HEAD_CHARS],
                     payload_bytes=len(body.encode("utf-8")),
                 )
+                trace_payload("tool_call.unparsed", body)
                 raise ProtocolError(f"invalid tool-call JSON: {exc}") from exc
             values = decoded
         if not values:
@@ -463,6 +465,7 @@ class ToolCallStreamParser:
                 if not value or not all(isinstance(item, dict) for item in value):
                     raise ProtocolError("tool-call payload must be a JSON object")
                 log_debug("tool_call.repaired", variant="json_array")
+                trace_payload("tool_call.repaired", body, variant="json_array")
                 objects.extend(value)
                 continue
             if not isinstance(value, dict):
@@ -470,6 +473,7 @@ class ToolCallStreamParser:
             objects.append(value)
         if len(objects) > 1:
             log_debug("tool_call.repaired", variant="packed_objects")
+            trace_payload("tool_call.repaired", body, variant="packed_objects")
         return objects
 
     def _decode_payload(self, body: str) -> list[Any] | None:
@@ -477,6 +481,7 @@ class ToolCallStreamParser:
             decoded = decoder.decode(body, self._allowed_tool_names)
             if decoded is not None:
                 log_debug("tool_call.repaired", variant=decoder.name)
+                trace_payload("tool_call.repaired", body, variant=decoder.name)
                 return list(decoded)
         return None
 

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from factory_droid_openai.attachments import AttachmentSet, extract_attachments
 from factory_droid_openai.dialects import (
@@ -18,7 +18,7 @@ from factory_droid_openai.dialects import (
 from factory_droid_openai.errors import ProtocolError, RequestTooLargeError
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import trace as log_trace
-from factory_droid_openai.payloadlog import trace_payload
+from factory_droid_openai.payloadlog import NULL_PAYLOAD_TRACER
 from factory_droid_openai.strictjson import decode_json_values, parse_strict_json
 
 if TYPE_CHECKING:
@@ -66,6 +66,10 @@ class ToolCallEmission:
 
 
 ProtocolEmission = TextEmission | ToolCallEmission
+
+
+class PayloadTrace(Protocol):
+    def __call__(self, event: str, payload: str, **fields: Any) -> None: ...
 
 
 def build_prompt(
@@ -250,10 +254,12 @@ class ToolCallStreamParser:
         *,
         require_tool_call: bool = False,
         max_tool_calls: int = 1,
+        trace_payload: PayloadTrace | None = None,
     ) -> None:
         self._allowed_tool_names = allowed_tool_names
         self._require_tool_call = require_tool_call
         self._max_tool_calls = max(1, max_tool_calls)
+        self._trace_payload: PayloadTrace = trace_payload or NULL_PAYLOAD_TRACER.trace
         self._text_tail = ""
         self._payload_chunks: list[str] = []
         self._payload_bytes = 0
@@ -452,7 +458,7 @@ class ToolCallStreamParser:
                     head=body[:_UNPARSED_HEAD_CHARS],
                     payload_bytes=len(body.encode("utf-8")),
                 )
-                trace_payload("tool_call.unparsed", body)
+                self._trace_payload("tool_call.unparsed", body)
                 raise ProtocolError(f"invalid tool-call JSON: {exc}") from exc
             values = decoded
         if not values:
@@ -465,7 +471,7 @@ class ToolCallStreamParser:
                 if not value or not all(isinstance(item, dict) for item in value):
                     raise ProtocolError("tool-call payload must be a JSON object")
                 log_debug("tool_call.repaired", variant="json_array")
-                trace_payload("tool_call.repaired", body, variant="json_array")
+                self._trace_payload("tool_call.repaired", body, variant="json_array")
                 objects.extend(value)
                 continue
             if not isinstance(value, dict):
@@ -473,7 +479,7 @@ class ToolCallStreamParser:
             objects.append(value)
         if len(objects) > 1:
             log_debug("tool_call.repaired", variant="packed_objects")
-            trace_payload("tool_call.repaired", body, variant="packed_objects")
+            self._trace_payload("tool_call.repaired", body, variant="packed_objects")
         return objects
 
     def _decode_payload(self, body: str) -> list[Any] | None:
@@ -481,7 +487,7 @@ class ToolCallStreamParser:
             decoded = decoder.decode(body, self._allowed_tool_names)
             if decoded is not None:
                 log_debug("tool_call.repaired", variant=decoder.name)
-                trace_payload("tool_call.repaired", body, variant=decoder.name)
+                self._trace_payload("tool_call.repaired", body, variant=decoder.name)
                 return list(decoded)
         return None
 

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from factory_droid_openai.attachments import AttachmentSet, extract_attachments
 from factory_droid_openai.dialects import (
@@ -22,7 +22,13 @@ from factory_droid_openai.payloadlog import NULL_PAYLOAD_TRACER
 from factory_droid_openai.strictjson import decode_json_values, parse_strict_json
 
 if TYPE_CHECKING:
+    from typing import Protocol
+
     from factory_droid_openai.models import ChatCompletionRequest, ToolDefinition
+
+    class PayloadTrace(Protocol):
+        def __call__(self, event: str, payload: str, **fields: Any) -> None: ...
+
 
 _MAX_TOOL_PAYLOAD_BYTES = 1_000_000
 _ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
@@ -66,10 +72,6 @@ class ToolCallEmission:
 
 
 ProtocolEmission = TextEmission | ToolCallEmission
-
-
-class PayloadTrace(Protocol):
-    def __call__(self, event: str, payload: str, **fields: Any) -> None: ...
 
 
 def build_prompt(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -232,6 +232,43 @@ def _client(app: Any) -> httpx.AsyncClient:
 
 
 @pytest.mark.asyncio
+async def test_apps_keep_payload_tracing_configuration_isolated(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    disabled_runner = FakeRunner([RunComplete(Usage())])
+    enabled_runner = FakeRunner([RunComplete(Usage())])
+    disabled_app = create_app(
+        Settings(workdir=tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: disabled_runner),
+    )
+    enabled_app = create_app(
+        Settings(
+            workdir=tmp_path,
+            trace_payloads="full",
+            trace_payload_file=trace_path,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: enabled_runner),
+    )
+
+    async with _client(disabled_app) as client:
+        disabled_response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(messages=[{"role": "user", "content": "do not trace"}]),
+        )
+    async with _client(enabled_app) as client:
+        enabled_response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(messages=[{"role": "user", "content": "trace this"}]),
+        )
+
+    assert disabled_response.status_code == 200
+    assert enabled_response.status_code == 200
+    records = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 1
+    assert "trace this" in records[0]["payload"]
+    assert "do not trace" not in records[0]["payload"]
+
+
+@pytest.mark.asyncio
 async def test_health_and_models(tmp_path: Path) -> None:
     runner = FakeRunner([])
     async with _client(_app(tmp_path, runner)) as client:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -486,13 +487,26 @@ def test_settings_trace_payloads_defaults_to_off(
     assert settings.trace_payload_file is None
 
 
-def test_settings_trace_payloads_defaults_file_to_workdir(
+def test_settings_trace_payloads_requires_explicit_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     _clear_environment(monkeypatch)
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
     monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_PAYLOADS", " FULL ")
+
+    with pytest.raises(ValueError, match="TRACE_FILE is required"):
+        Settings.from_env()
+
+
+def test_settings_trace_payloads_normalizes_mode_with_explicit_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_PAYLOADS", " FULL ")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_FILE", str(tmp_path / "trace.jsonl"))
 
     settings = Settings.from_env()
 
@@ -537,4 +551,35 @@ def test_settings_trace_file_rejects_missing_parent(
     monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_FILE", str(tmp_path / "missing" / "t.jsonl"))
 
     with pytest.raises(ValueError, match="parent directory does not exist"):
+        Settings.from_env()
+
+
+def test_settings_trace_file_rejects_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    existing = tmp_path / "traces"
+    existing.mkdir()
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_FILE", str(existing))
+
+    with pytest.raises(ValueError, match="must be a regular file"):
+        Settings.from_env()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_settings_trace_file_rejects_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    target = tmp_path / "target.jsonl"
+    target.write_text("", encoding="utf-8")
+    link = tmp_path / "trace.jsonl"
+    link.symlink_to(target)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_FILE", str(link))
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
         Settings.from_env()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,8 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_WARM_SESSIONS",
     "FACTORY_DROID_OPENAI_WARM_SESSION_TTL_SECONDS",
     "FACTORY_DROID_OPENAI_DETACHED_CLEANUP",
+    "FACTORY_DROID_OPENAI_TRACE_PAYLOADS",
+    "FACTORY_DROID_OPENAI_TRACE_FILE",
 )
 
 
@@ -469,3 +471,70 @@ def test_settings_ignore_blank_optional_values(
 
     assert settings.worktree is None
     assert settings.append_system_prompt_file is None
+
+
+def test_settings_trace_payloads_defaults_to_off(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+
+    settings = Settings.from_env()
+
+    assert settings.trace_payloads == "off"
+    assert settings.trace_payload_file is None
+
+
+def test_settings_trace_payloads_defaults_file_to_workdir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_PAYLOADS", " FULL ")
+
+    settings = Settings.from_env()
+
+    assert settings.trace_payloads == "full"
+    assert settings.trace_payload_file == (tmp_path / "trace.jsonl").resolve()
+
+
+def test_settings_trace_payloads_reads_explicit_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_PAYLOADS", "heads")
+    target = tmp_path / "custom.jsonl"
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_FILE", str(target))
+
+    settings = Settings.from_env()
+
+    assert settings.trace_payloads == "heads"
+    assert settings.trace_payload_file == target.resolve()
+
+
+def test_settings_trace_payloads_rejects_unknown_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_PAYLOADS", "everything")
+
+    with pytest.raises(ValueError, match="must be one of"):
+        Settings.from_env()
+
+
+def test_settings_trace_file_rejects_missing_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TRACE_FILE", str(tmp_path / "missing" / "t.jsonl"))
+
+    with pytest.raises(ValueError, match="parent directory does not exist"):
+        Settings.from_env()

--- a/tests/test_payloadlog.py
+++ b/tests/test_payloadlog.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from factory_droid_openai import payloadlog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing() -> None:
+    payloadlog.reset_payload_tracing()
+
+
+def _read_records(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_tracing_off_writes_nothing(tmp_path: Path) -> None:
+    payloadlog.configure_payload_tracing(mode="off", path=tmp_path / "trace.jsonl")
+    payloadlog.trace_payload("chat.prompt", "hello")
+    assert not (tmp_path / "trace.jsonl").exists()
+
+
+def test_full_mode_writes_redacted_payload(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    payloadlog.configure_payload_tracing(mode="full", path=path)
+    payloadlog.trace_payload("chat.prompt", "use key sk-abcdef123456 please")
+    (record,) = _read_records(path)
+    assert record["event"] == "chat.prompt"
+    assert record["mode"] == "full"
+    assert record["payload"] == "use key [REDACTED] please"
+    assert record["payload_sha256"] == hashlib.sha256(b"use key sk-abcdef123456 please").hexdigest()
+    assert record["payload_bytes"] == len(b"use key sk-abcdef123456 please")
+
+
+def test_heads_mode_truncates_and_hashes(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    payloadlog.configure_payload_tracing(mode="heads", path=path)
+    payload = "xy " * 2000
+    payloadlog.trace_payload("chat.prompt", payload)
+    (record,) = _read_records(path)
+    assert "payload" not in record
+    assert record["payload_head"] == payload[:2048]
+    assert record["payload_tail"] == payload[-1024:]
+    assert record["payload_sha256"] == hashlib.sha256(payload.encode()).hexdigest()
+
+
+def test_heads_mode_short_payload_has_no_tail(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    payloadlog.configure_payload_tracing(mode="heads", path=path)
+    payloadlog.trace_payload("chat.prompt", "short")
+    (record,) = _read_records(path)
+    assert record["payload_head"] == "short"
+    assert "payload_tail" not in record
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('"api_key": "supersecretvalue"', '"api_key": "[REDACTED]"'),
+        ("Authorization: Bearer abcdef1234567890", "Authorization: [REDACTED]"),
+        ("token=ghp_abcdef123456", "token=[REDACTED]"),
+        ("A" * 130, "[REDACTED]"),
+    ],
+)
+def test_redact_patterns(raw: str, expected: str) -> None:
+    assert payloadlog.redact(raw) == expected
+
+
+def test_extra_fields_pass_through(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    payloadlog.configure_payload_tracing(mode="heads", path=path)
+    payloadlog.trace_payload("tool_call.repaired", "{}", variant="json_array", skipped=None)
+    (record,) = _read_records(path)
+    assert record["variant"] == "json_array"
+    assert "skipped" not in record
+
+
+def test_configure_rejects_unknown_mode(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unsupported payload trace mode"):
+        payloadlog.configure_payload_tracing(mode="verbose", path=tmp_path / "t.jsonl")
+
+
+def test_configure_requires_path_when_enabled() -> None:
+    with pytest.raises(ValueError, match="requires a destination file"):
+        payloadlog.configure_payload_tracing(mode="full", path=None)
+
+
+def test_configure_rejects_missing_parent(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="directory does not exist"):
+        payloadlog.configure_payload_tracing(
+            mode="full",
+            path=tmp_path / "missing" / "trace.jsonl",
+        )
+
+
+def test_configure_replaces_previous_setup(tmp_path: Path) -> None:
+    first = tmp_path / "first.jsonl"
+    payloadlog.configure_payload_tracing(mode="full", path=first)
+    payloadlog.configure_payload_tracing(mode="off", path=None)
+    payloadlog.trace_payload("chat.prompt", "hello")
+    assert not first.exists()

--- a/tests/test_payloadlog.py
+++ b/tests/test_payloadlog.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import stat
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,49 +14,61 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.fixture(autouse=True)
-def _reset_tracing() -> None:
-    payloadlog.reset_payload_tracing()
-
-
 def _read_records(path: Path) -> list[dict[str, object]]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
 
 
 def test_tracing_off_writes_nothing(tmp_path: Path) -> None:
-    payloadlog.configure_payload_tracing(mode="off", path=tmp_path / "trace.jsonl")
-    payloadlog.trace_payload("chat.prompt", "hello")
+    tracer = payloadlog.configure_payload_tracing(mode="off", path=tmp_path / "trace.jsonl")
+    tracer.trace("chat.prompt", "hello")
     assert not (tmp_path / "trace.jsonl").exists()
 
 
 def test_full_mode_writes_redacted_payload(tmp_path: Path) -> None:
     path = tmp_path / "trace.jsonl"
-    payloadlog.configure_payload_tracing(mode="full", path=path)
-    payloadlog.trace_payload("chat.prompt", "use key sk-abcdef123456 please")
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+    raw = b"use key sk-abcdef123456 please"
+    tracer.trace("chat.prompt", raw.decode())
     (record,) = _read_records(path)
     assert record["event"] == "chat.prompt"
     assert record["mode"] == "full"
     assert record["payload"] == "use key [REDACTED] please"
-    assert record["payload_sha256"] == hashlib.sha256(b"use key sk-abcdef123456 please").hexdigest()
-    assert record["payload_bytes"] == len(b"use key sk-abcdef123456 please")
+    assert record["redacted_sha256"] == hashlib.sha256(b"use key [REDACTED] please").hexdigest()
+    assert record["redacted_sha256"] != hashlib.sha256(raw).hexdigest()
+    assert record["payload_bytes"] == len(raw)
+    assert "payload_truncated" not in record
+
+
+def test_full_mode_caps_oversized_payload(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+    payload = "zy " * 400_000
+
+    tracer.trace("chat.prompt", payload)
+
+    (record,) = _read_records(path)
+    assert len(payload) > 1_048_576
+    assert record["payload"] == payload[:1_048_576]
+    assert record["payload_truncated"] is True
+    assert record["payload_bytes"] == len(payload)
 
 
 def test_heads_mode_truncates_and_hashes(tmp_path: Path) -> None:
     path = tmp_path / "trace.jsonl"
-    payloadlog.configure_payload_tracing(mode="heads", path=path)
+    tracer = payloadlog.configure_payload_tracing(mode="heads", path=path)
     payload = "xy " * 2000
-    payloadlog.trace_payload("chat.prompt", payload)
+    tracer.trace("chat.prompt", payload)
     (record,) = _read_records(path)
     assert "payload" not in record
     assert record["payload_head"] == payload[:2048]
     assert record["payload_tail"] == payload[-1024:]
-    assert record["payload_sha256"] == hashlib.sha256(payload.encode()).hexdigest()
+    assert record["redacted_sha256"] == hashlib.sha256(payload.encode()).hexdigest()
 
 
 def test_heads_mode_short_payload_has_no_tail(tmp_path: Path) -> None:
     path = tmp_path / "trace.jsonl"
-    payloadlog.configure_payload_tracing(mode="heads", path=path)
-    payloadlog.trace_payload("chat.prompt", "short")
+    tracer = payloadlog.configure_payload_tracing(mode="heads", path=path)
+    tracer.trace("chat.prompt", "short")
     (record,) = _read_records(path)
     assert record["payload_head"] == "short"
     assert "payload_tail" not in record
@@ -65,7 +79,16 @@ def test_heads_mode_short_payload_has_no_tail(tmp_path: Path) -> None:
     [
         ('"api_key": "supersecretvalue"', '"api_key": "[REDACTED]"'),
         ("Authorization: Bearer abcdef1234567890", "Authorization: [REDACTED]"),
+        ("Authorization: ApiKey abcdef1234567890", "Authorization: [REDACTED]"),
+        ("password: correct horse battery staple", "password: [REDACTED]"),
+        ("Authorization: Basic dXNlcjpwYXNzd29yZA==", "Authorization: [REDACTED]"),
         ("token=ghp_abcdef123456", "token=[REDACTED]"),
+        (
+            '{"content":"{\\"password\\":\\"supersecretvalue\\"}"}',
+            '{"content":"{\\"password\\":\\"[REDACTED]\\"}"}',
+        ),
+        ('"access_token":"supersecretvalue"', '"access_token":"[REDACTED]"'),
+        ('"client_secret":"supersecretvalue"', '"client_secret":"[REDACTED]"'),
         ("A" * 130, "[REDACTED]"),
     ],
 )
@@ -73,13 +96,135 @@ def test_redact_patterns(raw: str, expected: str) -> None:
     assert payloadlog.redact(raw) == expected
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            '{"headers":"Authorization: Bearer abc","model":"gpt-5.4"}',
+            '{"headers":"Authorization: [REDACTED]","model":"gpt-5.4"}',
+        ),
+        (
+            '{"note":"password: hunter2","model":"gpt-5.4","keep":"this"}',
+            '{"note":"password: [REDACTED]","model":"gpt-5.4","keep":"this"}',
+        ),
+        ("?api_key=abcdef&model=gpt-5.4", "?api_key=[REDACTED]&model=gpt-5.4"),
+        ("token: abc; model: gpt-5.4", "token: [REDACTED]; model: gpt-5.4"),
+        ("{secret: abc}", "{secret: [REDACTED]}"),
+        ("[token: abc]", "[token: [REDACTED]]"),
+    ],
+)
+def test_redact_stops_at_delimiters(raw: str, expected: str) -> None:
+    assert payloadlog.redact(raw) == expected
+    assert payloadlog.redact(expected) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Authorization: Bearer abcdef1234567890",
+        "Authorization: Basic QUJDREVGZ2hpamtsZa==",
+        "token=abcdef1234567890",
+        "password: correct horse battery staple",
+        '"api_key": "supersecretvalue"',
+    ],
+)
+def test_redact_is_idempotent(raw: str) -> None:
+    once = payloadlog.redact(raw)
+
+    assert payloadlog.redact(once) == once
+
+
+def test_redact_keeps_trailing_fields_of_minified_prompt() -> None:
+    payload = json.dumps(
+        {
+            "messages": [{"role": "user", "content": "set authorization: Bearer abc header"}],
+            "model": "gpt-5.4",
+            "stream": True,
+        },
+    )
+
+    redacted = payloadlog.redact(payload)
+
+    assert "abc" not in redacted
+    assert json.loads(redacted)["model"] == "gpt-5.4"
+    assert json.loads(redacted)["stream"] is True
+
+
+def test_sequence_fields_are_redacted(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    tracer = payloadlog.configure_payload_tracing(mode="heads", path=path)
+
+    tracer.trace(
+        "tool_call.repaired",
+        "{}",
+        variants=["sk-abcdef123456", {"password": "metadata secret"}],
+        tried=("Bearer abcdef1234567890",),
+    )
+
+    (record,) = _read_records(path)
+    assert record["variants"] == ["[REDACTED]", {"password": "[REDACTED]"}]
+    assert record["tried"] == ["[REDACTED]"]
+
+
+def test_redact_nested_json_at_any_escape_depth() -> None:
+    raw = r'{"password":"prefix\"supersecretvalue"}'
+
+    for _ in range(5):
+        assert "supersecretvalue" not in payloadlog.redact(raw)
+        raw = json.dumps(raw)
+
+
 def test_extra_fields_pass_through(tmp_path: Path) -> None:
     path = tmp_path / "trace.jsonl"
-    payloadlog.configure_payload_tracing(mode="heads", path=path)
-    payloadlog.trace_payload("tool_call.repaired", "{}", variant="json_array", skipped=None)
+    tracer = payloadlog.configure_payload_tracing(mode="heads", path=path)
+    tracer.trace(
+        "tool_call.repaired",
+        "{}",
+        variant="json_array",
+        attempt=3,
+        recovered=True,
+        skipped=None,
+    )
     (record,) = _read_records(path)
     assert record["variant"] == "json_array"
+    assert record["attempt"] == 3
+    assert record["recovered"] is True
     assert "skipped" not in record
+
+
+def test_extra_fields_are_redacted_and_ascii_safe(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+
+    tracer.trace(
+        "chat.prompt",
+        "hello",
+        model="sk-abcdef123456",
+        password="ordinary metadata secret",
+        nested={
+            "authorization": "Bearer abcdef1234567890",
+            "client_secret": "another metadata secret",
+        },
+        unusual="\ud800",
+    )
+
+    (record,) = _read_records(path)
+    assert record["model"] == "[REDACTED]"
+    assert record["password"] == "[REDACTED]"
+    assert record["nested"] == {
+        "authorization": "[REDACTED]",
+        "client_secret": "[REDACTED]",
+    }
+    assert record["unusual"] == "\ud800"
+
+
+def test_unencodable_payload_does_not_escape(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+
+    tracer.trace("chat.prompt", "\ud800")
+
+    assert not path.exists()
 
 
 def test_configure_rejects_unknown_mode(tmp_path: Path) -> None:
@@ -100,9 +245,81 @@ def test_configure_rejects_missing_parent(tmp_path: Path) -> None:
         )
 
 
-def test_configure_replaces_previous_setup(tmp_path: Path) -> None:
+def test_tracers_keep_independent_configuration(tmp_path: Path) -> None:
     first = tmp_path / "first.jsonl"
-    payloadlog.configure_payload_tracing(mode="full", path=first)
-    payloadlog.configure_payload_tracing(mode="off", path=None)
-    payloadlog.trace_payload("chat.prompt", "hello")
-    assert not first.exists()
+    enabled = payloadlog.configure_payload_tracing(mode="full", path=first)
+    disabled = payloadlog.configure_payload_tracing(mode="off", path=None)
+    disabled.trace("chat.prompt", "ignored")
+    enabled.trace("chat.prompt", "hello")
+    (record,) = _read_records(first)
+    assert record["payload"] == "hello"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_trace_file_permissions_are_owner_only(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    path.write_text("", encoding="utf-8")
+    path.chmod(0o644)
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+
+    tracer.trace("chat.prompt", "private")
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_configure_rejects_directory(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must be a regular file"):
+        payloadlog.configure_payload_tracing(mode="full", path=tmp_path)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO unavailable")
+def test_configure_rejects_fifo(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    os.mkfifo(path)
+
+    with pytest.raises(ValueError, match="must be a regular file"):
+        payloadlog.configure_payload_tracing(mode="full", path=path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_configure_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("protected", encoding="utf-8")
+    link = tmp_path / "trace.jsonl"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        payloadlog.configure_payload_tracing(mode="full", path=link)
+
+    assert target.read_text(encoding="utf-8") == "protected"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
+def test_trace_io_failure_does_not_escape(tmp_path: Path) -> None:
+    destination = tmp_path / "traces"
+    destination.mkdir()
+    path = destination / "trace.jsonl"
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+    destination.chmod(0o500)
+
+    try:
+        tracer.trace("chat.prompt", "private")
+        assert not path.exists()
+    finally:
+        destination.chmod(0o700)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO unavailable")
+def test_trace_rejects_destination_swapped_after_validation(tmp_path: Path) -> None:
+    path = tmp_path / "trace.jsonl"
+    path.write_text("", encoding="utf-8")
+    tracer = payloadlog.configure_payload_tracing(mode="full", path=path)
+    path.unlink()
+    os.mkfifo(path)
+    reader = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+
+    try:
+        tracer.trace("chat.prompt", "private")
+        assert os.read(reader, 4096) == b""
+    finally:
+        os.close(reader)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -497,6 +498,41 @@ def test_stream_parser_repairs_arg_key_value_payload() -> None:
     assert len(emissions) == 1
     assert isinstance(emissions[0], ToolCallEmission)
     assert json.loads(emissions[0].arguments) == {"city": "Gdańsk", "days": 3}
+
+
+def test_stream_parser_uses_injected_payload_tracer() -> None:
+    traces: list[tuple[str, str, dict[str, Any]]] = []
+
+    def trace(event: str, payload: str, **fields: Any) -> None:
+        traces.append((event, payload, fields))
+
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=2,
+        trace_payload=trace,
+    )
+    payload = (
+        '{"name":"weather","arguments":{"city":"Gdansk"}}'
+        '{"name":"weather","arguments":{"city":"Sopot"}}'
+    )
+
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+    assert traces == [("tool_call.repaired", payload, {"variant": "packed_objects"})]
+
+
+def test_stream_parser_traces_unparsed_payload() -> None:
+    traces: list[tuple[str, str, dict[str, Any]]] = []
+
+    def trace(event: str, payload: str, **fields: Any) -> None:
+        traces.append((event, payload, fields))
+
+    parser = ToolCallStreamParser(frozenset({"weather"}), trace_payload=trace)
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}")
+
+    assert traces == [("tool_call.unparsed", "not json", {})]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds opt-in payload tracing that writes redacted prompts and tool-call payloads to a JSONL file, so model behavior (tool-call repairs, malformed payloads) can be analyzed without flooding the main log.

- New `payloadlog` module: JSONL writer, thread-safe, redaction always on (`sk-*`, `Bearer`, `api_key`/`token`/`secret`/`password` in JSON and `key=value`, long base64), sha256 + byte count on every record
- Config: `FACTORY_DROID_OPENAI_TRACE_PAYLOADS=off|heads|full` (default `off`), `FACTORY_DROID_OPENAI_TRACE_FILE` (default `<workdir>/trace.jsonl`)
- Events: `chat.prompt` (full prompt at prompt_built), `tool_call.repaired`/`tool_call.unparsed` with raw payload and repair variant
- `bridge.started` reports trace mode and destination
- Default `off` preserves the project rule of not logging private prompt content

## Validation

- ruff check + format: clean
- mypy strict: clean
- pytest: 516 passed, coverage 98.63% (>= 95% gate)
- uv lock --check + uv build: OK