### PR TITLE
fix(runner): report elapsed time in the timeout error message

### DIFF
--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -358,6 +358,11 @@ class DroidRunner:
         if deadline <= loop.time():
             raise _timeout_error(request)
 
+        # The deadline above is the request's total budget (queue wait plus the
+        # run). From here on the message reports how long the Droid run itself
+        # took before it timed out, so a 60 s model-backend timeout no longer
+        # reads as the configured 600 s ceiling.
+        started = loop.time()
         warm = request.warm_session
         if warm is not None:
             warm.consumed = True
@@ -502,7 +507,11 @@ class DroidRunner:
                             error_type=event.error_type or "factory_droid_error",
                         )
         except (TimeoutError, DroidTimeoutError) as exc:
-            raise _timeout_error(request) from exc
+            raise RunnerError(
+                f"Factory Droid timed out after {loop.time() - started:.1f} seconds.",
+                status_code=504,
+                error_type="factory_droid_timeout",
+            ) from exc
         except FileNotFoundError as exc:
             raise RunnerError(
                 f"Factory Droid executable was not found: {self._droid_path}",
@@ -679,13 +688,15 @@ class DroidRunner:
         client.set_ask_user_handler(
             lambda _params: {"cancelled": True, "answers": []},
         )
+        started = asyncio.get_running_loop().time()
         try:
             async with asyncio.timeout(timeout_seconds):
                 await client.connect()
                 return await operation(client)
         except (TimeoutError, DroidTimeoutError) as exc:
             raise RunnerError(
-                f"Factory Droid timed out after {timeout_seconds:.1f} seconds.",
+                f"Factory Droid timed out after"
+                f" {asyncio.get_running_loop().time() - started:.1f} seconds.",
                 status_code=504,
                 error_type="factory_droid_timeout",
             ) from exc

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import sys
 import textwrap
 import time
@@ -346,6 +347,30 @@ async def test_runner_maps_sdk_timeout_to_gateway_timeout(tmp_path: Path) -> Non
     assert error.value.status_code == 504
     assert error.value.error_type == "factory_droid_timeout"
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_sdk_timeout_message_reports_elapsed_not_the_configured_ceiling(
+    tmp_path: Path,
+) -> None:
+    # The SDK fails immediately, so the timeout message must report the small
+    # elapsed time of the run, not the configured 30 s ceiling the old message
+    # echoed regardless of when the failure actually happened.
+    client = SdkTimeoutClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError) as error:
+        await _collect(runner, _request(timeout_seconds=30.0))
+
+    assert error.value.status_code == 504
+    assert error.value.error_type == "factory_droid_timeout"
+    match = re.search(r"after ([\d.]+) seconds", str(error.value))
+    assert match is not None
+    assert float(match.group(1)) < 1.0
 
 
 class MissingExecutableClient(FakeClient):


### PR DESCRIPTION
## Problem

The 504 `Gateway Timeout` error message echoed the **configured timeout ceiling** (e.g. `600.0 seconds`) regardless of when the Droid SDK or model backend actually timed out. An E2E test against glm-5.2 observed a real wall-time failure at ~60 s, yet the bridge reported:

```
Factory Droid timed out after 600.0 seconds.
```

This is misleading: the client sees a 60 s failure but the message claims 600 s.

## Fix

Report the **elapsed time of the Droid run** (from when the run started to when the timeout fired) instead of the configured ceiling.

- `run()`: record `started = loop.time()` after the early-deadline guard; the timeout `except` now computes `loop.time() - started`.
- `_session_operation()`: same pattern with `asyncio.get_running_loop().time()`.
- The early-deadline guard (request budget exhausted by queue wait before the run starts) still reports the configured budget via `_timeout_error(request)` - that path is accurate because the full budget elapsed.

## Testing

- Added `test_sdk_timeout_message_reports_elapsed_not_the_configured_ceiling`: the SDK fails immediately, so the message must report a small elapsed (< 1.0 s), not the configured 30 s ceiling.
- 655 passed, 100% coverage.
- ruff / mypy / openapi / lock / build all clean.

## Finding

E2E finding F3 from `traces/e2e-report-2026-07-31.md`.