### PR TITLE
feat: add anonymous aggregate telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 __pycache__/
 *.py[cod]
 dist/
+.wrangler/

--- a/README.md
+++ b/README.md
@@ -1148,7 +1148,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_LOG_LEVEL` | `info` | Bridge and Uvicorn log level |
 | `FACTORY_DROID_OPENAI_LOG_FORMAT` | `text` | Bridge log rendering: `text` or `json` |
 | `FACTORY_DROID_OPENAI_TELEMETRY` | `true` | Send anonymous aggregate usage telemetry |
-| `DO_NOT_TRACK` | unset | Set to `1` to disable telemetry |
+| `DO_NOT_TRACK` | unset | Any value other than `0` disables telemetry |
 | `FACTORY_DROID_OPENAI_TRACE_PAYLOADS` | `off` | Payload tracing: `off`, `heads`, or `full` |
 | `FACTORY_DROID_OPENAI_TRACE_FILE` | unset | Trace destination, required unless tracing is `off` |
 
@@ -1171,8 +1171,8 @@ matching server settings.
 Anonymous aggregate telemetry is enabled by default. The bridge sends a batch
 at startup, every 15 minutes, and during graceful shutdown to
 `https://telemetry.guziak.net/v1/events`. Sending runs outside request handling,
-uses a 500 ms timeout, keeps no retry queue on disk, and never fails a client
-request.
+gives up after 5 seconds (1 second during shutdown), keeps no retry queue on
+disk, and never fails a client request.
 
 Collected fields:
 
@@ -1187,9 +1187,15 @@ Collected fields:
 Telemetry never includes prompts, responses, model or tool names, tool
 arguments, attachment contents, file paths, environment variables, API keys,
 IP addresses, host User-Agent values, client timestamps, or a persistent
-installation identifier. Cloudflare processes connection metadata while
-serving the collector and uses the source IP for transient rate limiting, but
-the collector does not write it to the analytics dataset.
+installation identifier. The request body is built in
+[`src/factory_droid_openai/telemetry.py`](src/factory_droid_openai/telemetry.py),
+so every field the bridge sends can be verified from this repository.
+
+The collector runs behind Cloudflare, which processes connection metadata to
+serve the request, and the collector uses the source IP only for transient rate
+limiting rather than writing it to the analytics dataset. The collector is
+operated separately from this repository, so that part is a statement of
+operator policy rather than something this source tree can prove.
 
 Disable all telemetry before startup with either setting:
 

--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,8 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` | `0` | MCP initialization window before tool discovery |
 | `FACTORY_DROID_OPENAI_LOG_LEVEL` | `info` | Bridge and Uvicorn log level |
 | `FACTORY_DROID_OPENAI_LOG_FORMAT` | `text` | Bridge log rendering: `text` or `json` |
+| `FACTORY_DROID_OPENAI_TELEMETRY` | `true` | Send anonymous aggregate usage telemetry |
+| `DO_NOT_TRACK` | unset | Set to `1` to disable telemetry |
 | `FACTORY_DROID_OPENAI_TRACE_PAYLOADS` | `off` | Payload tracing: `off`, `heads`, or `full` |
 | `FACTORY_DROID_OPENAI_TRACE_FILE` | unset | Trace destination, required unless tracing is `off` |
 
@@ -1163,6 +1165,39 @@ usage: factory-droid-openai [-h] [--host HOST] [--port PORT]
 
 Environment variables define defaults. The command-line options override the
 matching server settings.
+
+### Anonymous usage telemetry
+
+Anonymous aggregate telemetry is enabled by default. The bridge sends a batch
+at startup, every 15 minutes, and during graceful shutdown to
+`https://telemetry.guziak.net/v1/events`. Sending runs outside request handling,
+uses a 500 ms timeout, keeps no retry queue on disk, and never fails a client
+request.
+
+Collected fields:
+
+- bridge version, Python major and minor version, operating system family, and
+  CPU architecture
+- route category, streaming mode, outcome category, request count, and aggregate
+  duration
+- counts for tools, structured output, attachments, reasoning effort, session
+  continuity, multiple choices, and warm-session use
+- aggregate warm-pool, model-discovery, quarantine, and forced-kill counters
+
+Telemetry never includes prompts, responses, model or tool names, tool
+arguments, attachment contents, file paths, environment variables, API keys,
+IP addresses, host User-Agent values, client timestamps, or a persistent
+installation identifier. Cloudflare processes connection metadata while
+serving the collector and uses the source IP for transient rate limiting, but
+the collector does not write it to the analytics dataset.
+
+Disable all telemetry before startup with either setting:
+
+```bash
+export FACTORY_DROID_OPENAI_TELEMETRY=false
+# or
+export DO_NOT_TRACK=1
+```
 
 ## Limits and metrics
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       # FACTORY_DROID_OPENAI_WARM_SESSIONS: "2"
       # FACTORY_DROID_OPENAI_TIMEOUT_SECONDS: "600"
       # FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS: "300"
+      # FACTORY_DROID_OPENAI_TELEMETRY: "false"
     # Optional: expose your project to Droid as /work. Read-only is safe
     # because Factory-native tools are disabled. Uncomment to mount a workdir.
     # volumes:

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1051,6 +1051,8 @@ def create_app(
         payload: ChatCompletionRequest,
         request: Request,
     ) -> JSONResponse | StreamingResponse:
+        # Requests rejected before the handler (validation, auth, request size)
+        # never reach this line, so they stay reported as "not_applicable".
         request.state.telemetry_mode = "stream" if payload.stream else "non_stream"
         timeout_seconds = min(
             payload.timeout or resolved_settings.timeout_seconds,

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -76,6 +76,7 @@ from factory_droid_openai.runner import (
     WarmSession,
     normalize_reasoning_effort,
 )
+from factory_droid_openai.telemetry import DEFAULT_TELEMETRY_ENDPOINT, TelemetryReporter
 
 if TYPE_CHECKING:
     from jsonschema.protocols import Validator
@@ -90,6 +91,7 @@ BearerCredentials = Annotated[
 # Warming happens off the request path, so it never needs the full request
 # timeout budget.
 _WARM_TIMEOUT_CEILING = 120.0
+_BRIDGE_VERSION = "1.4.1"  # x-release-please-version
 
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
@@ -559,6 +561,8 @@ class RequestSizeLimitMiddleware:
                 _request_outcome(status_code, scope),
                 status_code,
                 time.perf_counter() - started,
+                route=_request_route(scope),
+                mode=_request_mode(scope),
             )
 
 
@@ -629,6 +633,12 @@ def create_app(
         ttl_seconds=resolved_settings.warm_session_ttl_seconds,
         metrics=metrics,
     )
+    telemetry = TelemetryReporter(
+        metrics=metrics,
+        app_version=_BRIDGE_VERSION,
+        endpoint=DEFAULT_TELEMETRY_ENDPOINT,
+        enabled=resolved_settings.telemetry,
+    )
 
     @contextlib.asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
@@ -640,11 +650,13 @@ def create_app(
                 reasoning_effort=resolved_settings.reasoning_effort,
             ),
         )
