### PR TITLE
feat(protocol): show a concrete tool-call example in the prompt

### DIFF
--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -181,7 +181,11 @@ def build_prompt(
             f"{TOOL_CALL_CLOSE}. "
             "Between the markers emit exactly one JSON object with the keys "
             '"name" and "arguments"; never emit <arg_key>/<arg_value> blocks, '
-            "a code fence, or two objects inside one marker pair. "
+            "python-style name(...) or name{...} call syntax, a code fence, "
+            "or two objects inside one marker pair. "
+            f"Example: {TOOL_CALL_OPEN}"
+            '{"name":"get_weather","arguments":{"city":"Paris"}}'
+            f"{TOOL_CALL_CLOSE}. "
             f"Do not call Droid-native tools. {trailing_rule}"
         )
         if require_tool_call:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -90,6 +90,24 @@ def test_build_prompt_preserves_openai_transcript_and_tools() -> None:
     assert plan.allowed_tool_names == frozenset({"weather"})
 
 
+def test_build_prompt_shows_a_concrete_tool_call_example() -> None:
+    request = _request(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ]
+    )
+
+    plan = build_prompt(request)
+
+    assert (
+        'Example: <tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>.'
+    ) in plan.prompt
+    assert "python-style name(...) or name{...} call syntax" in plan.prompt
+
+
 def test_tool_choice_limits_the_available_tool() -> None:
     request = _request(
         tools=[


### PR DESCRIPTION
## Problem

The bridge prompt lists only negative rules ("never emit <arg_key>/<arg_value> blocks, a code fence, ..."). Models that fall back to their own chat-template dialect (GLM observed emitting python-call syntax and mangled arg_key blocks) ignored them.

## Fix

- One concrete few-shot example of a correct call: `<tool_call>{"name":"get_weather","arguments":{"city":"Paris"}}</tool_call>`
- Explicit ban of python-style `name(...)` / `name{...}` call syntax

Positive examples steer small models better than prohibitions; repair-side handling of these dialects ships separately.

## Validation

ruff, ruff format, strict mypy, full pytest suite.