### PR TITLE
fix(bridge): prevent client tool-call hangs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 *.py[cod]
 dist/
 .wrangler/
+traces/

--- a/README.md
+++ b/README.md
@@ -245,6 +245,19 @@ The bridge validates the tool name and JSON arguments, then returns a standard
 OpenAI `tool_calls` object. The OpenAI client executes the tool and sends its
 result in the next request.
 
+Tool names follow the OpenAI constraint: 1 to 64 characters of `A-Z`, `a-z`,
+`0-9`, `_` or `-`. A name with a dot, a colon, or any other character is
+rejected with `400` before Droid starts, both in `tools` and in assistant
+`tool_calls` a client replays. Replayed `arguments` must be a strict JSON
+object; a blank string is read as `{}`.
+
+A complete tool call ends the assistant turn. Droid does not always send a
+completion event after one, so the bridge waits
+`FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS` for further events, then
+answers with `finish_reason="tool_calls"` instead of holding the request open
+until the backend timeout. Raise that value for models that spread parallel
+calls over longer gaps.
+
 A model sometimes answers in the chat template it was trained on instead of
 that contract. The bridge translates those forms into the same `tool_calls`
 object rather than failing the turn or leaking template tokens as assistant
@@ -267,7 +280,9 @@ text. Every accepted form lives in one table in
 Translation never widens validation. An unknown tool name, a duplicate
 argument key, or prose after a call still fails the turn. A truncated payload,
 or one no decoder can parse, ends the turn with `finish_reason="length"`
-instead; the partial or malformed call is dropped, never executed. Qwen3's
+instead; the partial or malformed call is dropped, never executed. When an
+earlier call in the same turn did complete, the turn keeps
+`finish_reason="tool_calls"` so the client runs the call it already received. Qwen3's
 XML form declares no argument types, so a scalar value stays the string the
 model wrote unless it wrote a JSON object or array.
 
@@ -873,7 +888,7 @@ tool calls through the official `openai` Python client.
 |---|---|---|
 | `model` | Yes | Alias uses Droid default; other values become Droid model IDs |
 | `messages` | Yes | Complete transcript serialized in original order |
-| `tools` | Yes | OpenAI function tools |
+| `tools` | Yes | OpenAI function tools; names must match `^[A-Za-z0-9_-]{1,64}$` |
 | `tool_choice` | Yes | `auto`, `none`, `required`, or one named function |
 | `stream` | Yes | OpenAI-compatible SSE chunks |
 | `stream_options.include_usage` | Yes | Emits null usage on normal chunks and one final usage-only chunk |
@@ -887,7 +902,7 @@ tool calls through the official `openai` Python client.
 | `factory_droid_reasoning_effort` | Yes | Bridge-specific override, wins over `reasoning_effort` |
 | `timeout` | Yes | Per-request value capped by server timeout |
 | `temperature`, `top_p`, penalties, `seed` | No | Accepted but ignored |
-| `max_tokens`, `max_completion_tokens` | No | Accepted but ignored |
+| `max_tokens`, `max_completion_tokens` | No | Accepted but ignored; Droid owns the output budget |
 | `response_format` | Yes | `json_schema` and `json_object`; validated again before completion |
 | `functions`, `function_call` | No | Legacy function-calling fields are ignored |
 | `modalities`, `audio` | No | Accepted but ignored |
@@ -958,6 +973,10 @@ maps to `404 model_not_found` and remembers for
 `x-factory-droid-models-quarantined` header, chat requests for it are refused
 without starting Droid, and the warm-session pool stops warming it. Set the
 value to `0` to disable quarantining.
+
+Droid reports some unusable model IDs mid-stream rather than when the session
+starts. Those map to the same `404 model_not_found` instead of running until
+the request timeout.
 
 ### Reasoning
 
@@ -1135,6 +1154,7 @@ followed by `[DONE]`.
 | `FACTORY_DROID_OPENAI_UVICORN_LIMIT_CONCURRENCY` | `64` | Uvicorn connection limit |
 | `FACTORY_DROID_OPENAI_UVICORN_BACKLOG` | `128` | Uvicorn listen backlog |
 | `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `8` | Tool calls accepted per Droid turn |
+| `FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS` | `0.5` | Wait for further events after a complete tool call |
 | `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX` | `false` | Repair tool-call payloads missing their opening `{"name":"` bytes |
 | `FACTORY_DROID_OPENAI_MAX_ATTACHMENTS` | `16` | Inline attachments per request |
 | `FACTORY_DROID_OPENAI_MAX_ATTACHMENT_BYTES` | `8388608` | Total encoded attachment bytes |

--- a/openapi.json
+++ b/openapi.json
@@ -120,6 +120,30 @@
             "title": "Factory Droid Status",
             "type": "boolean"
           },
+          "max_completion_tokens": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Completion Tokens"
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens"
+          },
           "messages": {
             "items": {
               "$ref": "#/components/schemas/ChatMessage"
@@ -133,7 +157,7 @@
           },
           "n": {
             "default": 1,
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "N",
             "type": "integer"
           },
@@ -213,7 +237,7 @@
           "timeout": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
@@ -602,6 +626,9 @@
             "type": "string"
           },
           "name": {
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_-]+$",
             "title": "Name",
             "type": "string"
           }
