### PR TITLE
fix(api): reject duplicate keys in the raw request body

### DIFF
--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -77,6 +77,10 @@ from factory_droid_openai.runner import (
     WarmSession,
     normalize_reasoning_effort,
 )
+from factory_droid_openai.strictjson import (
+    DuplicateKeyError,
+    check_no_duplicate_keys,
+)
 from factory_droid_openai.telemetry import DEFAULT_TELEMETRY_ENDPOINT, TelemetryReporter
 
 if TYPE_CHECKING:
@@ -523,6 +527,27 @@ class RequestSizeLimitMiddleware:
                     max_request_bytes=self._max_request_bytes,
                     max_json_depth=self._max_json_depth,
                 )
+            # FastAPI binds the body with Pydantic, which keeps the last value for
+            # a repeated key instead of rejecting it. A duplicate key in the raw
+            # request body is almost always a client bug, so the bridge fails
+            # closed here before the handler can act on a silently-wrong value.
+            if body and _json_content_type(scope):
+                try:
+                    check_no_duplicate_keys(body.decode("utf-8"))
+                except DuplicateKeyError as exc:
+                    status_code = 400
+                    await _send_asgi_error(
+                        scope,
+                        receive,
+                        send,
+                        message=str(exc),
+                        status_code=400,
+                        error_type="invalid_request_error",
+                    )
+                    return
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    # Malformed JSON or encoding is left for FastAPI to report.
+                    pass
             replayed = False
 
             async def replay_receive() -> Message:
@@ -2165,6 +2190,14 @@ def _content_length(scope: Scope) -> int | None:
             return None
         return parsed if parsed >= 0 else None
     return None
+
+
+def _json_content_type(scope: Scope) -> bool:
+    for name, value in scope.get("headers", []):
+        if name.lower() != b"content-type":
+            continue
+        return bool(value.lower().strip().startswith(b"application/json"))
+    return False
 
 
 async def _read_limited_body(

--- a/src/factory_droid_openai/strictjson.py
+++ b/src/factory_droid_openai/strictjson.py
@@ -5,9 +5,25 @@ import math
 from typing import Any
 
 __all__ = [
+    "DuplicateKeyError",
+    "check_no_duplicate_keys",
     "decode_json_values",
     "parse_strict_json",
 ]
+
+
+class DuplicateKeyError(ValueError):
+    """Raised when a JSON object repeats a key the bridge must not accept."""
+
+
+def check_no_duplicate_keys(text: str) -> None:
+    """Rejects a JSON document that repeats any object key.
+
+    Unlike :func:`parse_strict_json` this keeps the standard JSON number
+    handling, so it only adds the duplicate-key rejection the request-body
+    parser needs, without changing what FastAPI would otherwise accept.
+    """
+    json.loads(text, object_pairs_hook=_reject_duplicate_keys)
 
 
 def parse_strict_json(text: str) -> Any:
@@ -51,7 +67,7 @@ def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
         if key in result:
-            raise ValueError(f"duplicate key '{key}'")
+            raise DuplicateKeyError(f"duplicate key '{key}'")
         result[key] = value
     return result
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1061,6 +1061,74 @@ async def test_chunked_request_body_stops_at_size_limit(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_duplicate_request_keys_are_rejected(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            content=(
+                b'{"model":"factory-droid","model":"gpt-5.4",'
+                b'"messages":[{"role":"user","content":"hi"}]}'
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert "duplicate key" in response.json()["error"]["message"]
+    assert not runner.requests
+
+
+@pytest.mark.asyncio
+async def test_duplicate_nested_keys_are_rejected(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            content=(
+                b'{"model":"factory-droid",'
+                b'"messages":[{"role":"user","content":"hi","content":"dup"}]}'
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert "duplicate key" in response.json()["error"]["message"]
+    assert not runner.requests
+
+
+@pytest.mark.asyncio
+async def test_unique_keys_still_pass_the_size_middleware(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            content=(b'{"model":"factory-droid","messages":[{"role":"user","content":"hi"}]}'),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200
+    assert runner.requests
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_falls_through_to_fastapi(tmp_path: Path) -> None:
+    # The duplicate-key check must not swallow a body that is not JSON at all;
+    # FastAPI still owns the malformed-JSON error.
+    runner = FakeRunner([RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            content=b"{not json}",
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert not runner.requests
+
+
+@pytest.mark.asyncio
 async def test_request_body_read_has_bounded_timeout(tmp_path: Path) -> None:
     runner = FakeRunner([RunComplete(Usage())])
     app = create_app(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -23,6 +23,10 @@ from factory_droid_openai.protocol import (
     build_prompt,
     parse_strict_json,
 )
+from factory_droid_openai.strictjson import (
+    DuplicateKeyError,
+    check_no_duplicate_keys,
+)
 
 
 def _request(**overrides: object) -> ChatCompletionRequest:
@@ -403,6 +407,27 @@ def test_strict_json_rejects_values_outside_the_json_grammar(
 
 def test_strict_json_keeps_finite_numbers() -> None:
     assert parse_strict_json('{"amount":1.5,"count":2}') == {"amount": 1.5, "count": 2}
+
+
+def test_check_no_duplicate_keys_rejects_repeated_keys() -> None:
+    with pytest.raises(DuplicateKeyError, match="duplicate key 'model'"):
+        check_no_duplicate_keys('{"model":"a","model":"b"}')
+
+
+def test_check_no_duplicate_keys_rejects_nested_repeats() -> None:
+    with pytest.raises(DuplicateKeyError, match="duplicate key 'content'"):
+        check_no_duplicate_keys('{"messages":[{"content":"a","content":"b"}]}')
+
+
+def test_check_no_duplicate_keys_accepts_unique_keys() -> None:
+    # Must not raise for a well-formed document, including nested objects.
+    check_no_duplicate_keys('{"model":"a","messages":[{"role":"user","content":"hi"}]}')
+
+
+def test_check_no_duplicate_keys_keeps_standard_number_handling() -> None:
+    # Unlike parse_strict_json, this check must not reject values the standard
+    # JSON parser accepts, so it only adds the duplicate-key rejection.
+    check_no_duplicate_keys('{"big":1e400}')
 
 
 def test_stream_parser_rejects_non_finite_tool_arguments() -> None:


### PR DESCRIPTION
## Problem

Adversarial E2E testing found that a request body with a repeated JSON key was silently accepted. Pydantic (`ChatCompletionRequest` with `extra="allow"`) keeps the last value for a duplicate key, so:

```json
{"model":"glm-5.2","model":"kimi-k3","messages":[...]}
```

was forwarded to `kimi-k3` with no error. The bridge already rejects duplicate keys inside tool-call *arguments* (`strictjson.parse_strict_json`), but the outer request body was not checked.

## Fix

Add a fail-closed duplicate-key check in `RequestSizeLimitMiddleware`, right after the body is buffered and before it is replayed to FastAPI. A new `check_no_duplicate_keys` helper (in `strictjson.py`) parses the body with `object_pairs_hook=_reject_duplicate_keys`, rejecting repeated keys at any nesting depth. It keeps standard JSON number handling so it only adds the duplicate-key rejection without changing what FastAPI would otherwise accept. Malformed JSON / encoding still falls through to FastAPI's own 400.

## Validation

- `uv run ruff check .` / `ruff format --check .` / `mypy` clean
- `uv run pytest --cov=factory_droid_openai` - 662 passed, 100% coverage
- `openapi-spec-validator openapi.json` OK (no route/schema change)
- `uv lock --check` / `uv build` OK

Replaces the silent last-value-wins behavior with an explicit `400 invalid_request_error` carrying `duplicate key '<name>'`.