### PR TITLE
feat(telemetry): add privacy-safe aggregate dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,14 +1184,19 @@ Collected fields:
   CPU architecture
 - route category, streaming mode, outcome category, request count, and aggregate
   duration
+- coarse latency buckets by route, payload-size buckets by route, and normalized
+  model family
+- coarse error category by route, without error messages
 - counts for tools, structured output, attachments, reasoning effort, session
   continuity, multiple choices, and warm-session use
 - aggregate warm-pool, model-discovery, quarantine, and forced-kill counters
 
-Telemetry never includes prompts, responses, model or tool names, tool
-arguments, attachment contents, file paths, environment variables, API keys,
-IP addresses, host User-Agent values, client timestamps, or a persistent
-installation identifier. The request body is built in
+Telemetry never includes prompts, responses, full model names, tool names, tool
+arguments, attachment contents, file paths, environment variables, API keys, IP
+addresses, host User-Agent values, client timestamps, or a persistent
+installation identifier. Model usage is reduced to a fixed family such as
+`gpt`, `gemini`, or `other`; latency and payload size use fixed buckets. The
+request body is built in
 [`src/factory_droid_openai/telemetry.py`](src/factory_droid_openai/telemetry.py),
 so every field the bridge sends can be verified from this repository.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ branch = true
 source = ["factory_droid_openai"]
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 100
 show_missing = true
 skip_covered = true
 exclude_lines = [

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -97,6 +97,26 @@ BearerCredentials = Annotated[
 # timeout budget.
 _WARM_TIMEOUT_CEILING = 120.0
 _BRIDGE_VERSION = "1.5.0"  # x-release-please-version
+_LATENCY_BUCKETS = (
+    (0.1, "lt_100ms"),
+    (0.5, "100ms_500ms"),
+    (1.0, "500ms_1s"),
+    (5.0, "1s_5s"),
+    (30.0, "5s_30s"),
+)
+_PAYLOAD_SIZE_BUCKETS = (
+    (10_240, "lt_10kb"),
+    (102_400, "10kb_100kb"),
+    (1_048_576, "100kb_1mb"),
+)
+_MODEL_FAMILY_PREFIXES = (
+    (("gpt-", "o1", "o3", "o4"), "gpt"),
+    (("gemini",), "gemini"),
+    (("claude",), "claude"),
+    (("qwen",), "qwen"),
+    (("kimi",), "kimi"),
+    (("deepseek",), "deepseek"),
+)
 
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
@@ -508,10 +528,15 @@ class RequestSizeLimitMiddleware:
             if message["type"] == "http.response.start":
                 response_started = True
                 status_code = int(message["status"])
+                _set_request_state(scope, status_code=status_code)
             await send(message)
 
         try:
             if content_length is not None and content_length > self._max_request_bytes:
+                _set_request_state(
+                    scope,
+                    payload_size_bucket=_payload_size_bucket(content_length),
+                )
                 status_code = 413
                 self._metrics.increment_payload_rejections()
                 await _send_payload_too_large(
@@ -527,6 +552,7 @@ class RequestSizeLimitMiddleware:
                     max_request_bytes=self._max_request_bytes,
                     max_json_depth=self._max_json_depth,
                 )
+            _set_request_state(scope, payload_size_bucket=_payload_size_bucket(len(body)))
             # FastAPI binds the body with Pydantic, which keeps the last value for
             # a repeated key instead of rejecting it. A duplicate key in the raw
             # request body is almost always a client bug, so the bridge fails
@@ -583,12 +609,18 @@ class RequestSizeLimitMiddleware:
         except _ClientDisconnectedError:
             status_code = 499
         finally:
+            elapsed = time.perf_counter() - started
             self._metrics.record_request(
                 _request_outcome(status_code, scope),
                 status_code,
-                time.perf_counter() - started,
+                elapsed,
                 route=_request_route(scope),
                 mode=_request_mode(scope),
+                features=_request_telemetry_features(
+                    scope,
+                    status_code=status_code,
+                    seconds=elapsed,
+                ),
             )
 
 
@@ -756,7 +788,8 @@ def create_app(
             )
 
     @application.exception_handler(BridgeHTTPError)
-    async def handle_bridge_error(_request: Request, exc: BridgeHTTPError) -> JSONResponse:
+    async def handle_bridge_error(request: Request, exc: BridgeHTTPError) -> JSONResponse:
+        request.state.telemetry_error_type = exc.error_type
         return _error_response(
             exc.message,
             exc.status_code,
@@ -766,9 +799,10 @@ def create_app(
 
     @application.exception_handler(RequestValidationError)
     async def handle_validation_error(
-        _request: Request,
+        request: Request,
         exc: RequestValidationError,
     ) -> JSONResponse:
+        request.state.telemetry_error_type = "invalid_request_error"
         return _error_response(
             _validation_message(exc),
             400,
@@ -1080,6 +1114,7 @@ def create_app(
         # Requests rejected before the handler (validation, auth, request size)
         # never reach this line, so they stay reported as "not_applicable".
         request.state.telemetry_mode = "stream" if payload.stream else "non_stream"
+        request.state.telemetry_model_family = _model_family(payload.model)
         timeout_seconds = min(
             payload.timeout or resolved_settings.timeout_seconds,
             resolved_settings.timeout_seconds,
@@ -1103,18 +1138,21 @@ def create_app(
 
         rejection = _validate_options(payload, resolved_settings)
         if rejection is not None:
+            request.state.telemetry_error_type = "invalid_request_error"
             log_warning("chat.rejected", status=rejection.status_code, phase="options")
             return rejection
 
         session_id: str | None = None
         if payload.factory_droid_session_id is not None:
             if not resolved_settings.session_continuity:
+                request.state.telemetry_error_type = "invalid_request_error"
                 return _error_response(
                     "Session continuity is disabled on this bridge.",
                     400,
                     "invalid_request_error",
                 )
             if not sessions.knows(payload.factory_droid_session_id):
+                request.state.telemetry_error_type = "session_not_found"
                 return _error_response(
                     "Unknown Factory Droid session. Only sessions created by this "
                     "bridge process can be continued.",
@@ -1145,9 +1183,11 @@ def create_app(
             )
         except RequestTooLargeError as exc:
             metrics.increment_payload_rejections()
+            request.state.telemetry_error_type = "invalid_request_error"
             log_warning("chat.rejected", status=413, phase="prompt", reason=str(exc))
             return _error_response(str(exc), 413, "invalid_request_error")
         except ProtocolError as exc:
+            request.state.telemetry_error_type = "invalid_request_error"
             log_warning("chat.rejected", status=400, phase="prompt", reason=str(exc))
             return _error_response(str(exc), 400, "invalid_request_error")
 
@@ -1166,11 +1206,13 @@ def create_app(
         try:
             reasoning_effort = normalize_reasoning_effort(reasoning_effort)
         except RunnerError as exc:
+            request.state.telemetry_error_type = exc.error_type
             log_warning("chat.rejected", status=exc.status_code, phase="reasoning_effort")
             return _error_response(str(exc), exc.status_code, exc.error_type)
 
         quarantined = quarantine.reason(payload.model)
         if quarantined is not None:
+            request.state.telemetry_error_type = "model_not_found"
             log_warning("chat.rejected", status=404, phase="model", model=payload.model)
             return _error_response(quarantined, 404, "model_not_found")
 
@@ -1207,6 +1249,7 @@ def create_app(
             lease = await admission.acquire(deadline)
         except AdmissionRejectedError:
             metrics.increment_overload_rejections()
+            request.state.telemetry_error_type = "rate_limit_error"
             log_warning("chat.rejected", status=429, phase="queue")
             return _error_response(
                 "Factory Droid request queue is full.",
@@ -1215,6 +1258,7 @@ def create_app(
                 headers={"Retry-After": str(resolved_settings.retry_after_seconds)},
             )
         except TimeoutError:
+            request.state.telemetry_error_type = "factory_droid_timeout"
             log_warning(
                 "chat.rejected",
                 status=504,
@@ -1326,6 +1370,7 @@ def create_app(
                         stop_sequences=payload.stop_sequences,
                     )
                     if result is None:
+                        request.state.telemetry_error_type = "client_disconnected"
                         return _error_response(
                             "Client disconnected.",
                             499,
@@ -1343,6 +1388,7 @@ def create_app(
                     total_usage = _add_usage(total_usage, result.usage)
                     choices.append(_choice_dict(result, index))
         except ProtocolError as exc:
+            request.state.telemetry_error_type = "factory_protocol_error"
             log_warning(
                 "chat.failed",
                 status=502,
@@ -1351,6 +1397,7 @@ def create_app(
             )
             return _error_response(str(exc), 502, "factory_protocol_error")
         except RunnerError as exc:
+            request.state.telemetry_error_type = exc.error_type
             log_warning("chat.failed", status=exc.status_code, error_type=exc.error_type)
             note_runner_failure(payload.model, exc)
             return _error_response(str(exc), exc.status_code, exc.error_type)
@@ -2257,6 +2304,45 @@ def _content_length(scope: Scope) -> int | None:
     return None
 
 
+def _set_request_state(scope: Scope, **values: object) -> None:
+    state = scope.get("state")
+    if not isinstance(state, dict):
+        state = {}
+        scope["state"] = state
+    state.update(values)
+
+
+def _request_state(scope: Scope) -> dict[str, object]:
+    state = scope.get("state")
+    return state if isinstance(state, dict) else {}
+
+
+def _payload_size_bucket(size: int) -> str:
+    if size <= 0:
+        return "empty"
+    for upper, bucket in _PAYLOAD_SIZE_BUCKETS:
+        if size < upper:
+            return bucket
+    return "gt_1mb"
+
+
+def _latency_bucket(seconds: float) -> str:
+    for upper, bucket in _LATENCY_BUCKETS:
+        if seconds < upper:
+            return bucket
+    return "gt_30s"
+
+
+def _model_family(model: str) -> str:
+    normalized = model.strip().lower()
+    if normalized == "factory-droid":
+        return "factory_default"
+    for prefixes, family in _MODEL_FAMILY_PREFIXES:
+        if normalized.startswith(prefixes):
+            return family
+    return "other"
+
+
 def _json_content_type(scope: Scope) -> bool:
     for name, value in scope.get("headers", []):
         if name.lower() != b"content-type":
@@ -2357,12 +2443,80 @@ def _request_route(scope: Scope) -> str:
 
 
 def _request_mode(scope: Scope) -> str:
-    state = scope.get("state")
-    if isinstance(state, dict):
-        mode = state.get("telemetry_mode")
-        if mode in {"stream", "non_stream"}:
-            return str(mode)
+    mode = _request_state(scope).get("telemetry_mode")
+    if mode in {"stream", "non_stream"}:
+        return str(mode)
     return "not_applicable"
+
+
+def _telemetry_error_category(
+    scope: Scope,
+    *,
+    status_code: int,
+    outcome: str,
+) -> str:
+    error_type = _request_state(scope).get("telemetry_error_type")
+    if isinstance(error_type, str):
+        categories = {
+            "authentication_error": "authentication",
+            "client_disconnected": "cancelled",
+            "factory_droid_timeout": "timeout",
+            "factory_incomplete_response": "incomplete_response",
+            "factory_protocol_error": "protocol",
+            "factory_droid_sdk_error": "sdk",
+            "invalid_request_error": "invalid_request",
+            "model_not_found": "model_not_found",
+            "rate_limit_error": "rate_limited",
+            "session_not_found": "session_not_found",
+        }
+        return categories.get(error_type, "other")
+    if outcome in {"cancelled"} or status_code == 499:
+        return "cancelled"
+    if outcome in {"malformed", "truncated"}:
+        return "protocol"
+    if outcome == "error" and status_code < 400:
+        return "stream_error"
+    if status_code == 413:
+        return "payload_too_large"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code in {408, 504}:
+        return "timeout"
+    if status_code == 401:
+        return "authentication"
+    if status_code == 404:
+        return "not_found"
+    if 400 <= status_code < 500:
+        return "invalid_request"
+    if status_code >= 500:
+        return "server_error"
+    return "other"
+
+
+def _request_telemetry_features(
+    scope: Scope,
+    *,
+    status_code: int,
+    seconds: float,
+) -> tuple[str, ...]:
+    route = _request_route(scope)
+    state = _request_state(scope)
+    outcome = _request_outcome(status_code, scope)
+    features = [
+        f"request_latency:{route}:{_latency_bucket(max(0.0, seconds))}",
+        f"request_payload:{route}:{state.get('payload_size_bucket', 'unknown')}",
+    ]
+    model_family = state.get("telemetry_model_family")
+    if route == "chat_completions" and isinstance(model_family, str):
+        features.append(f"model_family:{model_family}")
+    if outcome != "success":
+        error_category = _telemetry_error_category(
+            scope,
+            status_code=status_code,
+            outcome=outcome,
+        )
+        features.append(f"request_error:{route}:{error_category}")
+    return tuple(features)
 
 
 def _observe_ttft(

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -58,6 +58,7 @@ class BridgeMetrics:
         *,
         route: str = "other",
         mode: str = "not_applicable",
+        features: tuple[str, ...] = (),
     ) -> None:
         with self._lock:
             self._request_totals[(outcome, status_code)] += 1
@@ -68,6 +69,7 @@ class BridgeMetrics:
             self._telemetry_request_duration_seconds[key] = (
                 self._telemetry_request_duration_seconds.get(key, 0.0) + max(0.0, seconds)
             )
+            self._telemetry_features.update(features)
 
     def record_features(self, features: tuple[str, ...]) -> None:
         with self._lock:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,11 +24,16 @@ from factory_droid_openai.app import (
     _content_length,
     _finalize_stream,
     _JsonDepthTracker,
+    _latency_bucket,
+    _model_family,
+    _payload_size_bucket,
     _request_mode,
     _request_outcome,
     _request_route,
+    _request_telemetry_features,
     _RequestPayloadLimitError,
     _stream_completion,
+    _telemetry_error_category,
     _validation_message,
     _wait_for_disconnect,
     create_app,
@@ -1715,6 +1720,95 @@ def test_request_telemetry_classifies_routes_and_modes() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("factory-droid", "factory_default"),
+        ("gpt-5.4", "gpt"),
+        ("gemini-3.1-pro", "gemini"),
+        ("claude-sonnet", "claude"),
+        ("custom-model", "other"),
+    ],
+)
+def test_model_family_is_coarse_and_stable(model: str, expected: str) -> None:
+    assert _model_family(model) == expected
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0.099, "lt_100ms"),
+        (0.1, "100ms_500ms"),
+        (0.5, "500ms_1s"),
+        (1.0, "1s_5s"),
+        (5.0, "5s_30s"),
+        (30.0, "gt_30s"),
+    ],
+)
+def test_latency_bucket_is_bounded(seconds: float, expected: str) -> None:
+    assert _latency_bucket(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (0, "empty"),
+        (10_239, "lt_10kb"),
+        (10_240, "10kb_100kb"),
+        (102_400, "100kb_1mb"),
+        (1_048_576, "gt_1mb"),
+    ],
+)
+def test_payload_size_bucket_is_bounded(size: int, expected: str) -> None:
+    assert _payload_size_bucket(size) == expected
+
+
+def test_request_telemetry_features_use_only_coarse_dimensions() -> None:
+    scope = cast(
+        "Any",
+        {
+            "path": "/v1/chat/completions",
+            "state": {
+                "telemetry_model_family": "gpt",
+                "payload_size_bucket": "10kb_100kb",
+            },
+        },
+    )
+
+    features = _request_telemetry_features(scope, status_code=504, seconds=5.0)
+
+    assert features == (
+        "request_latency:chat_completions:5s_30s",
+        "request_payload:chat_completions:10kb_100kb",
+        "model_family:gpt",
+        "request_error:chat_completions:timeout",
+    )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "outcome", "expected"),
+    [
+        (429, "error", "rate_limited"),
+        (401, "error", "authentication"),
+        (404, "error", "not_found"),
+        (200, "success", "other"),
+    ],
+)
+def test_telemetry_error_category_covers_status_fallbacks(
+    status_code: int,
+    outcome: str,
+    expected: str,
+) -> None:
+    assert (
+        _telemetry_error_category(
+            cast("Any", {"state": {}}),
+            status_code=status_code,
+            outcome=outcome,
+        )
+        == expected
+    )
+
+
 @pytest.mark.asyncio
 async def test_chat_endpoint_requires_configured_bearer_token(tmp_path: Path) -> None:
     runner = FakeRunner([RunComplete(Usage())])
@@ -3171,6 +3265,21 @@ async def test_lifespan_flushes_anonymous_telemetry(
     assert {"name": "feature", "feature": "tools", "count": 1} in events
     assert {"name": "feature", "feature": "reasoning_effort", "count": 1} in events
     assert {"name": "feature", "feature": "multiple_choices", "count": 1} in events
+    assert {
+        "name": "feature",
+        "feature": "model_family:factory_default",
+        "count": 1,
+    } in events
+    assert any(
+        event["name"] == "feature"
+        and str(event["feature"]).startswith("request_latency:chat_completions:")
+        for event in events
+    )
+    assert any(
+        event["name"] == "feature"
+        and str(event["feature"]).startswith("request_payload:chat_completions:")
+        for event in events
+    )
     assert "Hello" not in json.dumps(payloads)
     assert "factory-droid" not in json.dumps(payloads)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -29,6 +29,10 @@ def test_metrics_snapshot_contains_only_telemetry_dimensions() -> None:
         1.25,
         route="chat_completions",
         mode="stream",
+        features=(
+            "model_family:gpt",
+            "request_latency:chat_completions:1s_5s",
+        ),
     )
     metrics.record_request(
         "error",
@@ -61,7 +65,12 @@ def test_metrics_snapshot_contains_only_telemetry_dimensions() -> None:
         RequestMetric("health", "success", "not_applicable", 2, 1),
         RequestMetric("models", "error", "not_applicable", 1, 0),
     )
-    assert snapshot.features == (("attachments", 1), ("tools", 2))
+    assert snapshot.features == (
+        ("attachments", 1),
+        ("model_family:gpt", 1),
+        ("request_latency:chat_completions:1s_5s", 1),
+        ("tools", 2),
+    )
     assert snapshot.internal == (
         ("forced_kill", 1),
         ("model_discovery_failure", 1),


### PR DESCRIPTION
## Summary

- Add coarse latency and payload-size telemetry buckets by route.
- Add normalized model-family and error-category aggregates.
- Preserve privacy: no raw prompts, responses, model names, or error messages.
- Raise coverage gate to 100% and add missing branch tests.

## Validation

- 712 tests passed
- 100.00% coverage
- Ruff check and format check
- mypy
- OpenAPI validation
- uv lock --check
- uv build