+        telemetry.start()
         log_info(
             "bridge.started",
             warm_sessions=resolved_settings.warm_session_count(),
             max_concurrency=resolved_settings.max_concurrency,
             detached_cleanup=resolved_settings.detached_cleanup,
+            telemetry=telemetry.enabled,
             reasoning_effort=resolved_settings.reasoning_effort,
             trace_payloads=resolved_settings.trace_payloads,
             trace_payload_file=(
@@ -658,6 +670,7 @@ def create_app(
         finally:
             await pool.aclose()
             await reaper.drain()
+            await telemetry.close()
 
     application = FastAPI(
         lifespan=lifespan,
@@ -667,7 +680,7 @@ def create_app(
             "An unofficial compatibility bridge for OpenAI Chat Completions clients. "
             "The bridge runs one isolated Factory Droid session per request."
         ),
-        version="1.4.1",  # x-release-please-version
+        version=_BRIDGE_VERSION,
         license_info={
             "name": "Apache License 2.0",
             "identifier": "Apache-2.0",
@@ -700,6 +713,7 @@ def create_app(
     application.state.pool = pool
     application.state.reaper = reaper
     application.state.quarantine = quarantine
+    application.state.telemetry = telemetry
 
     async def require_auth(credentials: BearerCredentials) -> None:
         expected = resolved_settings.api_key
@@ -1037,6 +1051,7 @@ def create_app(
         payload: ChatCompletionRequest,
         request: Request,
     ) -> JSONResponse | StreamingResponse:
+        request.state.telemetry_mode = "stream" if payload.stream else "non_stream"
         timeout_seconds = min(
             payload.timeout or resolved_settings.timeout_seconds,
             resolved_settings.timeout_seconds,
@@ -1131,6 +1146,21 @@ def create_app(
             log_warning("chat.rejected", status=404, phase="model", model=payload.model)
             return _error_response(quarantined, 404, "model_not_found")
 
+        features: list[str] = []
+        if payload.tools:
+            features.append("tools")
+        if structured is not None:
+            features.append("structured_output")
+        if plan.attachments:
+            features.append("attachments")
+        if reasoning_effort is not None:
+            features.append("reasoning_effort")
+        if session_id is not None:
+            features.append("session_continuity")
+        if payload.n > 1:
+            features.append("multiple_choices")
+        metrics.record_features(tuple(features))
+
         created = int(time.time())
         run_request = RunRequest(
             prompt=plan.prompt,
@@ -1180,6 +1210,7 @@ def create_app(
         if session_id is None:
             warm_session = pool.acquire(run_request.session_key())
             if warm_session is not None:
+                metrics.record_features(("warm_session",))
                 run_request = replace(run_request, warm_session=warm_session)
 
         if payload.stream:
@@ -2182,6 +2213,32 @@ def _request_outcome(status_code: int, scope: Scope) -> str:
     if status_code in {408, 504}:
         return "timeout"
     return "error"
+
+
+def _request_route(scope: Scope) -> str:
+    path = str(scope.get("path", ""))
+    if path == "/health":
+        return "health"
+    if path == "/version":
+        return "version"
+    if path == "/metrics":
+        return "metrics"
+    if path == "/v1/models" or path.startswith("/v1/models/"):
+        return "models"
+    if path == "/v1/chat/completions":
+        return "chat_completions"
+    if path.startswith("/v1/factory/sessions/"):
+        return "session_operation"
+    return "other"
+
+
+def _request_mode(scope: Scope) -> str:
+    state = scope.get("state")
+    if isinstance(state, dict):
+        mode = state.get("telemetry_mode")
+        if mode in {"stream", "non_stream"}:
+            return str(mode)
+    return "not_applicable"
 
 
 def _observe_ttft(

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -56,6 +56,7 @@ class Settings:
     warm_sessions: int = -1
     warm_session_ttl_seconds: float = 600.0
     detached_cleanup: bool = True
+    telemetry: bool = True
     # Off by default: prompts and tool payloads are private user content.
     trace_payloads: str = "off"
     trace_payload_file: Path | None = None
@@ -111,6 +112,7 @@ class Settings:
             "FACTORY_DROID_OPENAI_DETACHED_CLEANUP",
             default=True,
         )
+        telemetry = _telemetry_enabled()
         max_queue_size = _non_negative_int(
             "FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE",
             default=8,
@@ -288,6 +290,7 @@ class Settings:
             warm_sessions=warm_sessions,
             warm_session_ttl_seconds=warm_session_ttl_seconds,
             detached_cleanup=detached_cleanup,
+            telemetry=telemetry,
             trace_payloads=trace_payloads,
             trace_payload_file=trace_payload_file,
         )
@@ -336,6 +339,12 @@ def _boolean(name: str, *, default: bool) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
     raise ValueError(f"{name} must be a boolean value")
+
+
+def _telemetry_enabled() -> bool:
+    if os.getenv("DO_NOT_TRACK", "").strip() == "1":
+        return False
+    return _boolean("FACTORY_DROID_OPENAI_TELEMETRY", default=True)
 
 
 def _choice(name: str, *, default: str, allowed: tuple[str, ...]) -> str:

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -342,7 +342,9 @@ def _boolean(name: str, *, default: bool) -> bool:
 
 
 def _telemetry_enabled() -> bool:
-    if os.getenv("DO_NOT_TRACK", "").strip() == "1":
+    # The DO_NOT_TRACK convention treats any value other than "0" as opt-out.
+    do_not_track = os.getenv("DO_NOT_TRACK", "").strip()
+    if do_not_track not in {"", "0"}:
         return False
     return _boolean("FACTORY_DROID_OPENAI_TELEMETRY", default=True)
 

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -2,6 +2,23 @@ from __future__ import annotations
 
 import threading
 from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RequestMetric:
+    route: str
+    outcome: str
+    mode: str
+    count: int
+    duration_ms_sum: int
+
+
+@dataclass(frozen=True, slots=True)
+class MetricsSnapshot:
+    requests: tuple[RequestMetric, ...]
+    features: tuple[tuple[str, int], ...]
+    internal: tuple[tuple[str, int], ...]
 
 
 class BridgeMetrics:
@@ -29,12 +46,32 @@ class BridgeMetrics:
         self._warm_misses = 0
         self._warm_failures = 0
         self._pending_reaps = 0
+        self._telemetry_requests: Counter[tuple[str, str, str]] = Counter()
+        self._telemetry_request_duration_seconds: dict[tuple[str, str, str], float] = {}
+        self._telemetry_features: Counter[str] = Counter()
 
-    def record_request(self, outcome: str, status_code: int, seconds: float) -> None:
+    def record_request(
+        self,
+        outcome: str,
+        status_code: int,
+        seconds: float,
+        *,
+        route: str,
+        mode: str,
+    ) -> None:
         with self._lock:
             self._request_totals[(outcome, status_code)] += 1
             self._request_duration_sum += max(0.0, seconds)
             self._request_duration_count += 1
+            key = (route, outcome, mode)
+            self._telemetry_requests[key] += 1
+            self._telemetry_request_duration_seconds[key] = (
+                self._telemetry_request_duration_seconds.get(key, 0.0) + max(0.0, seconds)
+            )
+
+    def record_features(self, features: tuple[str, ...]) -> None:
+        with self._lock:
+            self._telemetry_features.update(features)
 
     def observe_queue_wait(self, seconds: float) -> None:
         with self._lock:
@@ -99,6 +136,36 @@ class BridgeMetrics:
     def set_pending_reaps(self, count: int) -> None:
         with self._lock:
             self._pending_reaps = count
+
+    def telemetry_snapshot(self) -> MetricsSnapshot:
+        with self._lock:
+            requests = tuple(
+                RequestMetric(
+                    route=route,
+                    outcome=outcome,
+                    mode=mode,
+                    count=count,
+                    duration_ms_sum=round(
+                        self._telemetry_request_duration_seconds[(route, outcome, mode)] * 1000
+                    ),
+                )
+                for (route, outcome, mode), count in sorted(self._telemetry_requests.items())
+            )
+            features = tuple(sorted(self._telemetry_features.items()))
+            internal = tuple(
+                sorted(
+                    {
+                        "forced_kill": self._forced_kills,
+                        "model_discovery_failure": self._model_discovery_failures,
+                        "model_quarantine": self._model_quarantines,
+                        "warm_hit": self._warm_hits,
+                        "warm_miss": self._warm_misses,
+                        "warm_retune": self._warm_retunes,
+                        "warm_failure": self._warm_failures,
+                    }.items()
+                )
+            )
+        return MetricsSnapshot(requests=requests, features=features, internal=internal)
 
     def render(self) -> str:
         with self._lock:

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -56,8 +56,8 @@ class BridgeMetrics:
         status_code: int,
         seconds: float,
         *,
-        route: str,
-        mode: str,
+        route: str = "other",
+        mode: str = "not_applicable",
     ) -> None:
         with self._lock:
             self._request_totals[(outcome, status_code)] += 1

--- a/src/factory_droid_openai/telemetry.py
+++ b/src/factory_droid_openai/telemetry.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import platform
+import queue
+import sys
+import threading
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from typing import Literal, cast
+
+from factory_droid_openai.metrics import BridgeMetrics, MetricsSnapshot, RequestMetric
+
+DEFAULT_TELEMETRY_ENDPOINT = "https://telemetry.guziak.net/v1/events"
+DEFAULT_TELEMETRY_INTERVAL_SECONDS = 900.0
+DEFAULT_TELEMETRY_TIMEOUT_SECONDS = 0.5
+_MAX_EVENTS_PER_REQUEST = 25
+_MAX_EVENT_COUNT = 1_000_000
+_MAX_EVENT_DURATION_SUM_MS = 1_000_000_000_000
+
+TelemetryPost = Callable[[str, bytes, float], bool]
+SendResult = Literal["sent", "failed", "unknown"]
+
+
+class TelemetryReporter:
+    def __init__(
+        self,
+        *,
+        metrics: BridgeMetrics,
+        app_version: str,
+        endpoint: str,
+        enabled: bool,
+        interval_seconds: float = DEFAULT_TELEMETRY_INTERVAL_SECONDS,
+        timeout_seconds: float = DEFAULT_TELEMETRY_TIMEOUT_SECONDS,
+        post: TelemetryPost | None = None,
+    ) -> None:
+        self._metrics = metrics
+        self._app_version = app_version
+        self._endpoint = endpoint
+        self._enabled = enabled
+        self._interval_seconds = interval_seconds
+        self._timeout_seconds = timeout_seconds
+        self._post = post or _post
+        self._baseline = MetricsSnapshot(requests=(), features=(), internal=())
+        self._startup_pending = True
+        self._stop = asyncio.Event()
+        self._flush_lock = asyncio.Lock()
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def start(self) -> None:
+        if not self._enabled or self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def close(self) -> None:
+        if not self._enabled:
+            return
+        task = self._task
+        self._task = None
+        if task is not None:
+            self._stop.set()
+            await task
+        await self.flush()
+
+    async def flush(self) -> bool:
+        if not self._enabled:
+            return True
+        async with self._flush_lock:
+            snapshot = self._metrics.telemetry_snapshot()
+            events = _events_since(
+                self._baseline,
+                snapshot,
+                include_startup=self._startup_pending,
+            )
+            if not events:
+                return True
+            metadata = _runtime_metadata(self._app_version)
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + self._timeout_seconds
+            for batch in _event_batches(events):
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return False
+                payload = {
+                    **metadata,
+                    "events": batch,
+                }
+                body = json.dumps(
+                    payload,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                ).encode()
+                sent = await _post_with_deadline(
+                    self._post,
+                    self._endpoint,
+                    body,
+                    remaining,
+                )
+                if sent != "failed":
+                    self._baseline = _advance_snapshot(self._baseline, batch)
+                    if batch[0]["name"] == "bridge_started":
+                        self._startup_pending = False
+                if sent != "sent":
+                    return False
+            return True
+
+    async def _run(self) -> None:
+        while not self._stop.is_set():
+            await self.flush()
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(),
+                    timeout=self._interval_seconds,
+                )
+            except TimeoutError:
+                continue
+
+
+def _events_since(
+    baseline: MetricsSnapshot,
+    current: MetricsSnapshot,
+    *,
+    include_startup: bool,
+) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    if include_startup:
+        events.append({"name": "bridge_started", "count": 1})
+
+    previous_requests = {
+        (metric.route, metric.outcome, metric.mode): metric for metric in baseline.requests
+    }
+    for metric in current.requests:
+        key = (metric.route, metric.outcome, metric.mode)
+        previous = previous_requests.get(key)
+        previous_count = previous.count if previous is not None else 0
+        count = metric.count - previous_count
+        if count <= 0:
+            continue
+        previous_duration = previous.duration_ms_sum if previous is not None else 0
+        events.append(
+            {
+                "name": "request",
+                "route": metric.route,
+                "outcome": metric.outcome,
+                "mode": metric.mode,
+                "count": count,
+                "duration_ms_sum": max(0, metric.duration_ms_sum - previous_duration),
+            }
+        )
+
+    previous_features = dict(baseline.features)
+    for feature, total in current.features:
+        count = total - previous_features.get(feature, 0)
+        if count > 0:
+            events.append({"name": "feature", "feature": feature, "count": count})
+
+    previous_internal = dict(baseline.internal)
+    for metric_name, total in current.internal:
+        count = total - previous_internal.get(metric_name, 0)
+        if count > 0:
+            events.append({"name": "internal", "metric": metric_name, "count": count})
+    return events
+
+
+def _event_batches(events: list[dict[str, object]]) -> list[list[dict[str, object]]]:
+    batches: list[list[dict[str, object]]] = []
+    batch_keys: list[set[tuple[object, ...]]] = []
+    for event in events:
+        key = _event_key(event)
+        for part in _split_event(event):
+            for batch, keys in zip(batches, batch_keys, strict=True):
+                if len(batch) < _MAX_EVENTS_PER_REQUEST and key not in keys:
+                    batch.append(part)
+                    keys.add(key)
+                    break
+            else:
+                batches.append([part])
+                batch_keys.append({key})
+    return batches
+
+
+def _split_event(event: dict[str, object]) -> list[dict[str, object]]:
+    count = cast("int", event["count"])
+    duration = cast("int", event.get("duration_ms_sum", 0))
+    if count <= _MAX_EVENT_COUNT and duration <= _MAX_EVENT_DURATION_SUM_MS:
+        return [event]
+    duration = min(duration, count * _MAX_EVENT_DURATION_SUM_MS)
+    part_total = max(
+        (count + _MAX_EVENT_COUNT - 1) // _MAX_EVENT_COUNT,
+        (duration + _MAX_EVENT_DURATION_SUM_MS - 1) // _MAX_EVENT_DURATION_SUM_MS,
+    )
+    parts: list[dict[str, object]] = []
+    remaining_count = count
+    remaining_duration = duration
+    for remaining_parts in range(part_total, 0, -1):
+        part_count = min(
+            _MAX_EVENT_COUNT,
+            remaining_count - remaining_parts + 1,
+        )
+        part = {**event, "count": part_count}
+        if event["name"] == "request":
+            part_duration = min(
+                _MAX_EVENT_DURATION_SUM_MS,
+                (remaining_duration + remaining_parts - 1) // remaining_parts,
+            )
+            part["duration_ms_sum"] = part_duration
+            remaining_duration -= part_duration
+        parts.append(part)
+        remaining_count -= part_count
+    return parts
+
+
+def _event_key(event: dict[str, object]) -> tuple[object, ...]:
+    name = event["name"]
+    if name == "request":
+        return name, event["route"], event["outcome"], event["mode"]
+    if name == "feature":
+        return name, event["feature"]
+    if name == "internal":
+        return name, event["metric"]
+    return (name,)
+
+
+def _advance_snapshot(
+    baseline: MetricsSnapshot,
+    delivered: list[dict[str, object]],
+) -> MetricsSnapshot:
+    requests = {(metric.route, metric.outcome, metric.mode): metric for metric in baseline.requests}
+    features = dict(baseline.features)
+    internal = dict(baseline.internal)
+    for event in delivered:
+        name = event["name"]
+        count = cast("int", event["count"])
+        if name == "request":
+            route = cast("str", event["route"])
+            outcome = cast("str", event["outcome"])
+            mode = cast("str", event["mode"])
+            key = route, outcome, mode
+            previous = requests.get(key)
+            requests[key] = RequestMetric(
+                route=route,
+                outcome=outcome,
+                mode=mode,
+                count=(previous.count if previous is not None else 0) + count,
+                duration_ms_sum=(previous.duration_ms_sum if previous is not None else 0)
+                + cast("int", event["duration_ms_sum"]),
+            )
+        elif name == "feature":
+            feature = cast("str", event["feature"])
+            features[feature] = features.get(feature, 0) + count
+        elif name == "internal":
+            metric = cast("str", event["metric"])
+            internal[metric] = internal.get(metric, 0) + count
+    return MetricsSnapshot(
+        requests=tuple(
+            sorted(
+                requests.values(),
+                key=lambda metric: (metric.route, metric.outcome, metric.mode),
+            )
+        ),
+        features=tuple(sorted(features.items())),
+        internal=tuple(sorted(internal.items())),
+    )
+
+
+async def _post_with_deadline(
+    post: TelemetryPost,
+    endpoint: str,
+    body: bytes,
+    timeout_seconds: float,
+) -> SendResult:
+    loop = asyncio.get_running_loop()
+    result: queue.SimpleQueue[bool] = queue.SimpleQueue()
+
+    def send() -> None:
+        try:
+            sent = post(endpoint, body, timeout_seconds)
+        except Exception:
+            sent = False
+        result.put(sent)
+
+    thread = threading.Thread(
+        target=send,
+        name="factory-droid-openai-telemetry",
+        daemon=True,
+    )
+    try:
+        thread.start()
+    except Exception:
+        return "failed"
+    deadline = loop.time() + timeout_seconds
+    while True:
+        try:
+            return "sent" if result.get_nowait() else "failed"
+        except queue.Empty:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return "unknown"
+            await asyncio.sleep(min(0.01, remaining))
+
+
+def _runtime_metadata(app_version: str) -> dict[str, object]:
+    operating_system = {
+        "Darwin": "darwin",
+        "Linux": "linux",
+        "Windows": "windows",
+    }.get(platform.system(), "other")
+    architecture = {
+        "aarch64": "arm64",
+        "amd64": "x86_64",
+        "arm64": "arm64",
+        "x86_64": "x86_64",
+    }.get(platform.machine().lower(), "other")
+    return {
+        "schema": 1,
+        "app_version": app_version,
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "os": operating_system,
+        "arch": architecture,
+    }
+
+
+def _post(endpoint: str, body: bytes, timeout_seconds: float) -> bool:
+    try:
+        if urllib.parse.urlsplit(endpoint).scheme != "https":
+            return False
+        request = urllib.request.Request(  # noqa: S310 - HTTPS is required above.
+            endpoint,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "factory-droid-openai-telemetry/1",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(  # noqa: S310 - Request URL is HTTPS.
+            request,
+            timeout=timeout_seconds,
+        ) as response:
+            return bool(response.status == 204)
+    except (OSError, ValueError):
+        return False

--- a/src/factory_droid_openai/telemetry.py
+++ b/src/factory_droid_openai/telemetry.py
@@ -1,21 +1,29 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import platform
-import queue
 import sys
 import threading
 import urllib.parse
 import urllib.request
 from collections.abc import Callable
-from typing import Literal, cast
+from typing import IO, TYPE_CHECKING, Literal, cast
 
 from factory_droid_openai.metrics import BridgeMetrics, MetricsSnapshot, RequestMetric
 
+if TYPE_CHECKING:
+    from http.client import HTTPMessage
+
 DEFAULT_TELEMETRY_ENDPOINT = "https://telemetry.guziak.net/v1/events"
 DEFAULT_TELEMETRY_INTERVAL_SECONDS = 900.0
-DEFAULT_TELEMETRY_TIMEOUT_SECONDS = 0.5
+# Reporting runs off the request path, so the budget only has to stay well below
+# the reporting interval. A tighter budget mostly discards cold DNS and TLS
+# handshakes, which silently drops the batch.
+DEFAULT_TELEMETRY_TIMEOUT_SECONDS = 5.0
+# Shutdown blocks on the final batch, so it gets a much smaller budget.
+DEFAULT_TELEMETRY_SHUTDOWN_TIMEOUT_SECONDS = 1.0
 _MAX_EVENTS_PER_REQUEST = 25
 _MAX_EVENT_COUNT = 1_000_000
 _MAX_EVENT_DURATION_SUM_MS = 1_000_000_000_000
@@ -34,6 +42,7 @@ class TelemetryReporter:
         enabled: bool,
         interval_seconds: float = DEFAULT_TELEMETRY_INTERVAL_SECONDS,
         timeout_seconds: float = DEFAULT_TELEMETRY_TIMEOUT_SECONDS,
+        shutdown_timeout_seconds: float = DEFAULT_TELEMETRY_SHUTDOWN_TIMEOUT_SECONDS,
         post: TelemetryPost | None = None,
     ) -> None:
         self._metrics = metrics
@@ -42,6 +51,7 @@ class TelemetryReporter:
         self._enabled = enabled
         self._interval_seconds = interval_seconds
         self._timeout_seconds = timeout_seconds
+        self._shutdown_timeout_seconds = shutdown_timeout_seconds
         self._post = post or _post
         self._baseline = MetricsSnapshot(requests=(), features=(), internal=())
         self._startup_pending = True
@@ -65,10 +75,16 @@ class TelemetryReporter:
         self._task = None
         if task is not None:
             self._stop.set()
-            await task
-        await self.flush()
+            # A periodic batch may be mid-flight, and shutdown must not inherit
+            # the much larger periodic budget.
+            done, _pending = await asyncio.wait({task}, timeout=self._shutdown_timeout_seconds)
+            if not done:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        await self.flush(timeout_seconds=self._shutdown_timeout_seconds)
 
-    async def flush(self) -> bool:
+    async def flush(self, *, timeout_seconds: float | None = None) -> bool:
         if not self._enabled:
             return True
         async with self._flush_lock:
@@ -82,7 +98,8 @@ class TelemetryReporter:
                 return True
             metadata = _runtime_metadata(self._app_version)
             loop = asyncio.get_running_loop()
-            deadline = loop.time() + self._timeout_seconds
+            budget = self._timeout_seconds if timeout_seconds is None else timeout_seconds
+            deadline = loop.time() + budget
             for batch in _event_batches(events):
                 remaining = deadline - loop.time()
                 if remaining <= 0:
@@ -103,16 +120,23 @@ class TelemetryReporter:
                     remaining,
                 )
                 if sent != "failed":
+                    # A timed-out send may still land, so counters advance to keep
+                    # aggregates from double counting.
                     self._baseline = _advance_snapshot(self._baseline, batch)
-                    if batch[0]["name"] == "bridge_started":
-                        self._startup_pending = False
+                if sent == "sent" and _contains_startup(batch):
+                    # Startup is the one event that must arrive, so an uncertain
+                    # send keeps it queued for the next batch.
+                    self._startup_pending = False
                 if sent != "sent":
                     return False
             return True
 
     async def _run(self) -> None:
         while not self._stop.is_set():
-            await self.flush()
+            # Reporting is best effort and shutdown awaits this task, so a
+            # reporting failure must not escape.
+            with contextlib.suppress(Exception):
+                await self.flush()
             try:
                 await asyncio.wait_for(
                     self._stop.wait(),
@@ -166,6 +190,10 @@ def _events_since(
         if count > 0:
             events.append({"name": "internal", "metric": metric_name, "count": count})
     return events
+
+
+def _contains_startup(batch: list[dict[str, object]]) -> bool:
+    return any(event["name"] == "bridge_started" for event in batch)
 
 
 def _event_batches(events: list[dict[str, object]]) -> list[list[dict[str, object]]]:
@@ -276,14 +304,16 @@ async def _post_with_deadline(
     timeout_seconds: float,
 ) -> SendResult:
     loop = asyncio.get_running_loop()
-    result: queue.SimpleQueue[bool] = queue.SimpleQueue()
+    delivered: asyncio.Future[bool] = loop.create_future()
 
     def send() -> None:
         try:
             sent = post(endpoint, body, timeout_seconds)
         except Exception:
             sent = False
-        result.put(sent)
+        # The loop can already be closed once a timed-out send returns.
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(delivered.set_result, sent)
 
     thread = threading.Thread(
         target=send,
@@ -294,15 +324,10 @@ async def _post_with_deadline(
         thread.start()
     except Exception:
         return "failed"
-    deadline = loop.time() + timeout_seconds
-    while True:
-        try:
-            return "sent" if result.get_nowait() else "failed"
-        except queue.Empty:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return "unknown"
-            await asyncio.sleep(min(0.01, remaining))
+    done, _pending = await asyncio.wait({delivered}, timeout=timeout_seconds)
+    if not done:
+        return "unknown"
+    return "sent" if delivered.result() else "failed"
 
 
 def _runtime_metadata(app_version: str) -> dict[str, object]:
@@ -326,6 +351,25 @@ def _runtime_metadata(app_version: str) -> dict[str, object]:
     }
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuses redirects so a redirect can never downgrade the transport."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirectHandler())
+
+
 def _post(endpoint: str, body: bytes, timeout_seconds: float) -> bool:
     try:
         if urllib.parse.urlsplit(endpoint).scheme != "https":
@@ -339,10 +383,7 @@ def _post(endpoint: str, body: bytes, timeout_seconds: float) -> bool:
             },
             method="POST",
         )
-        with urllib.request.urlopen(  # noqa: S310 - Request URL is HTTPS.
-            request,
-            timeout=timeout_seconds,
-        ) as response:
-            return bool(response.status == 204)
+        with _OPENER.open(request, timeout=timeout_seconds) as response:
+            return 200 <= int(response.status) < 300
     except (OSError, ValueError):
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from factory_droid_openai import telemetry
+
+
+@pytest.fixture(autouse=True)
+def block_telemetry_network(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Fails tests that reach the collector instead of disabling or stubbing telemetry."""
+    attempts: list[str] = []
+
+    class _RefusingOpener:
+        def open(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            attempts.append("opener")
+            raise AssertionError("telemetry opened a connection to the collector")
+
+    def _refusing_post(endpoint: str, body: bytes, timeout_seconds: float) -> bool:
+        del endpoint, body, timeout_seconds
+        attempts.append("post")
+        return False
+
+    monkeypatch.setattr(telemetry, "_OPENER", _RefusingOpener())
+    monkeypatch.setattr(telemetry, "_post", _refusing_post)
+    yield
+    assert not attempts, (
+        "telemetry used the real sender: disable telemetry in the settings or "
+        f"pass a stub sender (reached: {sorted(set(attempts))})"
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.exceptions import RequestValidationError
 from jsonschema.validators import validator_for
 
+from factory_droid_openai import telemetry as telemetry_module
 from factory_droid_openai.app import (
     AdmissionController,
     AdmissionLease,
@@ -23,7 +24,9 @@ from factory_droid_openai.app import (
     _content_length,
     _finalize_stream,
     _JsonDepthTracker,
+    _request_mode,
     _request_outcome,
+    _request_route,
     _RequestPayloadLimitError,
     _stream_completion,
     _validation_message,
@@ -1386,6 +1389,15 @@ async def test_non_streaming_truncation_overrides_completed_tool_calls(tmp_path:
 )
 def test_request_outcome_handles_truncation(state: dict[str, str], expected: str) -> None:
     assert _request_outcome(200, cast("Any", {"state": state})) == expected
+
+
+def test_request_telemetry_classifies_routes_and_modes() -> None:
+    assert _request_route(cast("Any", {"path": "/health"})) == "health"
+    assert _request_route(cast("Any", {"path": "/v1/models/gpt-test"})) == "models"
+    assert _request_route(cast("Any", {"path": "/unknown"})) == "other"
+    assert (
+        _request_mode(cast("Any", {"state": {"telemetry_mode": "unexpected"}})) == "not_applicable"
+    )
 
 
 @pytest.mark.asyncio
@@ -2753,6 +2765,7 @@ async def test_lifespan_prewarms_and_drains_the_pool(tmp_path: Path) -> None:
         workdir=tmp_path,
         timeout_seconds=30.0,
         max_concurrency=1,
+        telemetry=False,
     )
     app = create_app(settings, runner_factory=cast("RunnerFactory", lambda: runner))
 
@@ -2774,12 +2787,77 @@ async def test_detached_cleanup_can_be_disabled(tmp_path: Path) -> None:
         timeout_seconds=30.0,
         warm_sessions=0,
         detached_cleanup=False,
+        telemetry=False,
     )
     app = create_app(settings)
 
     assert app.state.pool.enabled is False
     async with app.router.lifespan_context(app):
         assert "factory_droid_openai_warm_sessions 0" in app.state.metrics.render()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_flushes_anonymous_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payloads: list[dict[str, object]] = []
+
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        payloads.append(json.loads(body))
+        return True
+
+    monkeypatch.setattr(telemetry_module, "_post", post)
+    runner = FakeRunner([RunComplete(Usage())])
+    app = create_app(
+        Settings(
+            droid_path="droid",
+            workdir=tmp_path,
+            timeout_seconds=30.0,
+            warm_sessions=0,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+    async with app.router.lifespan_context(app):
+        async with _client(app) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                json=_payload(
+                    reasoning_effort="low",
+                    n=2,
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {"name": "weather", "parameters": {}},
+                        }
+                    ],
+                ),
+            )
+        assert response.status_code == 200
+
+    events = [
+        event
+        for payload in payloads
+        for event in cast("list[dict[str, object]]", payload["events"])
+    ]
+    assert {"name": "bridge_started", "count": 1} in events
+    request_events = [event for event in events if event["name"] == "request"]
+    assert len(request_events) == 1
+    assert request_events[0] | {"duration_ms_sum": 0} == {
+        "name": "request",
+        "route": "chat_completions",
+        "outcome": "success",
+        "mode": "non_stream",
+        "count": 1,
+        "duration_ms_sum": 0,
+    }
+    assert isinstance(request_events[0]["duration_ms_sum"], int)
+    assert {"name": "feature", "feature": "tools", "count": 1} in events
+    assert {"name": "feature", "feature": "reasoning_effort", "count": 1} in events
+    assert {"name": "feature", "feature": "multiple_choices", "count": 1} in events
+    assert "Hello" not in json.dumps(payloads)
+    assert "factory-droid" not in json.dumps(payloads)
 
 
 @pytest.mark.asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -460,16 +460,31 @@ def test_settings_telemetry_can_be_disabled(
     assert Settings.from_env().telemetry is False
 
 
+@pytest.mark.parametrize("raw", ["1", "true", "yes", " on "])
 def test_do_not_track_overrides_telemetry_configuration(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    raw: str,
 ) -> None:
     _clear_environment(monkeypatch)
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
     monkeypatch.setenv("FACTORY_DROID_OPENAI_TELEMETRY", "invalid")
-    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setenv("DO_NOT_TRACK", raw)
 
     assert Settings.from_env().telemetry is False
+
+
+@pytest.mark.parametrize("raw", ["", " ", "0"])
+def test_do_not_track_leaves_telemetry_configuration_alone(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    raw: str,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("DO_NOT_TRACK", raw)
+
+    assert Settings.from_env().telemetry is True
 
 
 def test_settings_reject_non_boolean_continuity_flag(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,8 +51,10 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_WARM_SESSIONS",
     "FACTORY_DROID_OPENAI_WARM_SESSION_TTL_SECONDS",
     "FACTORY_DROID_OPENAI_DETACHED_CLEANUP",
+    "FACTORY_DROID_OPENAI_TELEMETRY",
     "FACTORY_DROID_OPENAI_TRACE_PAYLOADS",
     "FACTORY_DROID_OPENAI_TRACE_FILE",
+    "DO_NOT_TRACK",
 )
 
 
@@ -433,6 +435,41 @@ def test_settings_parse_boolean_flags(
     monkeypatch.setenv("FACTORY_DROID_OPENAI_SESSION_CONTINUITY", raw)
 
     assert Settings.from_env().session_continuity is expected
+
+
+def test_settings_telemetry_defaults_to_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+
+    assert Settings.from_env().telemetry is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "no", "off"])
+def test_settings_telemetry_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    raw: str,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TELEMETRY", raw)
+
+    assert Settings.from_env().telemetry is False
+
+
+def test_do_not_track_overrides_telemetry_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TELEMETRY", "invalid")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+
+    assert Settings.from_env().telemetry is False
 
 
 def test_settings_reject_non_boolean_continuity_flag(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import Any, cast
+
+import pytest
+
+from factory_droid_openai.metrics import BridgeMetrics, MetricsSnapshot, RequestMetric
+from factory_droid_openai.telemetry import (
+    TelemetryReporter,
+    _event_batches,
+    _events_since,
+    _post,
+    _runtime_metadata,
+)
+
+
+def test_metrics_snapshot_contains_only_telemetry_dimensions() -> None:
+    metrics = BridgeMetrics()
+    metrics.record_request(
+        "success",
+        200,
+        1.25,
+        route="chat_completions",
+        mode="stream",
+    )
+    metrics.record_request(
+        "error",
+        500,
+        -1,
+        route="models",
+        mode="not_applicable",
+    )
+    for _ in range(2):
+        metrics.record_request(
+            "success",
+            200,
+            0.0004,
+            route="health",
+            mode="not_applicable",
+        )
+    metrics.record_features(("tools", "attachments", "tools"))
+    metrics.increment_forced_kills()
+    metrics.increment_model_discovery_failures()
+    metrics.increment_model_quarantines()
+    metrics.increment_warm_hits()
+    metrics.increment_warm_misses()
+    metrics.increment_warm_retunes()
+    metrics.increment_warm_failures()
+
+    snapshot = metrics.telemetry_snapshot()
+
+    assert snapshot.requests == (
+        RequestMetric("chat_completions", "success", "stream", 1, 1250),
+        RequestMetric("health", "success", "not_applicable", 2, 1),
+        RequestMetric("models", "error", "not_applicable", 1, 0),
+    )
+    assert snapshot.features == (("attachments", 1), ("tools", 2))
+    assert snapshot.internal == (
+        ("forced_kill", 1),
+        ("model_discovery_failure", 1),
+        ("model_quarantine", 1),
+        ("warm_failure", 1),
+        ("warm_hit", 1),
+        ("warm_miss", 1),
+        ("warm_retune", 1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reporter_sends_startup_and_metric_deltas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("factory_droid_openai.telemetry.platform.system", lambda: "Darwin")
+    monkeypatch.setattr("factory_droid_openai.telemetry.platform.machine", lambda: "arm64")
+    metrics = BridgeMetrics()
+    sent: list[tuple[str, dict[str, object], float]] = []
+
+    def post(endpoint: str, body: bytes, timeout: float) -> bool:
+        sent.append((endpoint, json.loads(body), timeout))
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=metrics,
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        post=post,
+    )
+
+    assert reporter.enabled is True
+    assert await reporter.flush() is True
+    metrics.record_request(
+        "success",
+        200,
+        0.25,
+        route="chat_completions",
+        mode="non_stream",
+    )
+    metrics.record_features(("tools",))
+    metrics.increment_warm_hits()
+    assert await reporter.flush() is True
+    assert await reporter.flush() is True
+
+    assert len(sent) == 2
+    endpoint, startup, timeout = sent[0]
+    assert endpoint == "https://telemetry.example/v1/events"
+    assert 0 < timeout <= 0.5
+    assert startup == {
+        "schema": 1,
+        "app_version": "1.5.0",
+        "python_version": _runtime_metadata("unused")["python_version"],
+        "os": "darwin",
+        "arch": "arm64",
+        "events": [{"name": "bridge_started", "count": 1}],
+    }
+    assert sent[1][1]["events"] == [
+        {
+            "name": "request",
+            "route": "chat_completions",
+            "outcome": "success",
+            "mode": "non_stream",
+            "count": 1,
+            "duration_ms_sum": 250,
+        },
+        {"name": "feature", "feature": "tools", "count": 1},
+        {"name": "internal", "metric": "warm_hit", "count": 1},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reporter_retries_failed_batch_without_advancing_baseline() -> None:
+    attempts: list[dict[str, object]] = []
+
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        attempts.append(json.loads(body))
+        return len(attempts) > 1
+
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        post=post,
+    )
+
+    assert await reporter.flush() is False
+    assert await reporter.flush() is True
+
+    assert [attempt["events"] for attempt in attempts] == [
+        [{"name": "bridge_started", "count": 1}],
+        [{"name": "bridge_started", "count": 1}],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reporter_swallows_sender_exceptions() -> None:
+    def post(_endpoint: str, _body: bytes, _timeout: float) -> bool:
+        raise RuntimeError("sender failed")
+
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        post=post,
+    )
+
+    assert await reporter.flush() is False
+
+
+@pytest.mark.asyncio
+async def test_reporter_bounds_sender_deadline() -> None:
+    release = threading.Event()
+    calls = 0
+
+    def post(_endpoint: str, _body: bytes, _timeout: float) -> bool:
+        nonlocal calls
+        calls += 1
+        release.wait()
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        timeout_seconds=0.01,
+        post=post,
+    )
+    started_at = asyncio.get_running_loop().time()
+
+    assert await reporter.flush() is False
+    assert asyncio.get_running_loop().time() - started_at < 0.1
+    release.set()
+    await asyncio.sleep(0)
+    assert await reporter.flush() is True
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_reporter_applies_one_deadline_to_all_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics = BridgeMetrics()
+    monkeypatch.setattr(
+        metrics,
+        "telemetry_snapshot",
+        lambda: MetricsSnapshot(
+            requests=(),
+            features=(("tools", 2_000_001),),
+            internal=(),
+        ),
+    )
+    timeouts: list[float] = []
+
+    def post(_endpoint: str, _body: bytes, timeout: float) -> bool:
+        timeouts.append(timeout)
+        time.sleep(0.03)
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=metrics,
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        timeout_seconds=0.05,
+        post=post,
+    )
+    started_at = asyncio.get_running_loop().time()
+
+    assert await reporter.flush() is False
+    assert asyncio.get_running_loop().time() - started_at < 0.1
+    assert len(timeouts) == 2
+    assert timeouts[1] < timeouts[0]
+
+
+@pytest.mark.asyncio
+async def test_reporter_swallows_thread_start_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_start(_thread: threading.Thread) -> None:
+        raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(threading.Thread, "start", fail_start)
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+    )
+
+    assert await reporter.flush() is False
+
+
+@pytest.mark.asyncio
+async def test_reporter_skips_send_after_expired_deadline() -> None:
+    calls = 0
+
+    def post(_endpoint: str, _body: bytes, _timeout: float) -> bool:
+        nonlocal calls
+        calls += 1
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        timeout_seconds=0,
+        post=post,
+    )
+
+    assert await reporter.flush() is False
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_reporter_chunks_batches_and_keeps_failed_chunk_pending() -> None:
+    metrics = BridgeMetrics()
+    routes = (
+        "health",
+        "version",
+        "metrics",
+        "models",
+        "chat_completions",
+        "session_operation",
+        "other",
+    )
+    outcomes = ("success", "error", "timeout", "cancelled")
+    for index in range(26):
+        metrics.record_request(
+            outcomes[index % len(outcomes)],
+            200,
+            0.001,
+            route=routes[index % len(routes)],
+            mode=f"mode-{index}",
+        )
+
+    payloads: list[dict[str, object]] = []
+
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        payloads.append(json.loads(body))
+        return len(payloads) != 2
+
+    reporter = TelemetryReporter(
+        metrics=metrics,
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        post=post,
+    )
+
+    assert await reporter.flush() is False
+    assert [len(cast("list[object]", payload["events"])) for payload in payloads] == [25, 2]
+
+    payloads.clear()
+    assert await reporter.flush() is True
+    assert [len(cast("list[object]", payload["events"])) for payload in payloads] == [2]
+    assert all(
+        cast("dict[str, object]", event)["name"] != "bridge_started"
+        for event in cast("list[object]", payloads[0]["events"])
+    )
+
+    payloads.clear()
+    assert await reporter.flush() is True
+    assert payloads == []
+
+
+@pytest.mark.asyncio
+async def test_reporter_splits_event_counts_above_collector_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics = BridgeMetrics()
+    monkeypatch.setattr(
+        metrics,
+        "telemetry_snapshot",
+        lambda: MetricsSnapshot(
+            requests=(),
+            features=(("tools", 2_000_001),),
+            internal=(),
+        ),
+    )
+    payloads: list[dict[str, object]] = []
+
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        payloads.append(json.loads(body))
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=metrics,
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        post=post,
+    )
+
+    assert await reporter.flush() is True
+    feature_counts = [
+        cast("int", event["count"])
+        for payload in payloads
+        for event in cast("list[dict[str, object]]", payload["events"])
+        if event["name"] == "feature"
+    ]
+    assert feature_counts == [1_000_000, 1_000_000, 1]
+    assert await reporter.flush() is True
+    assert len(payloads) == 3
+
+
+def test_event_batches_split_request_duration_proportionally() -> None:
+    batches = _event_batches(
+        [
+            {
+                "name": "request",
+                "route": "health",
+                "outcome": "success",
+                "mode": "not_applicable",
+                "count": 2_000_001,
+                "duration_ms_sum": 5,
+            }
+        ]
+    )
+
+    assert [(batch[0]["count"], batch[0]["duration_ms_sum"]) for batch in batches] == [
+        (1_000_000, 2),
+        (1_000_000, 2),
+        (1, 1),
+    ]
+
+    duration_batches = _event_batches(
+        [
+            {
+                "name": "request",
+                "route": "health",
+                "outcome": "success",
+                "mode": "not_applicable",
+                "count": 3,
+                "duration_ms_sum": 3_000_000_000_001,
+            }
+        ]
+    )
+    assert [(batch[0]["count"], batch[0]["duration_ms_sum"]) for batch in duration_batches] == [
+        (1, 1_000_000_000_000),
+        (1, 1_000_000_000_000),
+        (1, 1_000_000_000_000),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reporter_start_close_and_disabled_paths() -> None:
+    sent: list[bytes] = []
+
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        sent.append(body)
+        return True
+
+    enabled = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        interval_seconds=0.01,
+        post=post,
+    )
+    enabled.start()
+    enabled.start()
+    await asyncio.sleep(0.03)
+    await enabled.close()
+
+    unstarted = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        post=post,
+    )
+    await unstarted.close()
+
+    disabled = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=False,
+        post=post,
+    )
+    disabled.start()
+    assert disabled.enabled is False
+    assert await disabled.flush() is True
+    await disabled.close()
+
+    assert len(sent) == 2
+
+
+def test_events_since_ignores_non_positive_deltas() -> None:
+    baseline = MetricsSnapshot(
+        requests=(RequestMetric("health", "success", "not_applicable", 1, 100),),
+        features=(("tools", 2),),
+        internal=(("warm_hit", 2),),
+    )
+    unchanged = MetricsSnapshot(
+        requests=(RequestMetric("health", "success", "not_applicable", 1, 50),),
+        features=(("tools", 1),),
+        internal=(("warm_hit", 2),),
+    )
+    increased = MetricsSnapshot(
+        requests=(RequestMetric("health", "success", "not_applicable", 2, 50),),
+        features=(("tools", 3),),
+        internal=(("warm_hit", 3),),
+    )
+
+    assert _events_since(baseline, unchanged, include_startup=False) == []
+    assert _events_since(baseline, increased, include_startup=False) == [
+        {
+            "name": "request",
+            "route": "health",
+            "outcome": "success",
+            "mode": "not_applicable",
+            "count": 1,
+            "duration_ms_sum": 0,
+        },
+        {"name": "feature", "feature": "tools", "count": 1},
+        {"name": "internal", "metric": "warm_hit", "count": 1},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "expected_os", "expected_arch"),
+    [
+        ("Linux", "x86_64", "linux", "x86_64"),
+        ("Windows", "AMD64", "windows", "x86_64"),
+        ("Unknown", "riscv64", "other", "other"),
+    ],
+)
+def test_runtime_metadata_normalizes_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    system: str,
+    machine: str,
+    expected_os: str,
+    expected_arch: str,
+) -> None:
+    monkeypatch.setattr("factory_droid_openai.telemetry.platform.system", lambda: system)
+    monkeypatch.setattr("factory_droid_openai.telemetry.platform.machine", lambda: machine)
+
+    metadata = _runtime_metadata("1.5.0")
+
+    assert metadata["os"] == expected_os
+    assert metadata["arch"] == expected_arch
+
+
+class _Response:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+@pytest.mark.parametrize(("status", "expected"), [(204, True), (500, False)])
+def test_post_requires_no_content_response(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    expected: bool,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def urlopen(request: Any, *, timeout: float) -> _Response:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _Response(status)
+
+    monkeypatch.setattr("factory_droid_openai.telemetry.urllib.request.urlopen", urlopen)
+
+    assert _post("https://telemetry.example/v1/events", b"{}", 0.5) is expected
+    assert captured["request"].full_url == "https://telemetry.example/v1/events"
+    assert captured["request"].data == b"{}"
+    assert captured["request"].get_header("Content-type") == "application/json"
+    assert captured["timeout"] == 0.5
+
+
+@pytest.mark.parametrize("error", [OSError("offline"), ValueError("invalid URL")])
+def test_post_swallows_network_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    def urlopen(_request: Any, *, timeout: float) -> _Response:
+        del timeout
+        raise error
+
+    monkeypatch.setattr("factory_droid_openai.telemetry.urllib.request.urlopen", urlopen)
+
+    assert _post("https://telemetry.example/v1/events", b"{}", 0.5) is False
+
+
+@pytest.mark.parametrize("endpoint", ["http://telemetry.example/v1/events", "https://[invalid"])
+def test_post_rejects_non_https_and_invalid_urls(endpoint: str) -> None:
+    assert _post(endpoint, b"{}", 0.5) is False

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -235,7 +235,7 @@ async def test_reporter_applies_one_deadline_to_all_batches(
     assert await reporter.flush() is False
     assert asyncio.get_running_loop().time() - started_at < 0.1
     assert 1 <= len(timeouts) <= 2
-    assert all(0 < timeout <= 0.05 for timeout in timeouts)
+    assert all(timeout > 0 for timeout in timeouts)
     assert all(timeouts[index] < timeouts[index - 1] for index in range(1, len(timeouts)))
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -234,8 +234,9 @@ async def test_reporter_applies_one_deadline_to_all_batches(
 
     assert await reporter.flush() is False
     assert asyncio.get_running_loop().time() - started_at < 0.1
-    assert len(timeouts) == 2
-    assert timeouts[1] < timeouts[0]
+    assert 1 <= len(timeouts) <= 2
+    assert all(0 < timeout <= 0.05 for timeout in timeouts)
+    assert all(timeouts[index] < timeouts[index - 1] for index in range(1, len(timeouts)))
 
 
 @pytest.mark.asyncio

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -8,11 +8,14 @@ from typing import Any, cast
 
 import pytest
 
+from factory_droid_openai import telemetry as telemetry_module
 from factory_droid_openai.metrics import BridgeMetrics, MetricsSnapshot, RequestMetric
 from factory_droid_openai.telemetry import (
+    DEFAULT_TELEMETRY_TIMEOUT_SECONDS,
     TelemetryReporter,
     _event_batches,
     _events_since,
+    _NoRedirectHandler,
     _post,
     _runtime_metadata,
 )
@@ -108,7 +111,7 @@ async def test_reporter_sends_startup_and_metric_deltas(
     assert len(sent) == 2
     endpoint, startup, timeout = sent[0]
     assert endpoint == "https://telemetry.example/v1/events"
-    assert 0 < timeout <= 0.5
+    assert 0 < timeout <= DEFAULT_TELEMETRY_TIMEOUT_SECONDS
     assert startup == {
         "schema": 1,
         "app_version": "1.5.0",
@@ -175,11 +178,10 @@ async def test_reporter_swallows_sender_exceptions() -> None:
 @pytest.mark.asyncio
 async def test_reporter_bounds_sender_deadline() -> None:
     release = threading.Event()
-    calls = 0
+    bodies: list[dict[str, object]] = []
 
-    def post(_endpoint: str, _body: bytes, _timeout: float) -> bool:
-        nonlocal calls
-        calls += 1
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        bodies.append(json.loads(body))
         release.wait()
         return True
 
@@ -197,8 +199,15 @@ async def test_reporter_bounds_sender_deadline() -> None:
     assert asyncio.get_running_loop().time() - started_at < 0.1
     release.set()
     await asyncio.sleep(0)
+    # A send that outran the deadline may or may not have landed, so aggregate
+    # counters move on while the startup event is retried until it is confirmed.
     assert await reporter.flush() is True
-    assert calls == 1
+    assert [body["events"] for body in bodies] == [
+        [{"name": "bridge_started", "count": 1}],
+        [{"name": "bridge_started", "count": 1}],
+    ]
+    assert await reporter.flush() is True
+    assert len(bodies) == 2
 
 
 @pytest.mark.asyncio
@@ -455,6 +464,101 @@ async def test_reporter_start_close_and_disabled_paths() -> None:
     assert len(sent) == 2
 
 
+@pytest.mark.asyncio
+async def test_reporter_survives_a_failing_flush(monkeypatch: pytest.MonkeyPatch) -> None:
+    metrics = BridgeMetrics()
+    snapshots = 0
+
+    def telemetry_snapshot() -> MetricsSnapshot:
+        nonlocal snapshots
+        snapshots += 1
+        if snapshots == 1:
+            raise RuntimeError("snapshot failed")
+        return MetricsSnapshot(requests=(), features=(), internal=())
+
+    monkeypatch.setattr(metrics, "telemetry_snapshot", telemetry_snapshot)
+    sent: list[bytes] = []
+
+    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+        sent.append(body)
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=metrics,
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        interval_seconds=0.01,
+        post=post,
+    )
+    reporter.start()
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if sent:
+            break
+    await reporter.close()
+
+    assert len(sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_close_bounds_an_in_flight_periodic_batch() -> None:
+    release = threading.Event()
+    started = threading.Event()
+
+    def post(_endpoint: str, _body: bytes, _timeout: float) -> bool:
+        started.set()
+        release.wait()
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        interval_seconds=0.01,
+        timeout_seconds=30.0,
+        shutdown_timeout_seconds=0.05,
+        post=post,
+    )
+    reporter.start()
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if started.is_set():
+            break
+    started_at = asyncio.get_running_loop().time()
+
+    await reporter.close()
+
+    assert started.is_set()
+    assert asyncio.get_running_loop().time() - started_at < 1.0
+    release.set()
+
+
+@pytest.mark.asyncio
+async def test_close_applies_the_shutdown_deadline() -> None:
+    timeouts: list[float] = []
+
+    def post(_endpoint: str, _body: bytes, timeout: float) -> bool:
+        timeouts.append(timeout)
+        return True
+
+    reporter = TelemetryReporter(
+        metrics=BridgeMetrics(),
+        app_version="1.5.0",
+        endpoint="https://telemetry.example/v1/events",
+        enabled=True,
+        timeout_seconds=30.0,
+        shutdown_timeout_seconds=0.25,
+        post=post,
+    )
+
+    await reporter.close()
+
+    assert timeouts
+    assert all(0 < timeout <= 0.25 for timeout in timeouts)
+
+
 def test_events_since_ignores_non_positive_deltas() -> None:
     baseline = MetricsSnapshot(
         requests=(RequestMetric("health", "success", "not_applicable", 1, 100),),
@@ -522,26 +626,52 @@ class _Response:
         return None
 
 
-@pytest.mark.parametrize(("status", "expected"), [(204, True), (500, False)])
-def test_post_requires_no_content_response(
+class _Opener:
+    def __init__(self, result: _Response | Exception) -> None:
+        self._result = result
+        self.captured: dict[str, Any] = {}
+
+    def open(self, request: Any, *, timeout: float) -> _Response:
+        self.captured["request"] = request
+        self.captured["timeout"] = timeout
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [(200, True), (204, True), (302, False), (500, False)],
+)
+def test_post_accepts_success_responses_only(
     monkeypatch: pytest.MonkeyPatch,
     status: int,
     expected: bool,
 ) -> None:
-    captured: dict[str, Any] = {}
-
-    def urlopen(request: Any, *, timeout: float) -> _Response:
-        captured["request"] = request
-        captured["timeout"] = timeout
-        return _Response(status)
-
-    monkeypatch.setattr("factory_droid_openai.telemetry.urllib.request.urlopen", urlopen)
+    opener = _Opener(_Response(status))
+    monkeypatch.setattr(telemetry_module, "_OPENER", opener)
 
     assert _post("https://telemetry.example/v1/events", b"{}", 0.5) is expected
-    assert captured["request"].full_url == "https://telemetry.example/v1/events"
-    assert captured["request"].data == b"{}"
-    assert captured["request"].get_header("Content-type") == "application/json"
-    assert captured["timeout"] == 0.5
+    assert opener.captured["request"].full_url == "https://telemetry.example/v1/events"
+    assert opener.captured["request"].data == b"{}"
+    assert opener.captured["request"].get_header("Content-type") == "application/json"
+    assert opener.captured["timeout"] == 0.5
+
+
+def test_post_refuses_redirects() -> None:
+    handler = _NoRedirectHandler()
+
+    assert (
+        handler.redirect_request(
+            cast("Any", None),
+            cast("Any", None),
+            302,
+            "Found",
+            cast("Any", None),
+            "http://telemetry.example/v1/events",
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize("error", [OSError("offline"), ValueError("invalid URL")])
@@ -549,11 +679,7 @@ def test_post_swallows_network_errors(
     monkeypatch: pytest.MonkeyPatch,
     error: Exception,
 ) -> None:
-    def urlopen(_request: Any, *, timeout: float) -> _Response:
-        del timeout
-        raise error
-
-    monkeypatch.setattr("factory_droid_openai.telemetry.urllib.request.urlopen", urlopen)
+    monkeypatch.setattr(telemetry_module, "_OPENER", _Opener(error))
 
     assert _post("https://telemetry.example/v1/events", b"{}", 0.5) is False
 


### PR DESCRIPTION
## Summary

- Add default-on anonymous aggregate telemetry sent to `https://telemetry.guziak.net`.
- Collect only fixed runtime, request, feature, and internal aggregate categories.
- Support opt-out through `FACTORY_DROID_OPENAI_TELEMETRY=false` or `DO_NOT_TRACK=1`.
- Document collected and excluded data in the README.

## Reliability and privacy

- Send outside request handling with a flush-wide 500 ms deadline.
- Fail open on DNS, network, validation, and thread startup errors.
- Use HTTPS only, keep no disk queue, and bound collector-compatible batches.
- Never collect prompts, responses, identifiers, model or tool names, secrets, paths, or payload contents.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` (626 passed, 100% coverage)
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`