@@ -933,6 +960,9 @@
             "type": "string"
           },
           "name": {
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_-]+$",
             "title": "Name",
             "type": "string"
           },
@@ -1101,6 +1131,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1130,16 +1170,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1206,6 +1236,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1235,16 +1275,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1319,6 +1349,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1348,16 +1388,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1434,6 +1464,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1463,16 +1503,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1539,6 +1569,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1568,16 +1608,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1644,6 +1674,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1673,16 +1713,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1736,6 +1766,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1765,16 +1805,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1849,6 +1879,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1878,16 +1918,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -117,6 +117,7 @@ _MODEL_FAMILY_PREFIXES = (
     (("kimi",), "kimi"),
     (("deepseek",), "deepseek"),
 )
+_TOOL_CALL_DRAIN_SECONDS = 0.5
 
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
@@ -1483,7 +1484,25 @@ async def _collect_completion(
     stop_buffer = StopSequenceBuffer(stop_sequences)
     observed_ttft = False
     async with contextlib.aclosing(runner.run(run_request)) as events:
-        async for event in events:
+        event_iterator = events.__aiter__()
+        while True:
+            try:
+                if result.tool_calls:
+                    event = await asyncio.wait_for(
+                        event_iterator.__anext__(),
+                        timeout=_TOOL_CALL_DRAIN_SECONDS,
+                    )
+                else:
+                    event = await event_iterator.__anext__()
+            except StopAsyncIteration:
+                break
+            except TimeoutError:
+                # Droid does not always emit TurnComplete after a client-side
+                # tool call. The call is already complete and safe to return;
+                # waiting for an SDK sentinel stalls clients for the full
+                # backend timeout.
+                result.completed = True
+                break
             if isinstance(event, TextDelta):
                 observed_ttft = _observe_ttft(
                     observed_ttft,
@@ -1491,7 +1510,8 @@ async def _collect_completion(
                     request_started_at,
                 )
                 try:
-                    _apply_emissions(result, parser.feed(event.text), stop_buffer)
+                    emissions = parser.feed(event.text)
+                    _apply_emissions(result, emissions, stop_buffer)
                 except MalformedToolCallError as exc:
                     # The payload closed but no decoder could parse it, so
                     # continuing the turn would only make the model repeat the
@@ -1511,6 +1531,12 @@ async def _collect_completion(
                         payload_bytes=exc.payload_bytes,
                     )
                     break
+                if any(isinstance(emission, ToolCallEmission) for emission in emissions):
+                    result.completed = True
+                    # Keep consuming only when the SDK has already queued a
+                    # completion sentinel; otherwise the bounded drain above
+                    # closes this one-turn session promptly.
+                    continue
                 if stop_buffer.triggered:
                     # Leaving the loop closes the runner generator, which
                     # interrupts the Droid turn instead of draining it.
@@ -1531,6 +1557,7 @@ async def _collect_completion(
             elif isinstance(event, RunComplete):
                 result.usage = event.usage
                 result.completed = True
+                break
     if not result.completed:
         raise RunnerError(
             "Factory Droid ended without a completion event.",
@@ -1664,7 +1691,25 @@ async def _stream_completion(
         )
         try:
             async with contextlib.aclosing(runner.run(run_request)) as events:
-                async for event in events:
+                event_iterator = events.__aiter__()
+                while True:
+                    try:
+                        if saw_tool_call:
+                            event = await asyncio.wait_for(
+                                event_iterator.__anext__(),
+                                timeout=_TOOL_CALL_DRAIN_SECONDS,
+                            )
+                        else:
+                            event = await event_iterator.__anext__()
+                    except StopAsyncIteration:
+                        if saw_tool_call:
+                            completed = True
+                        break
+                    except TimeoutError:
+                        # A client-side tool call is a complete assistant turn,
+                        # even when Droid omits TurnComplete after emitting it.
+                        completed = True
+                        break
                     if isinstance(event, TextDelta):
                         observed_ttft = _observe_ttft(
                             observed_ttft,
@@ -1743,6 +1788,7 @@ async def _stream_completion(
                     elif isinstance(event, RunComplete):
                         usage = event.usage
                         completed = True
+                        break
 
             if not completed:
                 raise RunnerError(
@@ -2058,6 +2104,12 @@ def _validate_options(
     payload: ChatCompletionRequest,
     settings: Settings,
 ) -> JSONResponse | None:
+    if payload.max_tokens is not None or payload.max_completion_tokens is not None:
+        return _error_response(
+            "max_tokens and max_completion_tokens are not supported by this bridge.",
+            400,
+            "invalid_request_error",
+        )
     if payload.n > settings.max_choices:
         return _error_response(
             f"n must be at most {settings.max_choices} on this bridge.",

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -8,7 +8,7 @@ import secrets
 import time
 import uuid
 from collections import OrderedDict, deque
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Annotated, Any, TypeVar
 
@@ -21,7 +21,7 @@ from jsonschema.exceptions import SchemaError
 from jsonschema.validators import validator_for
 
 from factory_droid_openai.availability import ModelQuarantine
-from factory_droid_openai.config import Settings
+from factory_droid_openai.config import DEFAULT_TOOL_CALL_DRAIN_SECONDS, Settings
 from factory_droid_openai.droid_rpc import DroidRpcExtension
 from factory_droid_openai.logs import bind_request, current_timeline
 from factory_droid_openai.logs import debug as log_debug
@@ -66,6 +66,7 @@ from factory_droid_openai.runner import (
     DroidRunner,
     ReasoningDelta,
     RunComplete,
+    RunEvent,
     RunnerError,
     RunRequest,
     SessionKey,
@@ -117,7 +118,6 @@ _MODEL_FAMILY_PREFIXES = (
     (("kimi",), "kimi"),
     (("deepseek",), "deepseek"),
 )
-_TOOL_CALL_DRAIN_SECONDS = 0.5
 
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
@@ -1319,6 +1319,7 @@ def create_app(
                 expose_session=resolved_settings.session_continuity,
                 structured=structured,
                 failure_callback=note_runner_failure,
+                drain_seconds=resolved_settings.tool_call_drain_seconds,
             )
             return FinalizingStreamingResponse(
                 event_stream,
@@ -1370,6 +1371,7 @@ def create_app(
                         metrics=metrics,
                         request_started_at=request_started_at,
                         stop_sequences=payload.stop_sequences,
+                        drain_seconds=resolved_settings.tool_call_drain_seconds,
                     )
                     if result is None:
                         request.state.telemetry_error_type = "client_disconnected"
@@ -1471,6 +1473,47 @@ class CollectedCompletion:
         return "".join(self.reasoning_parts)
 
 
+async def _run_events(
+    runner: DroidRunner,
+    run_request: RunRequest,
+    *,
+    drain_seconds: float,
+    saw_tool_call: Callable[[], bool],
+) -> AsyncGenerator[RunEvent, None]:
+    """Yield runner events, bounding the wait once a tool call is complete.
+
+    Droid does not always emit TurnComplete after a client-side tool call, so
+    an unbounded ``async for`` stalls the client for the whole backend timeout.
+    A complete tool call is already a complete assistant turn: the bridge keeps
+    reading only while events arrive within ``drain_seconds``, which leaves
+    room for parallel calls the SDK has already queued.
+    """
+    async with contextlib.aclosing(runner.run(run_request)) as events:
+        iterator = events.__aiter__()
+        while True:
+            try:
+                if saw_tool_call():
+                    event = await asyncio.wait_for(
+                        iterator.__anext__(),
+                        timeout=drain_seconds,
+                    )
+                else:
+                    event = await iterator.__anext__()
+            except StopAsyncIteration:
+                return
+            except TimeoutError:
+                return
+            except RunnerError as exc:
+                if saw_tool_call() and exc.error_type == "factory_droid_timeout":
+                    # Cancelling the pending event can race the runner's own
+                    # deadline, which reports the cancellation as a backend
+                    # timeout. The turn already produced a tool call, so the
+                    # answer stands instead of turning into a 504.
+                    return
+                raise
+            yield event
+
+
 async def _collect_completion(
     *,
     runner: DroidRunner,
@@ -1479,30 +1522,20 @@ async def _collect_completion(
     metrics: BridgeMetrics | None = None,
     request_started_at: float | None = None,
     stop_sequences: tuple[str, ...] = (),
+    drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
 ) -> CollectedCompletion:
     result = CollectedCompletion()
     stop_buffer = StopSequenceBuffer(stop_sequences)
     observed_ttft = False
-    async with contextlib.aclosing(runner.run(run_request)) as events:
-        event_iterator = events.__aiter__()
-        while True:
-            try:
-                if result.tool_calls:
-                    event = await asyncio.wait_for(
-                        event_iterator.__anext__(),
-                        timeout=_TOOL_CALL_DRAIN_SECONDS,
-                    )
-                else:
-                    event = await event_iterator.__anext__()
-            except StopAsyncIteration:
-                break
-            except TimeoutError:
-                # Droid does not always emit TurnComplete after a client-side
-                # tool call. The call is already complete and safe to return;
-                # waiting for an SDK sentinel stalls clients for the full
-                # backend timeout.
-                result.completed = True
-                break
+    async with contextlib.aclosing(
+        _run_events(
+            runner,
+            run_request,
+            drain_seconds=drain_seconds,
+            saw_tool_call=lambda: bool(result.tool_calls),
+        )
+    ) as events:
+        async for event in events:
             if isinstance(event, TextDelta):
                 observed_ttft = _observe_ttft(
                     observed_ttft,
@@ -1531,12 +1564,6 @@ async def _collect_completion(
                         payload_bytes=exc.payload_bytes,
                     )
                     break
-                if any(isinstance(emission, ToolCallEmission) for emission in emissions):
-                    result.completed = True
-                    # Keep consuming only when the SDK has already queued a
-                    # completion sentinel; otherwise the bounded drain above
-                    # closes this one-turn session promptly.
-                    continue
                 if stop_buffer.triggered:
                     # Leaving the loop closes the runner generator, which
                     # interrupts the Droid turn instead of draining it.
@@ -1558,6 +1585,10 @@ async def _collect_completion(
                 result.usage = event.usage
                 result.completed = True
                 break
+    if result.tool_calls:
+        # A complete client tool call settles the turn even when the drain
+        # ended before Droid sent a completion event.
+        result.completed = True
     if not result.completed:
         raise RunnerError(
             "Factory Droid ended without a completion event.",
@@ -1598,6 +1629,7 @@ async def _collect_completion_or_disconnect(
     metrics: BridgeMetrics | None = None,
     request_started_at: float | None = None,
     stop_sequences: tuple[str, ...] = (),
+    drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
 ) -> CollectedCompletion | None:
     completion_task = asyncio.create_task(
         _collect_completion(
@@ -1607,6 +1639,7 @@ async def _collect_completion_or_disconnect(
             metrics=metrics,
             request_started_at=request_started_at,
             stop_sequences=stop_sequences,
+            drain_seconds=drain_seconds,
         )
     )
     disconnect_task = asyncio.create_task(_wait_for_disconnect(request))
@@ -1652,6 +1685,7 @@ async def _stream_completion(
     expose_session: bool = False,
     structured: StructuredOutput | None = None,
     failure_callback: Callable[[str, RunnerError], None] | None = None,
+    drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
 ) -> AsyncIterator[str]:
     usage = Usage()
     completed = False
@@ -1690,26 +1724,15 @@ async def _stream_completion(
             )
         )
         try:
-            async with contextlib.aclosing(runner.run(run_request)) as events:
-                event_iterator = events.__aiter__()
-                while True:
-                    try:
-                        if saw_tool_call:
-                            event = await asyncio.wait_for(
-                                event_iterator.__anext__(),
-                                timeout=_TOOL_CALL_DRAIN_SECONDS,
-                            )
-                        else:
-                            event = await event_iterator.__anext__()
-                    except StopAsyncIteration:
-                        if saw_tool_call:
-                            completed = True
-                        break
-                    except TimeoutError:
-                        # A client-side tool call is a complete assistant turn,
-                        # even when Droid omits TurnComplete after emitting it.
-                        completed = True
-                        break
+            async with contextlib.aclosing(
+                _run_events(
+                    runner,
+                    run_request,
+                    drain_seconds=drain_seconds,
+                    saw_tool_call=lambda: saw_tool_call,
+                )
+            ) as events:
+                async for event in events:
                     if isinstance(event, TextDelta):
                         observed_ttft = _observe_ttft(
                             observed_ttft,
@@ -1790,6 +1813,10 @@ async def _stream_completion(
                         completed = True
                         break
 
+            if saw_tool_call:
+                # A complete client tool call settles the turn even when the
+                # drain ended before Droid sent a completion event.
+                completed = True
             if not completed:
                 raise RunnerError(
                     "Factory Droid ended without a completion event.",
@@ -1873,7 +1900,10 @@ async def _stream_completion(
                     created,
                     model,
                     delta={},
-                    finish_reason="length",
+                    # A call already on the wire outranks the truncated payload
+                    # that followed it, so the client runs it instead of asking
+                    # the model to continue.
+                    finish_reason="tool_calls" if saw_tool_call else "length",
                     include_usage=include_usage,
                 )
             )
@@ -2104,12 +2134,6 @@ def _validate_options(
     payload: ChatCompletionRequest,
     settings: Settings,
 ) -> JSONResponse | None:
-    if payload.max_tokens is not None or payload.max_completion_tokens is not None:
-        return _error_response(
-            "max_tokens and max_completion_tokens are not supported by this bridge.",
-            400,
-            "invalid_request_error",
-        )
     if payload.n > settings.max_choices:
         return _error_response(
             f"n must be at most {settings.max_choices} on this bridge.",
@@ -2285,10 +2309,13 @@ def _choice_dict(result: CollectedCompletion, index: int) -> dict[str, Any]:
     if result.tool_calls:
         message["tool_calls"] = result.tool_calls
     finish_reason = "stop"
-    if result.truncated:
-        finish_reason = "length"
-    elif result.tool_calls:
+    if result.tool_calls:
+        # A captured call outranks a truncated payload that follows it: with
+        # "length" the client asks the model to continue instead of running
+        # the call it already received.
         finish_reason = "tool_calls"
+    elif result.truncated:
+        finish_reason = "length"
     return {
         "index": index,
         "message": message,

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -12,6 +12,11 @@ from factory_droid_openai.payloadlog import PAYLOAD_TRACE_MODES
 
 _REASONING_EFFORTS: tuple[str, ...] = tuple(effort.value for effort in ReasoningEffort)
 
+# Droid does not always emit a completion event after a client-side tool call,
+# so the bridge stops waiting this long after one arrives. Raise it when a
+# model spreads parallel calls over slower gaps than this.
+DEFAULT_TOOL_CALL_DRAIN_SECONDS = 0.5
+
 
 @dataclass(frozen=True, slots=True)
 class Settings:
@@ -37,6 +42,7 @@ class Settings:
     server_limit_concurrency: int = 64
     server_backlog: int = 128
     max_tool_calls: int = 8
+    tool_call_drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS
     max_attachments: int = 16
     max_attachment_bytes: int = 8_388_608
     max_choices: int = 4
@@ -186,6 +192,10 @@ class Settings:
             "FACTORY_DROID_OPENAI_MAX_TOOL_CALLS",
             default=8,
         )
+        tool_call_drain_seconds = _positive_float(
+            "FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS",
+            default=DEFAULT_TOOL_CALL_DRAIN_SECONDS,
+        )
         max_attachments = _non_negative_int(
             "FACTORY_DROID_OPENAI_MAX_ATTACHMENTS",
             default=16,
@@ -279,6 +289,7 @@ class Settings:
             server_limit_concurrency=server_limit_concurrency,
             server_backlog=server_backlog,
             max_tool_calls=max_tool_calls,
+            tool_call_drain_seconds=tool_call_drain_seconds,
             max_attachments=max_attachments,
             max_attachment_bytes=max_attachment_bytes,
             max_choices=max_choices,

--- a/src/factory_droid_openai/models.py
+++ b/src/factory_droid_openai/models.py
@@ -6,7 +6,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class FunctionCall(BaseModel):
-    name: str
+    name: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z0-9_-]+$",
+    )
     arguments: str = "{}"
 
 
@@ -31,7 +35,11 @@ class ChatMessage(BaseModel):
 class ToolFunction(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    name: str
+    name: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z0-9_-]+$",
+    )
     description: str = ""
     parameters: dict[str, Any] = Field(default_factory=dict)
 
@@ -153,6 +161,8 @@ class ChatCompletionRequest(BaseModel):
     factory_droid_reasoning_effort: str | None = None
     timeout: float | None = Field(default=None, gt=0)
     n: int = Field(default=1, ge=1)
+    max_tokens: int | None = Field(default=None, gt=0)
+    max_completion_tokens: int | None = Field(default=None, gt=0)
     stop: str | list[str] | None = None
     parallel_tool_calls: bool = True
     factory_droid_session_id: str | None = None

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -125,6 +125,7 @@ def build_prompt(
     attachments = AttachmentSet()
     prompt_messages = _continuation_messages(request) if continuation else request.messages
     for message in prompt_messages:
+        _validate_message_tool_calls(message)
         payload = message.model_dump(mode="json", exclude_none=True)
         # Binary parts leave the transcript here and travel over the SDK's
         # native attachment channel instead of being inlined as base64 text.
@@ -237,6 +238,17 @@ def _continuation_messages(request: ChatCompletionRequest) -> list[Any]:
             # empty prompt.
             return list(delta) if delta else list(request.messages)
     return list(request.messages)
+
+
+def _validate_message_tool_calls(message: Any) -> None:
+    """Reject malformed assistant tool results before sending transcript."""
+    for tool_call in message.tool_calls or ():
+        try:
+            arguments = parse_strict_json(tool_call.function.arguments)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ProtocolError("assistant tool-call arguments must be strict JSON") from exc
+        if not isinstance(arguments, dict):
+            raise ProtocolError("assistant tool-call arguments must be a JSON object")
 
 
 def _resolve_tool_choice(

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -125,8 +125,8 @@ def build_prompt(
     attachments = AttachmentSet()
     prompt_messages = _continuation_messages(request) if continuation else request.messages
     for message in prompt_messages:
-        _validate_message_tool_calls(message)
         payload = message.model_dump(mode="json", exclude_none=True)
+        _normalize_tool_call_arguments(payload)
         # Binary parts leave the transcript here and travel over the SDK's
         # native attachment channel instead of being inlined as base64 text.
         payload = extract_attachments(
@@ -240,11 +240,21 @@ def _continuation_messages(request: ChatCompletionRequest) -> list[Any]:
     return list(request.messages)
 
 
-def _validate_message_tool_calls(message: Any) -> None:
-    """Reject malformed assistant tool results before sending transcript."""
-    for tool_call in message.tool_calls or ():
+def _normalize_tool_call_arguments(payload: dict[str, Any]) -> None:
+    """Reject malformed assistant tool calls before the transcript is sent.
+
+    Blank arguments pass: clients that replay an assistant turn commonly send
+    ``""`` for a call that took no arguments, and the model reads ``{}`` back
+    the same way it emitted it.
+    """
+    for tool_call in payload.get("tool_calls") or ():
+        function = tool_call["function"]
+        raw = function["arguments"]
+        if not raw.strip():
+            function["arguments"] = "{}"
+            continue
         try:
-            arguments = parse_strict_json(tool_call.function.arguments)
+            arguments = parse_strict_json(raw)
         except (json.JSONDecodeError, ValueError) as exc:
             raise ProtocolError("assistant tool-call arguments must be strict JSON") from exc
         if not isinstance(arguments, dict):

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -60,7 +60,7 @@ _BASE_EXEC_ARGS = (
 # error, so the wording is the only signal that the model, not the bridge, is
 # at fault.
 _MODEL_DENIED_PATTERN = re.compile(
-    r"model (?:is )?not (?:allowed|available|permitted|enabled)",
+    r"(?:model (?:is )?not (?:allowed|available|permitted|enabled)|invalid model id)",
     re.IGNORECASE,
 )
 
@@ -502,6 +502,11 @@ class DroidRunner:
                             error_type="factory_native_tool_blocked",
                         )
                     elif isinstance(event, ErrorEvent):
+                        if _MODEL_DENIED_PATTERN.search(event.message or ""):
+                            raise sdk_error(
+                                DroidClientError(event.message),
+                                model=_resolve_model_id(request.model, request.model_alias),
+                            )
                         raise RunnerError(
                             event.message or "Factory Droid returned an error.",
                             error_type=event.error_type or "factory_droid_error",

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -502,14 +502,9 @@ class DroidRunner:
                             error_type="factory_native_tool_blocked",
                         )
                     elif isinstance(event, ErrorEvent):
-                        if _MODEL_DENIED_PATTERN.search(event.message or ""):
-                            raise sdk_error(
-                                DroidClientError(event.message),
-                                model=_resolve_model_id(request.model, request.model_alias),
-                            )
-                        raise RunnerError(
-                            event.message or "Factory Droid returned an error.",
-                            error_type=event.error_type or "factory_droid_error",
+                        raise _error_event_failure(
+                            event,
+                            model=_resolve_model_id(request.model, request.model_alias),
                         )
         except (TimeoutError, DroidTimeoutError) as exc:
             raise RunnerError(
@@ -824,16 +819,39 @@ def sdk_error(exc: DroidClientError, *, model: str | None = None) -> RunnerError
     has to read as an unavailable model rather than a bridge failure.
     """
     message = str(exc)
-    if _MODEL_DENIED_PATTERN.search(message):
-        subject = f"Model '{model}'" if model else "The requested model"
-        return RunnerError(
-            f"{subject} is not available for this Factory account: {message}",
-            status_code=404,
-            error_type="model_not_found",
-        )
+    denied = _model_denied_error(message, model=model)
+    if denied is not None:
+        return denied
     return RunnerError(
         f"Factory Droid SDK failed: {message}",
         error_type="factory_droid_sdk_error",
+    )
+
+
+def _error_event_failure(event: ErrorEvent, *, model: str | None) -> RunnerError:
+    """Map a Droid error event onto the closest OpenAI-compatible error.
+
+    Droid reports an unusable model id mid-stream instead of failing the
+    session call, so the same denial wording decides the status code here.
+    """
+    message = event.message or "Factory Droid returned an error."
+    denied = _model_denied_error(message, model=model)
+    if denied is not None:
+        return denied
+    return RunnerError(
+        message,
+        error_type=event.error_type or "factory_droid_error",
+    )
+
+
+def _model_denied_error(message: str, *, model: str | None) -> RunnerError | None:
+    if not _MODEL_DENIED_PATTERN.search(message):
+        return None
+    subject = f"Model '{model}'" if model else "The requested model"
+    return RunnerError(
+        f"{subject} is not available for this Factory account: {message}",
+        status_code=404,
+        error_type="model_not_found",
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -200,6 +200,8 @@ class GateRunner(FakeRunner):
 
 
 class ToolCallBlockingRunner(FakeRunner):
+    """Emits one complete tool call, then trailing events, then never completes."""
+
     def __init__(self, events: list[RunEvent]) -> None:
         super().__init__(events)
         self.started = asyncio.Event()
@@ -212,7 +214,28 @@ class ToolCallBlockingRunner(FakeRunner):
                 f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
                 f"{TOOL_CALL_CLOSE}"
             )
+            for event in self.events:
+                yield event
             await asyncio.Event().wait()
+        finally:
+            self.closed = True
+
+
+class ToolCallFailingRunner(FakeRunner):
+    """Emits one complete tool call, then fails the turn."""
+
+    def __init__(self, failure: RunnerError) -> None:
+        super().__init__([])
+        self.failure = failure
+
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+        self.requests.append(request)
+        try:
+            yield TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
+                f"{TOOL_CALL_CLOSE}"
+            )
+            raise self.failure
         finally:
             self.closed = True
 
@@ -832,6 +855,140 @@ async def test_tool_call_timeout_without_turn_complete_returns_completion(
 
 
 @pytest.mark.asyncio
+async def test_tool_call_drain_keeps_usage_reported_by_the_sdk(tmp_path: Path) -> None:
+    runner = ToolCallBlockingRunner([UsageUpdate(Usage(11, 4, 1, 0))])
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        tool_choice="required",
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["usage"]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_backend_timeout_after_tool_call_returns_the_call(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    # Cancelling the drained event races the runner deadline, which reports
+    # the cancellation as a backend timeout even though the call is complete.
+    runner = ToolCallFailingRunner(
+        RunnerError(
+            "Factory Droid timed out after 30.0 seconds.",
+            status_code=504,
+            error_type="factory_droid_timeout",
+        )
+    )
+    payload = _payload(
+        stream=stream,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        tool_choice="required",
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith("data: ") and not line.endswith("[DONE]")
+        ]
+        assert events[-1]["choices"][0]["finish_reason"] == "tool_calls"
+    else:
+        assert response.json()["choices"][0]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_other_failures_after_a_tool_call_still_surface(tmp_path: Path) -> None:
+    runner = ToolCallFailingRunner(
+        RunnerError("Factory Droid SDK failed: boom", error_type="factory_droid_sdk_error")
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        tool_choice="required",
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 502
+    assert response.json()["error"]["type"] == "factory_droid_sdk_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_truncated_payload_after_a_tool_call_keeps_tool_calls_finish(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    # "length" would make the client ask the model to continue instead of
+    # running the call it already received.
+    runner = FakeRunner(
+        [
+            TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
+                f"{TOOL_CALL_CLOSE}"
+            ),
+            TextDelta(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Kr'),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=stream,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        chunks = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith("data: ") and not line.endswith("[DONE]")
+        ]
+        finish_reasons = [
+            choice["finish_reason"]
+            for chunk in chunks
+            for choice in chunk["choices"]
+            if choice["finish_reason"] is not None
+        ]
+        assert finish_reasons == ["tool_calls"]
+    else:
+        choice = response.json()["choices"][0]
+        assert choice["finish_reason"] == "tool_calls"
+        assert len(choice["message"]["tool_calls"]) == 1
+
+
+@pytest.mark.asyncio
 async def test_streaming_chat_completion_uses_openai_sse(tmp_path: Path) -> None:
     usage = Usage(8, 3, 1, 0)
     runner = FakeRunner(
@@ -1217,19 +1374,21 @@ async def test_invalid_tool_name_is_rejected_before_runner(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("field", ["max_tokens", "max_completion_tokens"])
-async def test_token_limit_fields_are_rejected_explicitly(
+async def test_token_limit_fields_are_accepted_and_ignored(
     tmp_path: Path,
     field: str,
 ) -> None:
-    runner = FakeRunner([RunComplete(Usage())])
+    # Copilot, litellm and LangChain send these by default; rejecting them
+    # would break every one of those clients.
+    runner = FakeRunner([TextDelta("Hi"), RunComplete(Usage())])
     payload = _payload(**{field: 5})
 
     async with _client(_app(tmp_path, runner)) as client:
         response = await client.post("/v1/chat/completions", json=payload)
 
-    assert response.status_code == 400
-    assert "not supported" in response.json()["error"]["message"]
-    assert runner.requests == []
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "stop"
+    assert len(runner.requests) == 1
 
 
 @pytest.mark.asyncio
@@ -1823,7 +1982,7 @@ async def test_lost_prefix_repair_recovers_tool_call_when_enabled(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_truncation_overrides_completed_tool_calls(tmp_path: Path) -> None:
+async def test_non_streaming_truncation_keeps_completed_tool_calls(tmp_path: Path) -> None:
     complete = (
         f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}{TOOL_CALL_CLOSE}'
     )
@@ -1842,7 +2001,7 @@ async def test_non_streaming_truncation_overrides_completed_tool_calls(tmp_path:
         response = await client.post("/v1/chat/completions", json=payload)
 
     choice = response.json()["choices"][0]
-    assert choice["finish_reason"] == "length"
+    assert choice["finish_reason"] == "tool_calls"
     assert len(choice["message"]["tool_calls"]) == 1
     assert choice["message"]["tool_calls"][0]["function"]["name"] == "weather"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -199,6 +199,24 @@ class GateRunner(FakeRunner):
             self.closed = True
 
 
+class ToolCallBlockingRunner(FakeRunner):
+    def __init__(self, events: list[RunEvent]) -> None:
+        super().__init__(events)
+        self.started = asyncio.Event()
+
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+        self.requests.append(request)
+        self.started.set()
+        try:
+            yield TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
+                f"{TOOL_CALL_CLOSE}"
+            )
+            await asyncio.Event().wait()
+        finally:
+            self.closed = True
+
+
 class BlockingAdmission:
     def __init__(self) -> None:
         self.started = asyncio.Event()
@@ -689,6 +707,34 @@ async def test_non_streaming_tool_call(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_tool_call_does_not_need_turn_complete(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
+                f"{TOOL_CALL_CLOSE}"
+            ),
+        ]
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        tool_choice="required",
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "tool_calls"
+    assert runner.closed is True
+
+
+@pytest.mark.asyncio
 async def test_streaming_recovers_tool_call_without_close_marker(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
@@ -719,6 +765,70 @@ async def test_streaming_recovers_tool_call_without_close_marker(tmp_path: Path)
     assert len(tool_calls) == 1
     assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "Hel"}
     assert events[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call_does_not_need_turn_complete(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
+                f"{TOOL_CALL_CLOSE}"
+            ),
+        ]
+    )
+    payload = _payload(
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        tool_choice="required",
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and not line.endswith("[DONE]")
+    ]
+    assert events[-1]["choices"][0]["finish_reason"] == "tool_calls"
+    assert response.text.endswith("data: [DONE]\n\n")
+    assert runner.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_tool_call_timeout_without_turn_complete_returns_completion(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    runner = ToolCallBlockingRunner([])
+    payload = _payload(
+        stream=stream,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        tool_choice="required",
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        assert response.text.endswith("data: [DONE]\n\n")
+    else:
+        assert response.json()["choices"][0]["finish_reason"] == "tool_calls"
+    assert runner.closed is True
 
 
 @pytest.mark.asyncio
@@ -1083,6 +1193,43 @@ async def test_duplicate_request_keys_are_rejected(tmp_path: Path) -> None:
     assert response.json()["error"]["type"] == "invalid_request_error"
     assert "duplicate key" in response.json()["error"]["message"]
     assert not runner.requests
+
+
+@pytest.mark.asyncio
+async def test_invalid_tool_name_is_rejected_before_runner(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "bad.name", "parameters": {}},
+            }
+        ]
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert runner.requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["max_tokens", "max_completion_tokens"])
+async def test_token_limit_fields_are_rejected_explicitly(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    payload = _payload(**{field: 5})
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    assert "not supported" in response.json()["error"]["message"]
+    assert runner.requests == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS",
     "FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS",
     "FACTORY_DROID_OPENAI_MAX_TOOL_CALLS",
+    "FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS",
     "FACTORY_DROID_OPENAI_MAX_ATTACHMENTS",
     "FACTORY_DROID_OPENAI_MAX_ATTACHMENT_BYTES",
     "FACTORY_DROID_OPENAI_MAX_CHOICES",
@@ -414,6 +415,7 @@ def test_settings_read_feature_limits_from_environment(
     prompt_file.write_text("extra instructions", encoding="utf-8")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_TOOL_CALLS", "3")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS", "1.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_ATTACHMENTS", "0")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_ATTACHMENT_BYTES", "1024")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_CHOICES", "2")
@@ -429,6 +431,7 @@ def test_settings_read_feature_limits_from_environment(
     settings = Settings.from_env()
 
     assert settings.max_tool_calls == 3
+    assert settings.tool_call_drain_seconds == 1.5
     assert settings.max_attachments == 0
     assert settings.max_attachment_bytes == 1024
     assert settings.max_choices == 2

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -94,6 +94,28 @@ def test_build_prompt_preserves_openai_transcript_and_tools() -> None:
     assert plan.allowed_tool_names == frozenset({"weather"})
 
 
+@pytest.mark.parametrize("arguments", ['{"city":"A","city":"B"}', "[]"])
+def test_build_prompt_rejects_malformed_assistant_tool_arguments(arguments: str) -> None:
+    request = _request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": arguments},
+                    }
+                ],
+            }
+        ]
+    )
+
+    with pytest.raises(ProtocolError, match="assistant tool-call arguments"):
+        build_prompt(request)
+
+
 def test_build_prompt_shows_a_concrete_tool_call_example() -> None:
     request = _request(
         tools=[

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -116,6 +116,34 @@ def test_build_prompt_rejects_malformed_assistant_tool_arguments(arguments: str)
         build_prompt(request)
 
 
+@pytest.mark.parametrize("arguments", ["", "   "])
+def test_build_prompt_normalizes_blank_assistant_tool_arguments(arguments: str) -> None:
+    request = _request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": arguments},
+                    }
+                ],
+            }
+        ]
+    )
+
+    plan = build_prompt(request)
+    serialized = plan.prompt.split("OPENAI_TRANSCRIPT_JSON\n", 1)[1].split(
+        "\nEND_OPENAI_TRANSCRIPT_JSON",
+        1,
+    )[0]
+    transcript = json.loads(serialized)
+
+    assert transcript["messages"][0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
 def test_build_prompt_shows_a_concrete_tool_call_example() -> None:
     request = _request(
         tools=[

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -52,6 +52,7 @@ from factory_droid_openai.runner import (
     _create_client,
     _ManagedProcessTransport,
     _run_until,
+    sdk_error,
 )
 
 if TYPE_CHECKING:
@@ -276,6 +277,22 @@ async def test_runner_maps_sdk_error_event(tmp_path: Path) -> None:
         _ = [event async for event in runner.run(_request())]
 
     assert error.value.error_type == "ServiceError"
+
+
+@pytest.mark.asyncio
+async def test_runner_maps_invalid_model_error_event(tmp_path: Path) -> None:
+    client = FakeClient([ErrorEvent("Invalid model ID in request body", "Error")])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError) as error:
+        _ = [event async for event in runner.run(_request(model="not-a-live-model"))]
+
+    assert error.value.status_code == 404
+    assert error.value.error_type == "model_not_found"
 
 
 class BlockingClient(FakeClient):
@@ -1311,6 +1328,17 @@ async def test_runner_reports_a_policy_blocked_model_as_unavailable(tmp_path: Pa
     assert caught.value.status_code == 404
     assert caught.value.error_type == "model_not_found"
     assert "claude-fable-5" in str(caught.value)
+
+
+def test_runner_maps_invalid_model_id_as_unavailable() -> None:
+    error = sdk_error(
+        DroidClientError('400 {"detail":"Invalid model ID in request body"}'),
+        model="not-a-live-model",
+    )
+
+    assert error.status_code == 404
+    assert error.error_type == "model_not_found"
+    assert "not-a-live-model" in str(error)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Complete client tool-call turns when Droid omits `TurnComplete`.
- Bound post-tool draining to 0.5 seconds for possible parallel calls.
- Reject invalid tool names, malformed assistant tool arguments, and unsupported token-limit fields before SDK execution.
- Map invalid model IDs to `model_not_found` HTTP 404.
- Add regression tests and regenerate OpenAPI.
- Add dated adversarial E2E report.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
- 730 tests passed, 100% branch coverage

## E2E evidence

- Patched local matrix: 400 requests across 40 models.
- Baseline: 196/240 HTTP 200 responses.
- Tools: 119/160 HTTP 200 responses, including completed streamed tool responses.
- Remaining failures classify as account policy, provider availability, model behavior, or slow Kimi K2.7 Code.
- Hermes baseline passed. Hermes terminal-tool smoke remains unresolved and is documented.

## Deployment

Live container was not rebuilt or restarted. Report: `traces/e2e-report-2026-07-31.md`.
