### PR TITLE
fix(api): stop+note on malformed tool calls instead of length

### DIFF
--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1333,6 +1333,8 @@ def create_app(
                         )
                     if result.truncated:
                         request.state.stream_outcome = "truncated"
+                    elif result.malformed_note is not None:
+                        request.state.stream_outcome = "malformed"
                     if result.session_id is not None:
                         sessions.remember(result.session_id)
                         started_session = result.session_id
@@ -1409,6 +1411,7 @@ class CollectedCompletion:
         self.session_id: str | None = None
         self.stopped = False
         self.truncated = False
+        self.malformed_note: str | None = None
 
     @property
     def text(self) -> str:
@@ -1442,14 +1445,17 @@ async def _collect_completion(
                 try:
                     _apply_emissions(result, parser.feed(event.text), stop_buffer)
                 except MalformedToolCallError as exc:
-                    # Same contract as the streaming path: a tool-call payload
-                    # no decoder could parse returns completed output with
-                    # finish_reason="length" instead of a 502. The malformed
-                    # call is dropped, never executed.
-                    result.truncated = True
+                    # The payload closed but no decoder could parse it, so
+                    # continuing the turn would only make the model repeat the
+                    # same garbage. Answer with finish_reason="stop" plus a
+                    # visible note naming the expected format instead: the
+                    # client stops auto-continuing, and a resubmitted
+                    # transcript tells the model how to re-emit the call. The
+                    # malformed call is dropped, never executed.
+                    result.malformed_note = _malformed_tool_call_note(exc)
                     result.completed = True
                     log_warning(
-                        "chat.truncated",
+                        "chat.malformed",
                         stream=False,
                         error_type="factory_protocol_error",
                         reason=str(exc),
@@ -1483,9 +1489,9 @@ async def _collect_completion(
             error_type="factory_incomplete_response",
         )
     if not result.stopped:
-        if not result.truncated:
-            # A malformed payload already failed the parse; asking the parser
-            # to finish would re-raise on the same garbage.
+        if not result.truncated and result.malformed_note is None:
+            # A failed parse already settled the turn; asking the parser to
+            # finish would re-raise on the same garbage.
             try:
                 _apply_emissions(result, parser.finish(), stop_buffer)
             except IncompleteToolCallError as exc:
@@ -1575,6 +1581,7 @@ async def _stream_completion(
     usage = Usage()
     completed = False
     saw_tool_call = False
+    saw_text = False
     observed_ttft = False
     outcome = "success"
     stop_buffer = StopSequenceBuffer(stop_sequences)
@@ -1634,6 +1641,7 @@ async def _stream_completion(
                             if text:
                                 chunk_payload = text_chunk(text)
                                 if chunk_payload is not None:
+                                    saw_text = True
                                     yield chunk_payload
                         if stop_buffer.triggered:
                             # Closing the runner generator interrupts the Droid
@@ -1713,11 +1721,13 @@ async def _stream_completion(
                     if text:
                         chunk_payload = text_chunk(text)
                         if chunk_payload is not None:
+                            saw_text = True
                             yield chunk_payload
                 held = stop_buffer.flush()
                 if held:
                     chunk_payload = text_chunk(held)
                     if chunk_payload is not None:
+                        saw_text = True
                         yield chunk_payload
             if structured is not None and structured_buffer is not None:
                 structured_text = structured_buffer.text()
@@ -1743,13 +1753,12 @@ async def _stream_completion(
             )
             if include_usage:
                 yield _sse(_usage_chunk(request_id, created, model, usage))
-        except (IncompleteToolCallError, MalformedToolCallError) as exc:
-            # The turn died inside a tool-call payload, or the payload was
-            # garbage no decoder could parse. Surface it the way OpenAI
-            # surfaces a length cutoff - completed output plus
+        except IncompleteToolCallError as exc:
+            # The turn died inside a tool-call payload. Surface it the way
+            # OpenAI surfaces a length cutoff - completed output plus
             # finish_reason="length" - so clients continue instead of
-            # blind-retrying an unrecoverable request. The partial or
-            # malformed call is dropped, never executed.
+            # blind-retrying an unrecoverable request. The partial call is
+            # dropped, never executed.
             outcome = "truncated"
             log_warning(
                 "chat.truncated",
@@ -1771,6 +1780,43 @@ async def _stream_completion(
                     model,
                     delta={},
                     finish_reason="length",
+                    include_usage=include_usage,
+                )
+            )
+            if include_usage:
+                yield _sse(_usage_chunk(request_id, created, model, usage))
+        except MalformedToolCallError as exc:
+            # The payload closed but no decoder could parse it. A length
+            # finish would make the client ask the model to "continue", which
+            # only repeats the same garbage in a loop, so answer with
+            # finish_reason="stop" plus a visible note naming the expected
+            # format. The malformed call is dropped, never executed.
+            outcome = "malformed"
+            log_warning(
+                "chat.malformed",
+                stream=True,
+                error_type="factory_protocol_error",
+                reason=str(exc),
+                tool_name=exc.tool_name,
+                payload_bytes=exc.payload_bytes,
+            )
+            held = stop_buffer.flush()
+            if held:
+                chunk_payload = text_chunk(held)
+                if chunk_payload is not None:
+                    saw_text = True
+                    yield chunk_payload
+            note = _malformed_tool_call_note(exc)
+            note_chunk = text_chunk(f"\n\n{note}" if saw_text else note)
+            if note_chunk is not None:
+                yield note_chunk
+            yield _sse(
+                _chunk(
+                    request_id,
+                    created,
+                    model,
+                    delta={},
+                    finish_reason="tool_calls" if saw_tool_call else "stop",
                     include_usage=include_usage,
                 )
             )
@@ -2109,10 +2155,29 @@ def _reject_remote_schema_refs(value: Any) -> None:
             _reject_remote_schema_refs(item)
 
 
+def _malformed_tool_call_note(exc: MalformedToolCallError) -> str:
+    """Client- and model-readable explanation for a dropped malformed call.
+
+    The note becomes assistant content, so a client that resubmits the
+    transcript hands the model the exact format to re-emit instead of
+    repeating the payload no decoder could parse.
+    """
+    tool = f' for tool "{exc.tool_name}"' if exc.tool_name else ""
+    return (
+        f"[bridge notice: dropped a malformed tool call{tool} "
+        f"({exc.payload_bytes} bytes, undecodable payload). To call a tool, emit "
+        '<tool_call>{"name":"<tool_name>","arguments":{...}}</tool_call> '
+        "with exactly one JSON object between the markers.]"
+    )
+
+
 def _choice_dict(result: CollectedCompletion, index: int) -> dict[str, Any]:
+    content = result.text
+    if result.malformed_note is not None:
+        content = f"{content}\n\n{result.malformed_note}" if content else result.malformed_note
     message: dict[str, Any] = {
         "role": "assistant",
-        "content": result.text or None,
+        "content": content or None,
     }
     if result.reasoning:
         message["reasoning"] = result.reasoning
@@ -2259,7 +2324,7 @@ def _request_outcome(status_code: int, scope: Scope) -> str:
     state = scope.get("state")
     if isinstance(state, dict):
         stream_outcome = state.get("stream_outcome")
-        if stream_outcome in {"success", "error", "timeout", "cancelled", "truncated"}:
+        if stream_outcome in {"success", "error", "timeout", "cancelled", "truncated", "malformed"}:
             return str(stream_outcome)
     if status_code < 400:
         return "success"

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -409,7 +409,16 @@ class ToolCallStreamParser:
         self._append_payload(payload)
         trailing = value[close_index + len(close_marker) :]
         complete_payload = "".join(self._payload_chunks)
-        payload_objects = self._tool_payload_objects(complete_payload)
+        try:
+            payload_objects = self._tool_payload_objects(complete_payload)
+        except MalformedToolCallError:
+            # The payload is garbage but complete: reset the capture state so
+            # finish() does not re-raise it as a truncated call.
+            self._payload_chunks.clear()
+            self._payload_bytes = 0
+            self._close_tail = ""
+            self._capturing = False
+            raise
         self._payload_chunks.clear()
         # The size limit is per payload, so the bounded call count is what caps
         # the total bytes a single turn can buffer.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1349,7 +1349,7 @@ async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
-async def test_streaming_malformed_tool_call_finishes_with_length(tmp_path: Path) -> None:
+async def test_streaming_malformed_tool_call_stops_with_note(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
             TextDelta("checking "),
@@ -1384,19 +1384,21 @@ async def test_streaming_malformed_tool_call_finishes_with_length(tmp_path: Path
         for chunk in chunks
         if chunk["choices"] and chunk["choices"][0]["finish_reason"] is not None
     )
-    assert finish_chunk["choices"][0]["finish_reason"] == "length"
+    assert finish_chunk["choices"][0]["finish_reason"] == "stop"
     assert chunks[-1]["choices"] == []
     content = "".join(
         choice["delta"].get("content") or ""
         for chunk in chunks
         for choice in chunk.get("choices", [])
     )
-    assert content == "checking "
-    assert 'outcome="truncated",status="200"} 1' in metrics.text
+    assert content.startswith("checking \n\n[bridge notice: dropped a malformed tool call")
+    assert 'for tool "weather"' in content
+    assert "<tool_call>" in content
+    assert 'outcome="malformed",status="200"} 1' in metrics.text
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_malformed_tool_call_returns_length(tmp_path: Path) -> None:
+async def test_non_streaming_malformed_tool_call_stops_with_note(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
             TextDelta("partial answer"),
@@ -1418,11 +1420,143 @@ async def test_non_streaming_malformed_tool_call_returns_length(tmp_path: Path) 
 
     assert response.status_code == 200
     choice = response.json()["choices"][0]
-    assert choice["finish_reason"] == "length"
-    assert choice["message"]["content"] == "partial answer"
+    assert choice["finish_reason"] == "stop"
+    content = choice["message"]["content"]
+    assert content.startswith("partial answer\n\n[bridge notice: dropped a malformed tool call")
+    assert 'for tool "weather"' in content
     assert "tool_calls" not in choice["message"]
     assert runner.closed is True
-    assert 'outcome="truncated",status="200"} 1' in metrics.text
+    assert 'outcome="malformed",status="200"} 1' in metrics.text
+
+
+@pytest.mark.asyncio
+async def test_streaming_malformed_tool_call_without_prior_text(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}"),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith('data: {"')
+    ]
+    content = "".join(
+        choice["delta"].get("content") or ""
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+    )
+    assert content.startswith("[bridge notice: dropped a malformed tool call (")
+    assert "for tool" not in content
+    finish_chunk = next(
+        chunk
+        for chunk in chunks
+        if chunk["choices"] and chunk["choices"][0]["finish_reason"] is not None
+    )
+    assert finish_chunk["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_streaming_malformed_tool_call_flushes_held_text(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("working on EN"),
+            TextDelta(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}"),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=True,
+        stop="END",
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith('data: {"')
+    ]
+    content = "".join(
+        choice["delta"].get("content") or ""
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+    )
+    assert content.startswith("working on EN\n\n[bridge notice:")
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_drops_note_for_structured_output() -> None:
+    schema = {"type": "object"}
+    validator_class = validator_for(schema)
+    structured = StructuredOutput(
+        payload={"type": "json_schema", "schema": schema},
+        validator=validator_class(schema),
+        max_bytes=1024,
+    )
+    runner = FakeRunner(
+        [
+            TextDelta(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}"),
+            RunComplete(Usage()),
+        ]
+    )
+
+    events = await _collect_stream(
+        runner,
+        allowed_tool_names=frozenset({"weather"}),
+        structured=structured,
+    )
+
+    assert any('"finish_reason":"stop"' in event for event in events)
+    assert not any("bridge notice" in event for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_drops_held_text_for_structured_output() -> None:
+    schema = {"type": "object"}
+    validator_class = validator_for(schema)
+    structured = StructuredOutput(
+        payload={"type": "json_schema", "schema": schema},
+        validator=validator_class(schema),
+        max_bytes=1024,
+    )
+    runner = FakeRunner(
+        [
+            TextDelta("working on EN"),
+            TextDelta(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}"),
+            RunComplete(Usage()),
+        ]
+    )
+
+    events = await _collect_stream(
+        runner,
+        allowed_tool_names=frozenset({"weather"}),
+        stop_sequences=("END",),
+        structured=structured,
+    )
+
+    assert any('"finish_reason":"stop"' in event for event in events)
+    assert not any("working on" in event for event in events)
+    assert not any("bridge notice" in event for event in events)
 
 
 @pytest.mark.asyncio
@@ -1564,6 +1698,7 @@ async def test_non_streaming_truncation_overrides_completed_tool_calls(tmp_path:
     ("state", "expected"),
     [
         ({"stream_outcome": "truncated"}, "truncated"),
+        ({"stream_outcome": "malformed"}, "malformed"),
         ({}, "success"),
     ],
 )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -604,6 +604,15 @@ def test_stream_parser_malformed_error_without_recognized_name() -> None:
     assert excinfo.value.tool_name is None
 
 
+def test_stream_parser_finish_after_malformed_does_not_reraise() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(MalformedToolCallError):
+        parser.feed(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}")
+
+    assert parser.finish() == []
+
+
 def test_stream_parser_logs_unparsed_payload_details() -> None:
     stream = io.StringIO()
     logs.configure_logging(level="trace", log_format="json", stream=stream)


### PR DESCRIPTION
## Problem

A malformed tool call (closed marker, payload no decoder can parse) degraded to `finish_reason="length"`. Clients treat `length` as truncation and auto-send "continue exactly where you left off" - but the response was not truncated, so the model repeats the same malformed call. Observed live: an endless loop with `[response interrupted]` + continuation pairs piling into the transcript (~88 KB resent per iteration).

## Fix

- `MalformedToolCallError` → `finish_reason="stop"` (or `tool_calls` when earlier calls completed) plus a visible note: `[bridge notice: dropped a malformed tool call for tool "X" (N bytes, undecodable payload). To call a tool, emit <tool_call>{...}</tool_call> ...]`. The client stops auto-continuing; if the transcript is resubmitted, the model gets the exact repair format.
- `IncompleteToolCallError` keeps `finish_reason="length"` - continuation genuinely resumes a stream that died mid-payload.
- Parser resets capture state on malformed payloads so `finish()` cannot re-raise the same garbage as a truncation.
- Structured output mode skips the note, keeping the JSON parseable.
- New stream outcome label `malformed` for metrics/telemetry.

## Validation

ruff, ruff format, strict mypy, 659 tests, 99.98% coverage.