### PR TITLE
fix(protocol): finish_reason=length on truncated tool calls

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -68,7 +68,8 @@
           "finish_reason": {
             "enum": [
               "stop",
-              "tool_calls"
+              "tool_calls",
+              "length"
             ],
             "title": "Finish Reason",
             "type": "string"
@@ -132,7 +133,7 @@
           },
           "n": {
             "default": 1,
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "N",
             "type": "integer"
           },
@@ -212,7 +213,7 @@
           "timeout": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
@@ -1100,6 +1101,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1129,16 +1140,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1205,6 +1206,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1234,16 +1245,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1318,6 +1319,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1347,16 +1358,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1433,6 +1434,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1462,16 +1473,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1538,6 +1539,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1567,16 +1578,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1643,6 +1644,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1672,16 +1683,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1735,6 +1736,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1764,16 +1775,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1848,6 +1849,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1877,16 +1888,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -49,6 +49,7 @@ from factory_droid_openai.models import (
 from factory_droid_openai.payloadlog import configure_payload_tracing
 from factory_droid_openai.pool import BackgroundReaper, WarmSessionPool
 from factory_droid_openai.protocol import (
+    IncompleteToolCallError,
     ProtocolEmission,
     ProtocolError,
     RequestTooLargeError,
@@ -1344,6 +1345,7 @@ class CollectedCompletion:
         self.completed = False
         self.session_id: str | None = None
         self.stopped = False
+        self.truncated = False
 
     @property
     def text(self) -> str:
@@ -1401,7 +1403,22 @@ async def _collect_completion(
             error_type="factory_incomplete_response",
         )
     if not result.stopped:
-        _apply_emissions(result, parser.finish(), stop_buffer)
+        try:
+            _apply_emissions(result, parser.finish(), stop_buffer)
+        except IncompleteToolCallError as exc:
+            # Same contract as the streaming path: a turn that died inside a
+            # tool-call payload returns completed output with
+            # finish_reason="length" instead of a 502. The partial call is
+            # dropped, never executed.
+            result.truncated = True
+            log_warning(
+                "chat.truncated",
+                stream=False,
+                error_type="factory_protocol_error",
+                reason=str(exc),
+                tool_name=exc.tool_name,
+                payload_bytes=exc.payload_bytes,
+            )
         held = stop_buffer.flush()
         if held:
             result.text_parts.append(held)
@@ -1638,6 +1655,33 @@ async def _stream_completion(
                     model,
                     delta={},
                     finish_reason="tool_calls" if saw_tool_call else "stop",
+                    include_usage=include_usage,
+                )
+            )
+            if include_usage:
+                yield _sse(_usage_chunk(request_id, created, model, usage))
+        except IncompleteToolCallError as exc:
+            # The turn died inside a tool-call payload. Surface it the way
+            # OpenAI surfaces a length cutoff - completed output plus
+            # finish_reason="length" - so clients continue instead of
+            # blind-retrying an unrecoverable request. The partial call is
+            # dropped, never executed.
+            outcome = "truncated"
+            log_warning(
+                "chat.truncated",
+                stream=True,
+                error_type="factory_protocol_error",
+                reason=str(exc),
+                tool_name=exc.tool_name,
+                payload_bytes=exc.payload_bytes,
+            )
+            yield _sse(
+                _chunk(
+                    request_id,
+                    created,
+                    model,
+                    delta={},
+                    finish_reason="length",
                     include_usage=include_usage,
                 )
             )
@@ -1986,10 +2030,15 @@ def _choice_dict(result: CollectedCompletion, index: int) -> dict[str, Any]:
         message["reasoning_content"] = result.reasoning
     if result.tool_calls:
         message["tool_calls"] = result.tool_calls
+    finish_reason = "stop"
+    if result.tool_calls:
+        finish_reason = "tool_calls"
+    elif result.truncated:
+        finish_reason = "length"
     return {
         "index": index,
         "message": message,
-        "finish_reason": "tool_calls" if result.tool_calls else "stop",
+        "finish_reason": finish_reason,
     }
 
 
@@ -2113,7 +2162,7 @@ def _request_outcome(status_code: int, scope: Scope) -> str:
     state = scope.get("state")
     if isinstance(state, dict):
         stream_outcome = state.get("stream_outcome")
-        if stream_outcome in {"success", "error", "timeout", "cancelled"}:
+        if stream_outcome in {"success", "error", "timeout", "cancelled", "truncated"}:
             return str(stream_outcome)
     if status_code < 400:
         return "success"

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1270,6 +1270,8 @@ def create_app(
                             499,
                             "client_disconnected",
                         )
+                    if result.truncated:
+                        request.state.stream_outcome = "truncated"
                     if result.session_id is not None:
                         sessions.remember(result.session_id)
                         started_session = result.session_id
@@ -1675,6 +1677,11 @@ async def _stream_completion(
                 tool_name=exc.tool_name,
                 payload_bytes=exc.payload_bytes,
             )
+            held = stop_buffer.flush()
+            if held:
+                chunk_payload = text_chunk(held)
+                if chunk_payload is not None:
+                    yield chunk_payload
             yield _sse(
                 _chunk(
                     request_id,
@@ -2031,10 +2038,10 @@ def _choice_dict(result: CollectedCompletion, index: int) -> dict[str, Any]:
     if result.tool_calls:
         message["tool_calls"] = result.tool_calls
     finish_reason = "stop"
-    if result.tool_calls:
-        finish_reason = "tool_calls"
-    elif result.truncated:
+    if result.truncated:
         finish_reason = "length"
+    elif result.tool_calls:
+        finish_reason = "tool_calls"
     return {
         "index": index,
         "message": message,

--- a/src/factory_droid_openai/errors.py
+++ b/src/factory_droid_openai/errors.py
@@ -7,3 +7,20 @@ class ProtocolError(ValueError):
 
 class RequestTooLargeError(ProtocolError):
     pass
+
+
+class IncompleteToolCallError(ProtocolError):
+    """The turn ended inside a tool-call payload that never reached its close marker.
+
+    Carries the guessed tool name and captured size so logs and clients can
+    tell what was truncated without re-parsing the raw payload.
+    """
+
+    def __init__(self, tool_name: str | None, payload_bytes: int) -> None:
+        self.tool_name = tool_name
+        self.payload_bytes = payload_bytes
+        detail = f"tool '{tool_name}'" if tool_name else "unknown tool"
+        super().__init__(
+            f"incomplete tool-call marker ({detail}, "
+            f"{payload_bytes} bytes captured before the stream ended)"
+        )

--- a/src/factory_droid_openai/models.py
+++ b/src/factory_droid_openai/models.py
@@ -88,7 +88,7 @@ class AssistantMessageResponse(BaseModel):
 class ChatCompletionChoice(BaseModel):
     index: int
     message: AssistantMessageResponse
-    finish_reason: Literal["stop", "tool_calls"]
+    finish_reason: Literal["stop", "tool_calls", "length"]
 
 
 class ChatCompletionResponse(BaseModel):

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -15,7 +16,11 @@ from factory_droid_openai.dialects import (
     find_open_marker,
     strip_code_fence,
 )
-from factory_droid_openai.errors import ProtocolError, RequestTooLargeError
+from factory_droid_openai.errors import (
+    IncompleteToolCallError,
+    ProtocolError,
+    RequestTooLargeError,
+)
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import trace as log_trace
 from factory_droid_openai.payloadlog import NULL_PAYLOAD_TRACER
@@ -38,6 +43,7 @@ __all__ = [
     "TOOL_CALL_CLOSE",
     "TOOL_CALL_OPEN",
     "AttachmentSet",
+    "IncompleteToolCallError",
     "PromptPlan",
     "ProtocolEmission",
     "ProtocolError",
@@ -293,7 +299,11 @@ class ToolCallStreamParser:
         if self._capturing:
             recovered = self._recover_unclosed_tool_call()
             if recovered is None:
-                raise ProtocolError("incomplete tool-call marker")
+                payload = "".join(self._payload_chunks) + self._close_tail
+                raise IncompleteToolCallError(
+                    tool_name=_guess_tool_name(payload, self._allowed_tool_names),
+                    payload_bytes=len(payload.encode("utf-8")),
+                )
             emissions.extend(self._emit_tool_calls(recovered))
         if self._text_tail:
             # After a tool call only whitespace may separate further calls; any
@@ -583,6 +593,27 @@ def _json_depth_exceeds(value: Any, max_depth: int) -> bool:
         children = current.values() if isinstance(current, dict) else current
         stack.extend((child, depth + 1) for child in children)
     return False
+
+
+_NAME_FIELD_PATTERN = re.compile(r'"name"\s*:\s*"([^"\\]+)"')
+_BARE_NAME_PATTERN = re.compile(r"^([A-Za-z_][\w.-]*)(?=\s*[{[]|\s*$)")
+
+
+def _guess_tool_name(payload: str, allowed_tool_names: frozenset[str]) -> str | None:
+    """Best-effort tool name for a truncated payload.
+
+    Handles the wrapped ``{"name": ...}`` form and the bare ``name{...}`` /
+    ``name\\n{...}`` form seen from GLM-family models. Only names from the
+    allowed set are reported, so a garbled prefix never masquerades as a tool.
+    """
+    match = _NAME_FIELD_PATTERN.search(payload[:256])
+    if match and match.group(1) in allowed_tool_names:
+        return match.group(1)
+    head = payload.strip().split("\n", 1)[0]
+    match = _BARE_NAME_PATTERN.match(head)
+    if match and match.group(1) in allowed_tool_names:
+        return match.group(1)
+    return None
 
 
 def _partial_marker_suffix_length(value: str, marker: str) -> int:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 import httpx
 import pytest
 from fastapi.exceptions import RequestValidationError
+from jsonschema.validators import validator_for
 
 from factory_droid_openai.app import (
     AdmissionController,
@@ -16,12 +17,17 @@ from factory_droid_openai.app import (
     FinalizingStreamingResponse,
     RequestSizeLimitMiddleware,
     SessionRegistry,
+    StructuredOutput,
+    _collect_completion,
     _collect_completion_or_disconnect,
     _content_length,
     _finalize_stream,
     _JsonDepthTracker,
+    _request_outcome,
+    _RequestPayloadLimitError,
     _stream_completion,
     _validation_message,
+    _wait_for_disconnect,
     create_app,
 )
 from factory_droid_openai.config import Settings
@@ -36,6 +42,8 @@ from factory_droid_openai.pool import BackgroundReaper
 from factory_droid_openai.protocol import (
     TOOL_CALL_CLOSE,
     TOOL_CALL_OPEN,
+    ProtocolEmission,
+    TextEmission,
     ToolCallStreamParser,
 )
 from factory_droid_openai.runner import (
@@ -1269,13 +1277,15 @@ async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> 
 async def test_streaming_truncated_tool_call_finishes_with_length(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
-            TextDelta("working on it"),
+            TextDelta("working on EN"),
             TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Kr'),
             RunComplete(Usage()),
         ]
     )
     payload = _payload(
         stream=True,
+        stream_options={"include_usage": True},
+        stop="END",
         tools=[
             {
                 "type": "function",
@@ -1295,13 +1305,20 @@ async def test_streaming_truncated_tool_call_finishes_with_length(tmp_path: Path
     chunks = [json.loads(event) for event in events if event.startswith("{")]
     assert not any("error" in chunk for chunk in chunks)
     assert events[-1] == "[DONE]"
-    assert chunks[-1]["choices"][0]["finish_reason"] == "length"
+    finish_chunk = next(
+        chunk
+        for chunk in chunks
+        if chunk["choices"] and chunk["choices"][0]["finish_reason"] is not None
+    )
+    assert finish_chunk["choices"][0]["finish_reason"] == "length"
+    assert chunks[-1]["choices"] == []
+    assert chunks[-1]["usage"]["total_tokens"] == 0
     content = "".join(
         choice["delta"].get("content") or ""
         for chunk in chunks
         for choice in chunk.get("choices", [])
     )
-    assert content == "working on it"
+    assert content == "working on EN"
     assert 'outcome="truncated",status="200"} 1' in metrics.text
 
 
@@ -1324,6 +1341,7 @@ async def test_non_streaming_truncated_tool_call_returns_length(tmp_path: Path) 
     )
     async with _client(_app(tmp_path, runner)) as client:
         response = await client.post("/v1/chat/completions", json=payload)
+        metrics = await client.get("/metrics")
 
     assert response.status_code == 200
     choice = response.json()["choices"][0]
@@ -1331,6 +1349,43 @@ async def test_non_streaming_truncated_tool_call_returns_length(tmp_path: Path) 
     assert choice["message"]["content"] == "partial answer"
     assert "tool_calls" not in choice["message"]
     assert runner.closed is True
+    assert 'outcome="truncated",status="200"} 1' in metrics.text
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_truncation_overrides_completed_tool_calls(tmp_path: Path) -> None:
+    complete = (
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}{TOOL_CALL_CLOSE}'
+    )
+    truncated = f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Kr'
+    runner = FakeRunner([TextDelta(complete + truncated), RunComplete(Usage())])
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ]
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert len(choice["message"]["tool_calls"]) == 1
+    assert choice["message"]["tool_calls"][0]["function"]["name"] == "weather"
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ({"stream_outcome": "truncated"}, "truncated"),
+        ({}, "success"),
+    ],
+)
+def test_request_outcome_handles_truncation(state: dict[str, str], expected: str) -> None:
+    assert _request_outcome(200, cast("Any", {"state": state})) == expected
 
 
 @pytest.mark.asyncio
@@ -1420,6 +1475,68 @@ async def test_stream_generator_flushes_a_partial_stop_sequence() -> None:
 
     assert any('"content":"keep "' in event for event in events)
     assert any('"content":"HA"' in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_handles_truncation_without_held_text() -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{'),
+            RunComplete(Usage()),
+        ]
+    )
+
+    events = await _collect_stream(
+        runner,
+        allowed_tool_names=frozenset({"weather"}),
+    )
+
+    assert any('"finish_reason":"length"' in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_drops_buffered_structured_output_on_truncation() -> None:
+    schema = {"type": "object"}
+    validator_class = validator_for(schema)
+    structured = StructuredOutput(
+        payload={"type": "json_schema", "schema": schema},
+        validator=validator_class(schema),
+        max_bytes=1024,
+    )
+    runner = FakeRunner(
+        [
+            TextDelta("partial EN"),
+            TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{'),
+            RunComplete(Usage()),
+        ]
+    )
+
+    events = await _collect_stream(
+        runner,
+        allowed_tool_names=frozenset({"weather"}),
+        stop_sequences=("END",),
+        structured=structured,
+    )
+
+    assert any('"finish_reason":"length"' in event for event in events)
+    assert not any('"content":"partial EN"' in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_emits_validated_structured_output() -> None:
+    schema = {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+    validator_class = validator_for(schema)
+    structured = StructuredOutput(
+        payload={"type": "json_schema", "schema": schema},
+        validator=validator_class(schema),
+        max_bytes=1024,
+    )
+    events = await _collect_stream(
+        FakeRunner([TextDelta('{"ok":true}'), RunComplete(Usage())]),
+        structured=structured,
+    )
+
+    assert any('"content":"{\\"ok\\":true}"' in event for event in events)
 
 
 @pytest.mark.asyncio
@@ -1551,12 +1668,59 @@ async def test_non_stream_disconnect_cancels_runner_cleanup() -> None:
     assert runner.closed is True
 
 
+@pytest.mark.asyncio
+async def test_collect_completion_applies_finish_emissions() -> None:
+    class FinishTextParser:
+        def feed(self, _chunk: str) -> list[ProtocolEmission]:
+            return []
+
+        def finish(self) -> list[ProtocolEmission]:
+            return [TextEmission("finished")]
+
+    result = await _collect_completion(
+        runner=cast("Any", FakeRunner([RunComplete(Usage())])),
+        run_request=RunRequest(
+            prompt="prompt",
+            model="factory-droid",
+            model_alias="factory-droid",
+            reasoning_effort=None,
+            timeout_seconds=30,
+        ),
+        parser=cast("Any", FinishTextParser()),
+    )
+
+    assert result.text == "finished"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_disconnect_ignores_request_messages() -> None:
+    messages = iter(
+        [
+            {"type": "http.request", "body": b"", "more_body": False},
+            {"type": "http.disconnect"},
+        ]
+    )
+
+    async def receive() -> Any:
+        return next(messages)
+
+    await _wait_for_disconnect(cast("Any", SimpleNamespace(receive=receive)))
+
+
+def test_request_payload_limit_error_preserves_message() -> None:
+    error = _RequestPayloadLimitError("too large")
+
+    assert error.message == "too large"
+    assert str(error) == "too large"
+
+
 async def _collect_stream(
     runner: FakeRunner,
     *,
     allowed_tool_names: frozenset[str] = frozenset(),
     include_usage: bool = False,
     stop_sequences: tuple[str, ...] = (),
+    structured: StructuredOutput | None = None,
 ) -> list[str]:
     metrics = BridgeMetrics()
     admission = AdmissionController(max_concurrency=1, max_queue_size=1, metrics=metrics)
@@ -1579,6 +1743,7 @@ async def _collect_stream(
             lease=lease,
             include_usage=include_usage,
             stop_sequences=stop_sequences,
+            structured=structured,
         )
     ]
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1266,6 +1266,74 @@ async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_streaming_truncated_tool_call_finishes_with_length(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("working on it"),
+            TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Kr'),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+        metrics = await client.get("/metrics")
+
+    events = [
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    chunks = [json.loads(event) for event in events if event.startswith("{")]
+    assert not any("error" in chunk for chunk in chunks)
+    assert events[-1] == "[DONE]"
+    assert chunks[-1]["choices"][0]["finish_reason"] == "length"
+    content = "".join(
+        choice["delta"].get("content") or ""
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+    )
+    assert content == "working on it"
+    assert 'outcome="truncated",status="200"} 1' in metrics.text
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_truncated_tool_call_returns_length(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("partial answer"),
+            TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Kr'),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ]
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"] == "partial answer"
+    assert "tool_calls" not in choice["message"]
+    assert runner.closed is True
+
+
+@pytest.mark.asyncio
 async def test_chat_endpoint_requires_configured_bearer_token(tmp_path: Path) -> None:
     runner = FakeRunner([RunComplete(Usage())])
     app = _app(tmp_path, runner, api_key="secret")

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -62,3 +62,7 @@ def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> Non
     ]
     request_schema = schema["components"]["schemas"]["ChatCompletionRequest"]
     assert "response_format" in request_schema["properties"]
+    finish_reasons = schema["components"]["schemas"]["ChatCompletionChoice"]["properties"][
+        "finish_reason"
+    ]["enum"]
+    assert set(finish_reasons) == {"stop", "tool_calls", "length"}

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -10,6 +10,7 @@ from factory_droid_openai.protocol import (
     _MAX_TOOL_PAYLOAD_BYTES,
     TOOL_CALL_CLOSE,
     TOOL_CALL_OPEN,
+    IncompleteToolCallError,
     ProtocolError,
     RequestTooLargeError,
     StopSequenceBuffer,
@@ -1498,6 +1499,43 @@ def test_unclosed_marker_without_tools_still_fails() -> None:
 
     with pytest.raises(ProtocolError, match="incomplete tool-call marker"):
         parser.finish()
+
+
+def test_truncated_tool_call_reports_name_and_size() -> None:
+    payload = '{"name":"weather","arguments":{"city":"Kr'
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    with pytest.raises(IncompleteToolCallError) as excinfo:
+        parser.finish()
+
+    assert excinfo.value.tool_name == "weather"
+    assert excinfo.value.payload_bytes == len(payload.encode("utf-8"))
+    assert "weather" in str(excinfo.value)
+    assert str(len(payload.encode("utf-8"))) in str(excinfo.value)
+    # Stays a ProtocolError so existing fail-closed handlers keep working.
+    assert isinstance(excinfo.value, ProtocolError)
+
+
+def test_truncated_tool_call_guesses_bare_name_form() -> None:
+    parser = ToolCallStreamParser(frozenset({"execute_code"}))
+    parser.feed(f'{TOOL_CALL_OPEN}execute_code{{"code":"from hermes')
+
+    with pytest.raises(IncompleteToolCallError) as excinfo:
+        parser.finish()
+
+    assert excinfo.value.tool_name == "execute_code"
+
+
+def test_truncated_tool_call_without_recognized_name_reports_none() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    parser.feed(f"{TOOL_CALL_OPEN}{{")
+
+    with pytest.raises(IncompleteToolCallError) as excinfo:
+        parser.finish()
+
+    assert excinfo.value.tool_name is None
+    assert excinfo.value.payload_bytes == 1
 
 
 def test_stream_parser_rejects_oversized_payload() -> None:


### PR DESCRIPTION
## Problem

A model turn that ended inside an unclosed tool-call payload (observed with GLM-5.2 via Baseten stopping mid-`execute_code` at ~9KB) raised a bare `ProtocolError("incomplete tool-call marker")`. Streaming clients received a hard SSE error and blind-retried the identical request, hitting the same truncation in a retry loop until failure.

## Changes

- New `IncompleteToolCallError(ProtocolError)` carrying `tool_name` (guessed from wrapped `{"name": ...}` and bare `name{...}` payload forms, restricted to the allowed tool set) and `payload_bytes`.
- Streaming path: emit completed output with `finish_reason="length"` (+ usage chunk when requested) instead of an error body. The partial tool call is dropped, never executed (fail-closed preserved).
- Non-streaming path: return HTTP 200 with `finish_reason="length"` on the choice instead of a 502.
- New `chat.truncated` warning log with `tool_name`/`payload_bytes`; metrics gain the `truncated` request outcome.

## Validation

- `ruff check`, `ruff format --check`, strict `mypy`: clean
- `pytest --cov`: 556 passed, 98.64% coverage (gate: 95%)
- `openapi-spec-validator openapi.json`: OK (no route/schema changes)
- `uv lock --check`, `uv build`: OK