### PR TITLE
test: add e2e matrix harness and offline replay fixtures

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,6 +50,16 @@ body:
       description: Output from `python --version`.
     validations:
       required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: >-
+        Model id sent in the request. Tool-call behavior differs per model, so
+        a report without it is hard to reproduce.
+      placeholder: claude-sonnet-4-5
+    validations:
+      required: true
   - type: dropdown
     id: response-mode
     attributes:
@@ -66,6 +76,20 @@ body:
       label: Sanitized logs
       description: Remove credentials, private paths, and sensitive prompt content.
       render: text
+  - type: textarea
+    id: recorded-events
+    attributes:
+      label: Recorded Droid events (optional, most useful)
+      description: >-
+        A recorded event stream turns this report into an offline regression
+        test. Restart the bridge with
+        `FACTORY_DROID_OPENAI_TRACE_PAYLOADS=full` and
+        `FACTORY_DROID_OPENAI_TRACE_FILE=/path/trace.jsonl`, reproduce once,
+        then paste the `droid.event` lines of that request:
+        `grep '"event": "droid.event"' /path/trace.jsonl`. Every line contains
+        the model output verbatim, so read it before pasting and remove
+        anything private. See the payload tracing section of the README.
+      render: json
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,5 @@ Describe the change and why it is needed.
 - [ ] OpenAI response shapes remain compatible in streaming and non-streaming modes.
 - [ ] Factory-native tools remain blocked.
 - [ ] Documentation and tests cover user-visible behavior changes.
+- [ ] Behavior found against a live model is frozen as a replay fixture in
+      `tests/fixtures/events/`, or the reason it cannot be is stated above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,49 @@ uv run ruff format .
 
 CI runs tests on every supported Python version.
 
+## End-to-end matrix
+
+The default suite never talks to Factory. Behavior that only shows up with a
+real model is covered by a separate, manual loop: run the matrix, read the
+verdicts, fix, run again, compare.
+
+Start a bridge with payload tracing on, then run every scenario against every
+model the bridge lists:
+
+```bash
+export FACTORY_DROID_OPENAI_TRACE_PAYLOADS=full
+export FACTORY_DROID_OPENAI_TRACE_FILE="$PWD/traces/trace.jsonl"
+uv run factory-droid-openai &
+uv run python scripts/e2e_matrix.py run --out traces/run-a.jsonl
+```
+
+Each request becomes one JSONL row with a verdict. Only `bridge_defect` fails
+the run; `model_behavior`, `account_policy`, `capacity`,
+`provider_unavailable`, and `backend_timeout` describe the environment, not the
+code. Re-render a report or diff two runs after a change:
+
+```bash
+uv run python scripts/e2e_matrix.py report traces/run-a.jsonl
+uv run python scripts/e2e_matrix.py compare traces/run-a.jsonl traces/run-b.jsonl
+```
+
+`compare` exits non-zero on any pass to non-pass transition, which makes it the
+A/B tool for prompt and parser changes.
+
+Turn what a live run found into offline regression tests:
+
+```bash
+uv run python scripts/e2e_fixtures.py build \
+  --trace traces/trace.jsonl --run traces/run-a.jsonl
+```
+
+Each fixture in `tests/fixtures/events/` holds one recorded Droid event stream
+plus the contract it satisfied, and `tests/test_replay.py` replays all of them
+through the ASGI app on every test run. Live runs stay in `traces/`, which is
+gitignored: rows and traces carry model output and account-specific denials.
+Fixtures are committed, so review them for private prompt content before adding
+them.
+
 ## Change guidelines
 
 - Keep the bridge local-first and OpenAI-compatible.

--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,12 @@ factory-droid-openai
 | `heads` | First 2048 and last 1024 characters of the payload |
 | `full` | Whole payload, capped at 1 MiB with `payload_truncated` set |
 
+Traced events cover the built prompt (`chat.prompt`), parser repairs, and the
+raw Droid event stream (`droid.event`, one record per text delta, reasoning
+delta, status, usage, and completion event). Session identifiers are never
+written. A `full` trace is what
+[`scripts/e2e_fixtures.py`](CONTRIBUTING.md#end-to-end-matrix) replays offline.
+
 Both variables are required together, and the destination must be an existing
 directory holding a regular non-symlink file path. The file is created mode
 `0600` and re-chmodded on every write.

--- a/scripts/e2e_fixtures.py
+++ b/scripts/e2e_fixtures.py
@@ -1,0 +1,139 @@
+"""Turn a recorded bridge session into offline replay fixtures.
+
+Run the bridge with payload tracing on, run the matrix, then join the two
+files: the matrix rows say what each request was and how it was judged, the
+trace says which Droid events produced it.
+
+    FACTORY_DROID_OPENAI_TRACE_PAYLOADS=full \\
+    FACTORY_DROID_OPENAI_TRACE_PAYLOAD_FILE=traces/trace.jsonl \\
+    uv run factory-droid-openai
+    uv run python scripts/e2e_matrix.py run --out traces/run.jsonl
+    uv run python scripts/e2e_fixtures.py build \\
+        --trace traces/trace.jsonl --run traces/run.jsonl
+
+Every fixture is a real model dialect frozen in time, so tests/test_replay.py
+re-checks the whole contract offline instead of spending live requests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "events"
+TRACE_EVENT = "droid.event"
+# Fixtures are regression evidence, so only outcomes that a replay can assert
+# without failing the suite on purpose are exported by default.
+DEFAULT_VERDICTS: tuple[str, ...] = ("pass",)
+_SLUG = re.compile(r"[^a-z0-9]+")
+
+
+def slug(value: str) -> str:
+    return _SLUG.sub("-", value.lower()).strip("-")
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def group_events(trace: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Collect the SDK events of each request, in the order they arrived."""
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in trace:
+        if record.get("event") != TRACE_EVENT:
+            continue
+        payload = record.get("payload")
+        request_id = record.get("request_id")
+        if not isinstance(payload, str) or not isinstance(request_id, str):
+            # Head mode truncates payloads, so only full traces can be replayed.
+            continue
+        grouped.setdefault(request_id, []).append(json.loads(payload))
+    return grouped
+
+
+def fixture_name(row: dict[str, Any]) -> str:
+    suffix = "-stream" if row.get("stream") else ""
+    return f"{slug(str(row['scenario']))}--{slug(str(row['model']))}{suffix}.jsonl"
+
+
+def build_fixtures(
+    rows: list[dict[str, Any]],
+    events: dict[str, list[dict[str, Any]]],
+    *,
+    verdicts: tuple[str, ...] = DEFAULT_VERDICTS,
+    scenarios: tuple[str, ...] = (),
+) -> dict[str, list[dict[str, Any]]]:
+    """Pair matrix rows with their recorded events and stamp each with its contract."""
+    fixtures: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        request_id = row.get("request_id")
+        recorded = events.get(request_id) if isinstance(request_id, str) else None
+        if not recorded:
+            continue
+        if row.get("verdict") not in verdicts:
+            continue
+        if scenarios and str(row["scenario"]) not in scenarios:
+            continue
+        meta = {
+            "kind": "meta",
+            "scenario": row["scenario"],
+            "stream": bool(row["stream"]),
+            "recorded_model": row["model"],
+            "expect_verdict": row["verdict"],
+        }
+        fixtures[fixture_name(row)] = [meta, *recorded]
+    return fixtures
+
+
+def write_fixtures(fixtures: dict[str, list[dict[str, Any]]], out_dir: Path) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for name, lines in sorted(fixtures.items()):
+        path = out_dir / name
+        path.write_text(
+            "".join(json.dumps(line, ensure_ascii=False) + "\n" for line in lines),
+            encoding="utf-8",
+        )
+        written.append(path)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    build = sub.add_parser("build", help="write replay fixtures from a recorded run")
+    build.add_argument("--trace", type=Path, required=True)
+    build.add_argument("--run", type=Path, required=True)
+    build.add_argument("--out", type=Path, default=FIXTURE_DIR)
+    build.add_argument("--verdicts", default=",".join(DEFAULT_VERDICTS))
+    build.add_argument("--scenarios", default="", help="comma separated; default is every one")
+
+    args = parser.parse_args(argv)
+    fixtures = build_fixtures(
+        load_jsonl(args.run),
+        group_events(load_jsonl(args.trace)),
+        verdicts=tuple(value for value in args.verdicts.split(",") if value),
+        scenarios=tuple(value for value in args.scenarios.split(",") if value),
+    )
+    written = write_fixtures(fixtures, args.out)
+    for path in written:
+        print(path)
+    if not written:
+        print("no fixture matched: check the trace mode and the verdict filter")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -1,0 +1,815 @@
+"""Repeatable end-to-end matrix for a running bridge.
+
+Runs a fixed scenario set against every model the bridge lists, classifies each
+result, and writes one JSONL row per request. Results stay out of the
+repository: they carry model output and account-specific denials.
+
+    uv run python scripts/e2e_matrix.py run --out traces/run-a.jsonl
+    uv run python scripts/e2e_matrix.py report traces/run-a.jsonl
+    uv run python scripts/e2e_matrix.py compare traces/run-a.jsonl traces/run-b.jsonl
+
+The compare subcommand is the A/B tool: run the matrix, change the bridge (a
+prompt variant, a parser fix), run it again, and read the transitions instead
+of eyeballing two reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8787"
+_WEATHER_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "weather",
+        "description": "Current weather for one city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+_CLOCK_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "clock",
+        "description": "Current time in one city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+# Verdicts that do not indicate a bridge defect still fail a scenario; only
+# BLOCKING ones mean the bridge itself has to change.
+SUCCESS = "pass"
+BRIDGE_DEFECT = "bridge_defect"
+MODEL_BEHAVIOR = "model_behavior"
+ACCOUNT_POLICY = "account_policy"
+PROVIDER_UNAVAILABLE = "provider_unavailable"
+CAPACITY = "capacity"
+BACKEND_TIMEOUT = "backend_timeout"
+HARNESS_TIMEOUT = "harness_timeout"
+VERDICTS: tuple[str, ...] = (
+    SUCCESS,
+    BRIDGE_DEFECT,
+    MODEL_BEHAVIOR,
+    ACCOUNT_POLICY,
+    PROVIDER_UNAVAILABLE,
+    CAPACITY,
+    BACKEND_TIMEOUT,
+    HARNESS_TIMEOUT,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    """One request shape plus the contract it has to satisfy."""
+
+    name: str
+    body: dict[str, Any]
+    stream: bool = False
+    per_model: bool = True
+    expect_status: tuple[int, ...] = (200,)
+    expect_finish: tuple[str, ...] = ("stop",)
+    expect_tool_call: bool = False
+    expect_content: bool = True
+    timeout_seconds: float = 120.0
+
+
+def _baseline_scenarios() -> list[Scenario]:
+    return [
+        Scenario(
+            name="hello",
+            body={"messages": [{"role": "user", "content": "Reply with exactly: OK"}]},
+        ),
+        Scenario(
+            name="unicode",
+            body={
+                "messages": [
+                    {"role": "system", "content": "Odpowiadaj po polsku. Używaj ogonków."},
+                    {"role": "user", "content": "Napisz jedno zdanie o Gdańsku."},
+                ]
+            },
+        ),
+        Scenario(
+            name="stop_sequence",
+            body={
+                "messages": [{"role": "user", "content": "Count: one two THREE four"}],
+                "stop": "THREE",
+            },
+        ),
+        Scenario(
+            name="ignored_token_limit",
+            body={
+                "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+                "max_tokens": 5,
+            },
+        ),
+    ]
+
+
+def _tool_scenarios() -> list[Scenario]:
+    prompt = "What is the weather in Gdansk? Use the tool."
+    return [
+        Scenario(
+            name="tool_auto",
+            body={
+                "messages": [{"role": "user", "content": prompt}],
+                "tools": [_WEATHER_TOOL],
+            },
+            expect_finish=("tool_calls", "stop"),
+            expect_content=False,
+        ),
+        Scenario(
+            name="tool_required",
+            body={
+                "messages": [{"role": "user", "content": prompt}],
+                "tools": [_WEATHER_TOOL],
+                "tool_choice": "required",
+            },
+            expect_finish=("tool_calls",),
+            expect_tool_call=True,
+            expect_content=False,
+        ),
+        Scenario(
+            name="tool_parallel",
+            body={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Weather and local time in Gdansk. Call both tools.",
+                    }
+                ],
+                "tools": [_WEATHER_TOOL, _CLOCK_TOOL],
+                "tool_choice": "required",
+            },
+            expect_finish=("tool_calls",),
+            expect_tool_call=True,
+            expect_content=False,
+        ),
+        Scenario(
+            name="tool_result_followup",
+            body={
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "weather",
+                                    "arguments": '{"city":"Gdansk"}',
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": '{"temperature_c":20}',
+                    },
+                ],
+                "tools": [_WEATHER_TOOL],
+            },
+        ),
+        Scenario(
+            name="tool_blank_arguments",
+            body={
+                "messages": [
+                    {"role": "user", "content": "What time is it in Gdansk?"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "clock", "arguments": ""},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call_1", "content": "12:00"},
+                ],
+                "tools": [_CLOCK_TOOL],
+            },
+        ),
+    ]
+
+
+def _hostile_scenarios() -> list[Scenario]:
+    return [
+        Scenario(
+            name="hostile_bad_tool_name",
+            body={
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "bad.name", "parameters": {}},
+                    }
+                ],
+            },
+            per_model=False,
+            expect_status=(400,),
+            timeout_seconds=30.0,
+        ),
+        Scenario(
+            name="hostile_malformed_tool_arguments",
+            body={
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "weather", "arguments": "[]"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call_1", "content": "x"},
+                ],
+                "tools": [_WEATHER_TOOL],
+            },
+            per_model=False,
+            expect_status=(400,),
+            timeout_seconds=30.0,
+        ),
+        Scenario(
+            name="hostile_unknown_model",
+            body={
+                "messages": [{"role": "user", "content": "hi"}],
+                "model": "definitely-not-a-model",
+            },
+            per_model=False,
+            expect_status=(404,),
+            timeout_seconds=60.0,
+        ),
+        Scenario(
+            name="hostile_empty_messages",
+            body={"messages": []},
+            per_model=False,
+            expect_status=(400,),
+            timeout_seconds=30.0,
+        ),
+        Scenario(
+            name="hostile_too_many_choices",
+            body={"messages": [{"role": "user", "content": "hi"}], "n": 99},
+            per_model=False,
+            expect_status=(400,),
+            timeout_seconds=30.0,
+        ),
+    ]
+
+
+def scenarios(*, streaming: bool = True) -> list[Scenario]:
+    """Every scenario, each non-hostile one in both transport modes."""
+    base = _baseline_scenarios() + _tool_scenarios()
+    built: list[Scenario] = []
+    for scenario in base:
+        built.append(scenario)
+        if streaming:
+            built.append(
+                Scenario(
+                    name=scenario.name,
+                    body=scenario.body,
+                    stream=True,
+                    per_model=scenario.per_model,
+                    expect_status=scenario.expect_status,
+                    expect_finish=scenario.expect_finish,
+                    expect_tool_call=scenario.expect_tool_call,
+                    expect_content=scenario.expect_content,
+                    timeout_seconds=scenario.timeout_seconds,
+                )
+            )
+    built.extend(_hostile_scenarios())
+    return built
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """What one request produced, before it is judged."""
+
+    status: int
+    error_type: str | None = None
+    finish_reason: str | None = None
+    tool_calls: int = 0
+    content_chars: int = 0
+    request_id: str | None = None
+    duration_ms: float = 0.0
+    ttft_ms: float | None = None
+    stream_done: bool = False
+    timed_out: bool = False
+    transport_error: str | None = None
+
+
+def classify(scenario: Scenario, observation: Observation) -> tuple[str, str]:
+    """Return the verdict bucket and a short reason for one observation."""
+    if observation.timed_out:
+        return HARNESS_TIMEOUT, f"no response within {scenario.timeout_seconds:.0f}s"
+    if observation.transport_error is not None:
+        return BRIDGE_DEFECT, f"transport error: {observation.transport_error}"
+    error_type = observation.error_type
+    if observation.status not in scenario.expect_status:
+        if error_type == "model_not_found":
+            return ACCOUNT_POLICY, "model unavailable for this account"
+        if error_type == "factory_native_tool_blocked":
+            return MODEL_BEHAVIOR, "model attempted a Factory-native tool"
+        if observation.status == 429:
+            return CAPACITY, "bridge queue is full"
+        if observation.status == 503:
+            return PROVIDER_UNAVAILABLE, "Droid executable or provider unavailable"
+        if observation.status == 504:
+            return BACKEND_TIMEOUT, "backend timed out"
+        return BRIDGE_DEFECT, f"unexpected status {observation.status} ({error_type})"
+    if observation.status != 200:
+        return SUCCESS, f"rejected with {observation.status} as expected"
+    if scenario.stream and not observation.stream_done:
+        return BRIDGE_DEFECT, "stream ended without [DONE]"
+    if observation.finish_reason not in scenario.expect_finish:
+        if observation.finish_reason == "tool_calls":
+            return MODEL_BEHAVIOR, "model called a tool when none was required"
+        return BRIDGE_DEFECT, f"unexpected finish_reason {observation.finish_reason}"
+    if scenario.expect_tool_call and observation.tool_calls == 0:
+        return MODEL_BEHAVIOR, "model produced no client tool call"
+    if scenario.expect_content and observation.content_chars == 0:
+        return MODEL_BEHAVIOR, "model produced no content"
+    return SUCCESS, "contract satisfied"
+
+
+def _error_type(body: dict[str, Any]) -> str | None:
+    error = body.get("error")
+    if not isinstance(error, dict):
+        return None
+    value = error.get("type")
+    return value if isinstance(value, str) else None
+
+
+def _read_json_observation(
+    response: httpx.Response,
+    *,
+    duration_ms: float,
+) -> Observation:
+    try:
+        body = response.json()
+    except ValueError:
+        return Observation(
+            status=response.status_code,
+            duration_ms=duration_ms,
+            transport_error="response was not JSON",
+        )
+    if not isinstance(body, dict):
+        return Observation(
+            status=response.status_code,
+            duration_ms=duration_ms,
+            transport_error="response was not a JSON object",
+        )
+    choices = body.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    message = choice.get("message", {}) if isinstance(choice, dict) else {}
+    tool_calls = message.get("tool_calls") or []
+    content = message.get("content") or ""
+    return Observation(
+        status=response.status_code,
+        error_type=_error_type(body),
+        finish_reason=choice.get("finish_reason") if isinstance(choice, dict) else None,
+        tool_calls=len(tool_calls) if isinstance(tool_calls, list) else 0,
+        content_chars=len(content) if isinstance(content, str) else 0,
+        request_id=response.headers.get("x-request-id"),
+        duration_ms=duration_ms,
+    )
+
+
+def _stream_observation(
+    status: int,
+    headers: httpx.Headers,
+    events: list[tuple[float, str]],
+    *,
+    duration_ms: float,
+) -> Observation:
+    finish_reason: str | None = None
+    tool_calls = 0
+    content_chars = 0
+    error_type: str | None = None
+    stream_done = False
+    ttft_ms: float | None = None
+    for elapsed_ms, raw in events:
+        if raw == "[DONE]":
+            stream_done = True
+            continue
+        try:
+            chunk = json.loads(raw)
+        except ValueError:
+            return Observation(
+                status=status,
+                duration_ms=duration_ms,
+                transport_error="stream carried invalid JSON",
+            )
+        if not isinstance(chunk, dict):
+            continue
+        error_type = error_type or _error_type(chunk)
+        for choice in chunk.get("choices") or []:
+            delta = choice.get("delta") or {}
+            text = delta.get("content") or ""
+            if text:
+                content_chars += len(text)
+                ttft_ms = elapsed_ms if ttft_ms is None else ttft_ms
+            calls = delta.get("tool_calls") or []
+            if calls:
+                tool_calls += len(calls)
+                ttft_ms = elapsed_ms if ttft_ms is None else ttft_ms
+            finish_reason = choice.get("finish_reason") or finish_reason
+    return Observation(
+        status=status,
+        error_type=error_type,
+        finish_reason=finish_reason,
+        tool_calls=tool_calls,
+        content_chars=content_chars,
+        request_id=headers.get("x-request-id"),
+        duration_ms=duration_ms,
+        ttft_ms=ttft_ms,
+        stream_done=stream_done,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class Bridge:
+    """Thin client for the bridge under test."""
+
+    base_url: str
+    api_key: str | None
+    client: httpx.AsyncClient
+
+    @property
+    def headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    async def models(self) -> list[str]:
+        response = await self.client.get(
+            f"{self.base_url}/v1/models",
+            headers=self.headers,
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        body = response.json()
+        return [entry["id"] for entry in body.get("data", []) if isinstance(entry, dict)]
+
+    async def run(self, model: str, scenario: Scenario) -> Observation:
+        body: dict[str, Any] = {"model": model, **scenario.body}
+        if scenario.stream:
+            body["stream"] = True
+        started = time.perf_counter()
+        try:
+            if scenario.stream:
+                return await self._run_stream(body, scenario, started)
+            response = await self.client.post(
+                f"{self.base_url}/v1/chat/completions",
+                headers=self.headers,
+                json=body,
+                timeout=scenario.timeout_seconds,
+            )
+        except httpx.TimeoutException:
+            return Observation(
+                status=0,
+                duration_ms=(time.perf_counter() - started) * 1000,
+                timed_out=True,
+            )
+        except httpx.HTTPError as exc:
+            return Observation(
+                status=0,
+                duration_ms=(time.perf_counter() - started) * 1000,
+                transport_error=type(exc).__name__,
+            )
+        return _read_json_observation(
+            response,
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+    async def _run_stream(
+        self,
+        body: dict[str, Any],
+        scenario: Scenario,
+        started: float,
+    ) -> Observation:
+        try:
+            async with self.client.stream(
+                "POST",
+                f"{self.base_url}/v1/chat/completions",
+                headers=self.headers,
+                json=body,
+                timeout=scenario.timeout_seconds,
+            ) as response:
+                events = [
+                    ((time.perf_counter() - started) * 1000, line.removeprefix("data: "))
+                    async for line in response.aiter_lines()
+                    if line.startswith("data: ")
+                ]
+                status = response.status_code
+                headers = response.headers
+        except httpx.TimeoutException:
+            return Observation(
+                status=0,
+                duration_ms=(time.perf_counter() - started) * 1000,
+                timed_out=True,
+            )
+        except httpx.HTTPError as exc:
+            return Observation(
+                status=0,
+                duration_ms=(time.perf_counter() - started) * 1000,
+                transport_error=type(exc).__name__,
+            )
+        return _stream_observation(
+            status,
+            headers,
+            events,
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+
+def row(model: str, scenario: Scenario, observation: Observation) -> dict[str, Any]:
+    """One JSONL record: the request, what came back, and the verdict."""
+    verdict, detail = classify(scenario, observation)
+    return {
+        "ts": datetime.now(UTC).isoformat(),
+        "model": model,
+        "scenario": scenario.name,
+        "stream": scenario.stream,
+        "status": observation.status,
+        "error_type": observation.error_type,
+        "finish_reason": observation.finish_reason,
+        "tool_calls": observation.tool_calls,
+        "content_chars": observation.content_chars,
+        "request_id": observation.request_id,
+        "duration_ms": round(observation.duration_ms, 1),
+        "ttft_ms": None if observation.ttft_ms is None else round(observation.ttft_ms, 1),
+        "verdict": verdict,
+        "detail": detail,
+    }
+
+
+async def run_matrix(
+    bridge: Bridge,
+    models: list[str],
+    plan: list[Scenario],
+    *,
+    concurrency: int,
+    on_row: Any = None,
+) -> list[dict[str, Any]]:
+    """Run every applicable (model, scenario) pair and return the rows."""
+    jobs: list[tuple[str, Scenario]] = []
+    for scenario in plan:
+        if scenario.per_model:
+            jobs.extend((model, scenario) for model in models)
+        else:
+            jobs.append((models[0] if models else "factory-droid", scenario))
+    semaphore = asyncio.Semaphore(concurrency)
+    rows: list[dict[str, Any]] = []
+
+    async def execute(model: str, scenario: Scenario) -> None:
+        async with semaphore:
+            observation = await bridge.run(model, scenario)
+        record = row(model, scenario, observation)
+        rows.append(record)
+        if on_row is not None:
+            on_row(record)
+
+    await asyncio.gather(*(execute(model, scenario) for model, scenario in jobs))
+    return rows
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate verdicts, blocking failures and latency for a run."""
+    counts = dict.fromkeys(VERDICTS, 0)
+    for record in rows:
+        verdict = str(record.get("verdict"))
+        counts[verdict] = counts.get(verdict, 0) + 1
+    durations = [float(record["duration_ms"]) for record in rows if record.get("status") == 200]
+    blocking = [record for record in rows if record.get("verdict") == BRIDGE_DEFECT]
+    return {
+        "total": len(rows),
+        "counts": counts,
+        "pass_rate": (counts[SUCCESS] / len(rows)) if rows else 0.0,
+        "median_ms": round(statistics.median(durations), 1) if durations else None,
+        "slowest_ms": round(max(durations), 1) if durations else None,
+        "blocking": blocking,
+    }
+
+
+def render_report(rows: list[dict[str, Any]]) -> str:
+    """Markdown summary, generated so no report is ever written by hand."""
+    summary = summarize(rows)
+    lines = [
+        "# Bridge e2e run",
+        "",
+        f"- Requests: {summary['total']}",
+        f"- Pass rate: {summary['pass_rate']:.1%}",
+        f"- Median completed latency: {summary['median_ms']} ms",
+        f"- Slowest completed: {summary['slowest_ms']} ms",
+        "",
+        "| Verdict | Count |",
+        "| --- | ---: |",
+    ]
+    lines.extend(
+        f"| `{verdict}` | {count} |"
+        for verdict, count in summary["counts"].items()
+        if count or verdict in {SUCCESS, BRIDGE_DEFECT}
+    )
+    lines.extend(["", "## Blocking findings", ""])
+    if not summary["blocking"]:
+        lines.append("None. No result classified as a bridge defect.")
+    else:
+        lines.extend(["| Model | Scenario | Stream | Detail |", "| --- | --- | --- | --- |"])
+        lines.extend(
+            f"| `{record['model']}` | `{record['scenario']}` | {record['stream']} "
+            f"| {record['detail']} |"
+            for record in summary["blocking"]
+        )
+    lines.extend(["", "## Scenarios", "", "| Scenario | Pass | Total |", "| --- | ---: | ---: |"])
+    lines.extend(
+        f"| `{name}` | {sum(1 for record in group if record['verdict'] == SUCCESS)} "
+        f"| {len(group)} |"
+        for name, group in sorted(_group_by(rows, "scenario").items())
+    )
+    # Tool-call compliance is the number a prompt change is judged on, so it
+    # gets its own column instead of hiding inside the pass rate.
+    lines.extend(
+        [
+            "",
+            "## Models",
+            "",
+            "| Model | Pass | Total | Tool calls |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    lines.extend(
+        f"| `{name}` | {sum(1 for record in group if record['verdict'] == SUCCESS)} "
+        f"| {len(group)} | {sum(int(record['tool_calls']) for record in group)} |"
+        for name, group in sorted(_group_by(rows, "model").items())
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _group_by(rows: list[dict[str, Any]], key: str) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in rows:
+        grouped.setdefault(str(record[key]), []).append(record)
+    return grouped
+
+
+def _key(record: dict[str, Any]) -> tuple[str, str, bool]:
+    return (str(record["model"]), str(record["scenario"]), bool(record["stream"]))
+
+
+def compare(before: list[dict[str, Any]], after: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verdict transitions and latency delta between two runs."""
+    left = {_key(record): record for record in before}
+    right = {_key(record): record for record in after}
+    regressions = []
+    fixes = []
+    for key, new in right.items():
+        old = left.get(key)
+        if old is None:
+            continue
+        if old["verdict"] == SUCCESS and new["verdict"] != SUCCESS:
+            regressions.append({"key": key, "to": new["verdict"], "detail": new["detail"]})
+        elif old["verdict"] != SUCCESS and new["verdict"] == SUCCESS:
+            fixes.append({"key": key, "from": old["verdict"]})
+    return {
+        "shared": len(set(left) & set(right)),
+        "only_before": sorted(str(key) for key in set(left) - set(right)),
+        "only_after": sorted(str(key) for key in set(right) - set(left)),
+        "regressions": regressions,
+        "fixes": fixes,
+        "pass_rate_before": summarize(before)["pass_rate"],
+        "pass_rate_after": summarize(after)["pass_rate"],
+    }
+
+
+def render_comparison(result: dict[str, Any]) -> str:
+    lines = [
+        "# Bridge e2e comparison",
+        "",
+        f"- Shared cases: {result['shared']}",
+        f"- Pass rate: {result['pass_rate_before']:.1%} -> {result['pass_rate_after']:.1%}",
+        f"- Regressions: {len(result['regressions'])}",
+        f"- Fixes: {len(result['fixes'])}",
+        "",
+    ]
+    if result["regressions"]:
+        lines.extend(["## Regressions", "", "| Case | Now | Detail |", "| --- | --- | --- |"])
+        lines.extend(
+            f"| `{entry['key']}` | `{entry['to']}` | {entry['detail']} |"
+            for entry in result["regressions"]
+        )
+        lines.append("")
+    if result["fixes"]:
+        lines.extend(["## Fixes", "", "| Case | Was |", "| --- | --- |"])
+        lines.extend(f"| `{entry['key']}` | `{entry['from']}` |" for entry in result["fixes"])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+@dataclass(slots=True)
+class RunOptions:
+    base_url: str = DEFAULT_BASE_URL
+    api_key: str | None = None
+    models: list[str] = field(default_factory=list)
+    concurrency: int = 2
+    streaming: bool = True
+    out: Path | None = None
+
+
+async def _run(options: RunOptions) -> int:
+    out = options.out or Path("traces") / f"e2e-{datetime.now(UTC):%Y%m%dT%H%M%SZ}.jsonl"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    async with httpx.AsyncClient() as client:
+        bridge = Bridge(base_url=options.base_url, api_key=options.api_key, client=client)
+        models = options.models or await bridge.models()
+        plan = scenarios(streaming=options.streaming)
+        print(f"{len(models)} models x {len(plan)} scenarios -> {out}", file=sys.stderr)
+        with out.open("a", encoding="utf-8") as handle:
+
+            def write(record: dict[str, Any]) -> None:
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+                handle.flush()
+
+            rows = await run_matrix(
+                bridge,
+                models,
+                plan,
+                concurrency=options.concurrency,
+                on_row=write,
+            )
+    print(render_report(rows))
+    return 1 if summarize(rows)["blocking"] else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = sub.add_parser("run", help="run the matrix against a live bridge")
+    run_parser.add_argument("--base-url", default=os.getenv("BRIDGE_URL", DEFAULT_BASE_URL))
+    run_parser.add_argument("--models", default="", help="comma separated; default is discovery")
+    run_parser.add_argument("--concurrency", type=int, default=2)
+    run_parser.add_argument("--no-stream", action="store_true")
+    run_parser.add_argument("--out", type=Path, default=None)
+
+    report_parser = sub.add_parser("report", help="render a markdown report from a JSONL run")
+    report_parser.add_argument("path", type=Path)
+
+    compare_parser = sub.add_parser("compare", help="diff two JSONL runs")
+    compare_parser.add_argument("before", type=Path)
+    compare_parser.add_argument("after", type=Path)
+
+    args = parser.parse_args(argv)
+    if args.command == "report":
+        print(render_report(load_rows(args.path)), end="")
+        return 0
+    if args.command == "compare":
+        result = compare(load_rows(args.before), load_rows(args.after))
+        print(render_comparison(result), end="")
+        return 1 if result["regressions"] else 0
+    options = RunOptions(
+        base_url=args.base_url,
+        api_key=os.getenv("FACTORY_DROID_OPENAI_API_KEY"),
+        models=[value for value in args.models.split(",") if value],
+        concurrency=args.concurrency,
+        streaming=not args.no_stream,
+        out=args.out,
+    )
+    return asyncio.run(_run(options))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1320,6 +1320,7 @@ def create_app(
                 structured=structured,
                 failure_callback=note_runner_failure,
                 drain_seconds=resolved_settings.tool_call_drain_seconds,
+                trace_event=payload_tracer.trace,
             )
             return FinalizingStreamingResponse(
                 event_stream,
@@ -1372,6 +1373,7 @@ def create_app(
                         request_started_at=request_started_at,
                         stop_sequences=payload.stop_sequences,
                         drain_seconds=resolved_settings.tool_call_drain_seconds,
+                        trace_event=payload_tracer.trace,
                     )
                     if result is None:
                         request.state.telemetry_error_type = "client_disconnected"
@@ -1473,12 +1475,30 @@ class CollectedCompletion:
         return "".join(self.reasoning_parts)
 
 
+def _event_record(event: RunEvent) -> dict[str, Any]:
+    """Describe one SDK event as the JSON the replay fixtures are built from."""
+    if isinstance(event, TextDelta):
+        return {"kind": "text_delta", "text": event.text}
+    if isinstance(event, ReasoningDelta):
+        return {"kind": "reasoning_delta", "text": event.text}
+    if isinstance(event, UsageUpdate):
+        return {"kind": "usage", "usage": _usage_dict(event.usage)}
+    if isinstance(event, RunComplete):
+        return {"kind": "run_complete", "usage": _usage_dict(event.usage)}
+    if isinstance(event, StatusUpdate):
+        return {"kind": "status", "state": event.state}
+    # The session id identifies a Factory account session and replay never
+    # needs it, so SessionStarted is recorded without its payload.
+    return {"kind": "session_started"}
+
+
 async def _run_events(
     runner: DroidRunner,
     run_request: RunRequest,
     *,
     drain_seconds: float,
     saw_tool_call: Callable[[], bool],
+    trace_event: Callable[..., None] | None = None,
 ) -> AsyncGenerator[RunEvent, None]:
     """Yield runner events, bounding the wait once a tool call is complete.
 
@@ -1511,6 +1531,12 @@ async def _run_events(
                     # answer stands instead of turning into a 504.
                     return
                 raise
+            if trace_event is not None:
+                trace_event(
+                    "droid.event",
+                    json.dumps(_event_record(event), ensure_ascii=False),
+                    model=run_request.model,
+                )
             yield event
 
 
@@ -1523,6 +1549,7 @@ async def _collect_completion(
     request_started_at: float | None = None,
     stop_sequences: tuple[str, ...] = (),
     drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
+    trace_event: Callable[..., None] | None = None,
 ) -> CollectedCompletion:
     result = CollectedCompletion()
     stop_buffer = StopSequenceBuffer(stop_sequences)
@@ -1533,6 +1560,7 @@ async def _collect_completion(
             run_request,
             drain_seconds=drain_seconds,
             saw_tool_call=lambda: bool(result.tool_calls),
+            trace_event=trace_event,
         )
     ) as events:
         async for event in events:
@@ -1630,6 +1658,7 @@ async def _collect_completion_or_disconnect(
     request_started_at: float | None = None,
     stop_sequences: tuple[str, ...] = (),
     drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
+    trace_event: Callable[..., None] | None = None,
 ) -> CollectedCompletion | None:
     completion_task = asyncio.create_task(
         _collect_completion(
@@ -1640,6 +1669,7 @@ async def _collect_completion_or_disconnect(
             request_started_at=request_started_at,
             stop_sequences=stop_sequences,
             drain_seconds=drain_seconds,
+            trace_event=trace_event,
         )
     )
     disconnect_task = asyncio.create_task(_wait_for_disconnect(request))
@@ -1686,6 +1716,7 @@ async def _stream_completion(
     structured: StructuredOutput | None = None,
     failure_callback: Callable[[str, RunnerError], None] | None = None,
     drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
+    trace_event: Callable[..., None] | None = None,
 ) -> AsyncIterator[str]:
     usage = Usage()
     completed = False
@@ -1730,6 +1761,7 @@ async def _stream_completion(
                     run_request,
                     drain_seconds=drain_seconds,
                     saw_tool_call=lambda: saw_tool_call,
+                    trace_event=trace_event,
                 )
             ) as events:
                 async for event in events:

--- a/tests/fixtures/events/hello--seed.jsonl
+++ b/tests/fixtures/events/hello--seed.jsonl
@@ -1,0 +1,5 @@
+{"kind": "meta", "scenario": "hello", "stream": false, "recorded_model": "seed", "expect_verdict": "pass"}
+{"kind": "session_started"}
+{"kind": "text_delta", "text": "OK"}
+{"kind": "usage", "usage": {"prompt_tokens": 11, "completion_tokens": 1, "total_tokens": 12, "prompt_tokens_details": {"cached_tokens": 0}}}
+{"kind": "run_complete", "usage": {"prompt_tokens": 11, "completion_tokens": 1, "total_tokens": 12, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/tool_required--seed-stream.jsonl
+++ b/tests/fixtures/events/tool_required--seed-stream.jsonl
@@ -1,0 +1,6 @@
+{"kind": "meta", "scenario": "tool_required", "stream": true, "recorded_model": "seed", "expect_verdict": "pass"}
+{"kind": "session_started"}
+{"kind": "status", "state": "thinking"}
+{"kind": "text_delta", "text": "<tool_call>{\"name\":\"weather\","}
+{"kind": "text_delta", "text": "\"arguments\":{\"city\":\"Gdansk\"}}</tool_call>"}
+{"kind": "run_complete", "usage": {"prompt_tokens": 20, "completion_tokens": 9, "total_tokens": 29, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/tool_required--seed.jsonl
+++ b/tests/fixtures/events/tool_required--seed.jsonl
@@ -1,0 +1,4 @@
+{"kind": "meta", "scenario": "tool_required", "stream": false, "recorded_model": "seed", "expect_verdict": "pass"}
+{"kind": "session_started"}
+{"kind": "reasoning_delta", "text": "The user wants weather, so I call the tool."}
+{"kind": "text_delta", "text": "<tool_call>{\"name\":\"weather\",\"arguments\":{\"city\":\"Gdansk\"}}</tool_call>"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -321,9 +321,53 @@ async def test_apps_keep_payload_tracing_configuration_isolated(tmp_path: Path) 
     assert disabled_response.status_code == 200
     assert enabled_response.status_code == 200
     records = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
-    assert len(records) == 1
-    assert "trace this" in records[0]["payload"]
-    assert "do not trace" not in records[0]["payload"]
+    prompts = [record for record in records if record["event"] == "chat.prompt"]
+    assert len(prompts) == 1
+    assert "trace this" in prompts[0]["payload"]
+    assert "do not trace" not in prompts[0]["payload"]
+
+
+@pytest.mark.asyncio
+async def test_payload_tracing_records_sdk_events_for_replay(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    runner = FakeRunner(
+        [
+            SessionStarted("session-secret"),
+            StatusUpdate("executing_tool"),
+            ReasoningDelta("thinking"),
+            TextDelta("hello"),
+            UsageUpdate(Usage(input_tokens=1, output_tokens=1)),
+            RunComplete(Usage(input_tokens=1, output_tokens=2)),
+        ]
+    )
+    app = create_app(
+        Settings(
+            workdir=tmp_path,
+            trace_payloads="full",
+            trace_payload_file=trace_path,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload())
+
+    assert response.status_code == 200
+    records = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+    events = [
+        json.loads(record["payload"]) for record in records if record["event"] == "droid.event"
+    ]
+    assert [event["kind"] for event in events] == [
+        "session_started",
+        "status",
+        "reasoning_delta",
+        "text_delta",
+        "usage",
+        "run_complete",
+    ]
+    assert events[3]["text"] == "hello"
+    assert events[5]["usage"]["completion_tokens"] == 2
+    assert "session-secret" not in trace_path.read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e_fixtures.py
+++ b/tests/test_e2e_fixtures.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "e2e_fixtures.py"
+
+
+@pytest.fixture(scope="module")
+def fixtures_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("e2e_fixtures", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _trace_line(request_id: str, payload: dict[str, Any], *, event: str = "droid.event") -> str:
+    return json.dumps(
+        {
+            "event": event,
+            "request_id": request_id,
+            "mode": "full",
+            "payload": json.dumps(payload),
+        }
+    )
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "model": "gpt-5.4",
+        "scenario": "tool_required",
+        "stream": False,
+        "request_id": "req-1",
+        "verdict": "pass",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_events_are_grouped_per_request_in_arrival_order(fixtures_script: ModuleType) -> None:
+    trace = [
+        json.loads(_trace_line("req-1", {"kind": "text_delta", "text": "a"})),
+        json.loads(_trace_line("req-2", {"kind": "text_delta", "text": "b"})),
+        json.loads(_trace_line("req-1", {"kind": "text_delta", "text": "c"})),
+        json.loads(_trace_line("req-1", {"kind": "text_delta", "text": "x"}, event="chat.prompt")),
+        {"event": "droid.event", "request_id": "req-3", "payload_head": "truncated"},
+        {"event": "droid.event", "payload": "{}"},
+    ]
+
+    grouped = fixtures_script.group_events(trace)
+
+    assert [event["text"] for event in grouped["req-1"]] == ["a", "c"]
+    assert set(grouped) == {"req-1", "req-2"}
+
+
+def test_fixture_names_stay_filesystem_safe(fixtures_script: ModuleType) -> None:
+    name = fixtures_script.fixture_name(_row(model="Claude Sonnet 4.5", stream=True))
+
+    assert name == "tool-required--claude-sonnet-4-5-stream.jsonl"
+
+
+def test_only_selected_rows_with_recorded_events_become_fixtures(
+    fixtures_script: ModuleType,
+) -> None:
+    rows = [
+        _row(),
+        _row(request_id="req-2", verdict="model_behavior", scenario="hello"),
+        _row(request_id="missing"),
+        _row(request_id=None),
+        _row(request_id="req-4", scenario="unicode"),
+    ]
+    events = {
+        "req-1": [{"kind": "text_delta", "text": "a"}],
+        "req-2": [{"kind": "text_delta", "text": "b"}],
+        "req-4": [{"kind": "text_delta", "text": "c"}],
+    }
+
+    built = fixtures_script.build_fixtures(rows, events, scenarios=("tool_required", "hello"))
+
+    assert list(built) == ["tool-required--gpt-5-4.jsonl"]
+    assert built["tool-required--gpt-5-4.jsonl"][0] == {
+        "kind": "meta",
+        "scenario": "tool_required",
+        "stream": False,
+        "recorded_model": "gpt-5.4",
+        "expect_verdict": "pass",
+    }
+
+
+def test_other_verdicts_can_be_exported_on_purpose(fixtures_script: ModuleType) -> None:
+    rows = [_row(verdict="model_behavior")]
+    events = {"req-1": [{"kind": "text_delta", "text": "a"}]}
+
+    built = fixtures_script.build_fixtures(rows, events, verdicts=("model_behavior",))
+
+    assert built["tool-required--gpt-5-4.jsonl"][0]["expect_verdict"] == "model_behavior"
+
+
+def test_build_command_writes_one_file_per_case(
+    fixtures_script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    trace = tmp_path / "trace.jsonl"
+    run = tmp_path / "run.jsonl"
+    out = tmp_path / "fixtures"
+    trace.write_text(
+        _trace_line("req-1", {"kind": "text_delta", "text": "a"}) + "\n\n",
+        encoding="utf-8",
+    )
+    run.write_text(json.dumps(_row()) + "\n", encoding="utf-8")
+
+    code = fixtures_script.main(
+        ["build", "--trace", str(trace), "--run", str(run), "--out", str(out)]
+    )
+
+    written = list(out.glob("*.jsonl"))
+    assert code == 0
+    assert len(written) == 1
+    lines = [json.loads(line) for line in written[0].read_text(encoding="utf-8").splitlines()]
+    assert [line["kind"] for line in lines] == ["meta", "text_delta"]
+    assert str(written[0]) in capsys.readouterr().out
+
+
+def test_build_command_reports_when_nothing_matched(
+    fixtures_script: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    trace = tmp_path / "trace.jsonl"
+    run = tmp_path / "run.jsonl"
+    trace.write_text("", encoding="utf-8")
+    run.write_text(json.dumps(_row()) + "\n", encoding="utf-8")
+
+    code = fixtures_script.main(
+        [
+            "build",
+            "--trace",
+            str(trace),
+            "--run",
+            str(run),
+            "--out",
+            str(tmp_path / "fixtures"),
+            "--verdicts",
+            "pass",
+            "--scenarios",
+            "",
+        ]
+    )
+
+    assert code == 1
+    assert "no fixture matched" in capsys.readouterr().out

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "e2e_matrix.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("e2e_matrix", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses resolve string annotations through sys.modules, so a module
+    # loaded straight from a path has to register before it executes.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def e2e() -> ModuleType:
+    return _load_module()
+
+
+def _observation(e2e: ModuleType, **overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "status": 200,
+        "finish_reason": "stop",
+        "content_chars": 12,
+    }
+    defaults.update(overrides)
+    return e2e.Observation(**defaults)
+
+
+def _scenario(e2e: ModuleType, **overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "name": "hello",
+        "body": {"messages": [{"role": "user", "content": "hi"}]},
+    }
+    defaults.update(overrides)
+    return e2e.Scenario(**defaults)
+
+
+def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleType) -> None:
+    plan = e2e.scenarios()
+
+    streamed = {scenario.name for scenario in plan if scenario.stream}
+    hostile = [scenario for scenario in plan if not scenario.per_model]
+
+    assert "tool_required" in streamed
+    assert hostile, "hostile scenarios must be part of the default plan"
+    assert all(scenario.expect_status != (200,) for scenario in hostile)
+    assert all(not scenario.stream for scenario in hostile)
+    assert len(e2e.scenarios(streaming=False)) < len(plan)
+
+
+def test_contract_satisfied_is_a_pass(e2e: ModuleType) -> None:
+    verdict, _ = e2e.classify(_scenario(e2e), _observation(e2e))
+
+    assert verdict == e2e.SUCCESS
+
+
+def test_expected_rejection_is_a_pass(e2e: ModuleType) -> None:
+    scenario = _scenario(e2e, expect_status=(400,))
+
+    verdict, detail = e2e.classify(scenario, _observation(e2e, status=400, finish_reason=None))
+
+    assert verdict == e2e.SUCCESS
+    assert "expected" in detail
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"timed_out": True}, "harness_timeout"),
+        ({"transport_error": "ReadError"}, "bridge_defect"),
+        ({"status": 404, "error_type": "model_not_found"}, "account_policy"),
+        ({"status": 502, "error_type": "factory_native_tool_blocked"}, "model_behavior"),
+        ({"status": 429, "error_type": "rate_limit_error"}, "capacity"),
+        ({"status": 503, "error_type": "factory_droid_unavailable"}, "provider_unavailable"),
+        ({"status": 504, "error_type": "factory_droid_timeout"}, "backend_timeout"),
+        ({"status": 502, "error_type": "factory_protocol_error"}, "bridge_defect"),
+        ({"finish_reason": "length"}, "bridge_defect"),
+        ({"finish_reason": "tool_calls"}, "model_behavior"),
+        ({"content_chars": 0}, "model_behavior"),
+    ],
+)
+def test_failures_land_in_their_own_bucket(
+    e2e: ModuleType,
+    overrides: dict[str, Any],
+    expected: str,
+) -> None:
+    verdict, detail = e2e.classify(_scenario(e2e), _observation(e2e, **overrides))
+
+    assert verdict == expected
+    assert detail
+
+
+def test_missing_tool_call_is_model_behavior_not_a_bridge_defect(e2e: ModuleType) -> None:
+    scenario = _scenario(
+        e2e,
+        expect_finish=("tool_calls",),
+        expect_tool_call=True,
+        expect_content=False,
+    )
+
+    verdict, _ = e2e.classify(
+        scenario,
+        _observation(e2e, finish_reason="tool_calls", tool_calls=0, content_chars=0),
+    )
+
+    assert verdict == "model_behavior"
+
+
+def test_stream_without_done_is_a_bridge_defect(e2e: ModuleType) -> None:
+    scenario = _scenario(e2e, stream=True)
+
+    verdict, detail = e2e.classify(scenario, _observation(e2e, stream_done=False))
+
+    assert verdict == "bridge_defect"
+    assert "[DONE]" in detail
+
+
+def _bridge(e2e: ModuleType, handler: Any) -> Any:
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return e2e.Bridge(base_url="http://bridge", api_key="secret-key", client=client)
+
+
+@pytest.mark.asyncio
+async def test_bridge_reads_a_json_completion(e2e: ModuleType) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer secret-key"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "hello",
+                            "tool_calls": [{"id": "call_1"}],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+            headers={"x-request-id": "req-1"},
+        )
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        observation = await bridge.run("m", _scenario(e2e))
+
+    assert observation.status == 200
+    assert observation.finish_reason == "tool_calls"
+    assert observation.tool_calls == 1
+    assert observation.content_chars == 5
+    assert observation.request_id == "req-1"
+
+
+@pytest.mark.asyncio
+async def test_bridge_reads_a_streamed_completion(e2e: ModuleType) -> None:
+    chunks = [
+        {"choices": [{"index": 0, "delta": {"content": "he"}, "finish_reason": None}]},
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"tool_calls": [{"index": 0, "id": "call_1"}]},
+                    "finish_reason": None,
+                }
+            ]
+        },
+        {"choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
+    ]
+    body = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks) + "data: [DONE]\n\n"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(200, text=body, headers={"x-request-id": "req-2"})
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        observation = await bridge.run("m", _scenario(e2e, stream=True))
+
+    assert observation.stream_done is True
+    assert observation.finish_reason == "tool_calls"
+    assert observation.tool_calls == 1
+    assert observation.content_chars == 2
+    assert observation.ttft_ms is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_bridge_reports_transport_failures_without_raising(
+    e2e: ModuleType,
+    stream: bool,
+) -> None:
+    def timing_out(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("slow", request=request)
+
+    def failing(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused", request=request)
+
+    bridge = _bridge(e2e, timing_out)
+    async with bridge.client:
+        timed_out = await bridge.run("m", _scenario(e2e, stream=stream))
+    broken_bridge = _bridge(e2e, failing)
+    async with broken_bridge.client:
+        broken = await broken_bridge.run("m", _scenario(e2e, stream=stream))
+
+    assert timed_out.timed_out is True
+    assert broken.transport_error == "ConnectError"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("not json at all", "response was not JSON"),
+        ('"a string"', "response was not a JSON object"),
+    ],
+)
+async def test_bridge_flags_responses_that_are_not_completion_objects(
+    e2e: ModuleType,
+    payload: str,
+    expected: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(200, text=payload)
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        observation = await bridge.run("m", _scenario(e2e))
+
+    assert observation.transport_error == expected
+
+
+@pytest.mark.asyncio
+async def test_bridge_flags_invalid_stream_json(e2e: ModuleType) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(200, text="data: {oops\n\n")
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        observation = await bridge.run("m", _scenario(e2e, stream=True))
+
+    assert observation.transport_error == "stream carried invalid JSON"
+
+
+@pytest.mark.asyncio
+async def test_bridge_lists_models(e2e: ModuleType) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/models"
+        return httpx.Response(200, json={"data": [{"id": "a"}, {"id": "b"}, "junk"]})
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        models = await bridge.models()
+
+    assert models == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_matrix_runs_every_pair_and_streams_rows_out(e2e: ModuleType) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    plan = [_scenario(e2e), _scenario(e2e, name="hostile", per_model=False, expect_status=(400,))]
+    written: list[dict[str, Any]] = []
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        rows = await e2e.run_matrix(
+            bridge,
+            ["m1", "m2"],
+            plan,
+            concurrency=1,
+            on_row=written.append,
+        )
+
+    assert len(rows) == 3
+    assert written == rows
+    assert {row["model"] for row in rows} == {"m1", "m2"}
+    assert sum(1 for row in rows if row["scenario"] == "hostile") == 1
+
+
+@pytest.mark.asyncio
+async def test_matrix_without_models_still_runs_hostile_cases(e2e: ModuleType) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(400, json={"error": {"type": "invalid_request_error"}})
+
+    plan = [_scenario(e2e, name="hostile", per_model=False, expect_status=(400,))]
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        rows = await e2e.run_matrix(bridge, [], plan, concurrency=2)
+
+    assert [row["model"] for row in rows] == ["factory-droid"]
+    assert rows[0]["verdict"] == e2e.SUCCESS
+
+
+def _rows(e2e: ModuleType) -> list[dict[str, Any]]:
+    return [
+        e2e.row("m1", _scenario(e2e), _observation(e2e)),
+        e2e.row(
+            "m2",
+            _scenario(e2e),
+            _observation(e2e, status=404, error_type="model_not_found"),
+        ),
+        e2e.row(
+            "m3",
+            _scenario(e2e, stream=True),
+            _observation(e2e, stream_done=False),
+        ),
+    ]
+
+
+def test_summary_separates_blocking_findings(e2e: ModuleType) -> None:
+    summary = e2e.summarize(_rows(e2e))
+
+    assert summary["total"] == 3
+    assert summary["counts"]["account_policy"] == 1
+    assert len(summary["blocking"]) == 1
+    assert summary["median_ms"] is not None
+
+
+def test_summary_of_an_empty_run_is_not_a_division_by_zero(e2e: ModuleType) -> None:
+    summary = e2e.summarize([])
+
+    assert summary["pass_rate"] == 0.0
+    assert summary["median_ms"] is None
+
+
+def test_report_names_the_blocking_cases(e2e: ModuleType) -> None:
+    report = e2e.render_report(_rows(e2e))
+
+    assert "bridge_defect" in report
+    assert "`m3`" in report
+    assert "## Scenarios" in report
+    assert "| Model | Pass | Total | Tool calls |" in report
+
+
+def test_report_says_so_when_nothing_blocks(e2e: ModuleType) -> None:
+    report = e2e.render_report([e2e.row("m1", _scenario(e2e), _observation(e2e))])
+
+    assert "No result classified as a bridge defect" in report
+
+
+def test_compare_reports_regressions_and_fixes(e2e: ModuleType) -> None:
+    before = [
+        e2e.row("m1", _scenario(e2e), _observation(e2e)),
+        e2e.row("m2", _scenario(e2e), _observation(e2e, finish_reason="length")),
+        e2e.row("gone", _scenario(e2e), _observation(e2e)),
+    ]
+    after = [
+        e2e.row("m1", _scenario(e2e), _observation(e2e, finish_reason="length")),
+        e2e.row("m2", _scenario(e2e), _observation(e2e)),
+        e2e.row("new", _scenario(e2e), _observation(e2e)),
+    ]
+
+    result = e2e.compare(before, after)
+    rendered = e2e.render_comparison(result)
+
+    assert result["shared"] == 2
+    assert [entry["key"] for entry in result["regressions"]] == [("m1", "hello", False)]
+    assert [entry["key"] for entry in result["fixes"]] == [("m2", "hello", False)]
+    assert result["only_before"]
+    assert result["only_after"]
+    assert "## Regressions" in rendered
+    assert "## Fixes" in rendered
+
+
+def test_comparison_without_changes_stays_quiet(e2e: ModuleType) -> None:
+    rows = [e2e.row("m1", _scenario(e2e), _observation(e2e))]
+
+    rendered = e2e.render_comparison(e2e.compare(rows, rows))
+
+    assert "## Regressions" not in rendered
+    assert "## Fixes" not in rendered
+
+
+def test_report_command_reads_a_jsonl_run(
+    e2e: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "run.jsonl"
+    rows = _rows(e2e)
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n\n",
+        encoding="utf-8",
+    )
+
+    code = e2e.main(["report", str(path)])
+
+    assert code == 0
+    assert "Bridge e2e run" in capsys.readouterr().out
+
+
+def test_compare_command_fails_on_regressions(
+    e2e: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    before = tmp_path / "before.jsonl"
+    after = tmp_path / "after.jsonl"
+    before.write_text(
+        json.dumps(e2e.row("m1", _scenario(e2e), _observation(e2e))) + "\n",
+        encoding="utf-8",
+    )
+    after.write_text(
+        json.dumps(
+            e2e.row("m1", _scenario(e2e), _observation(e2e, finish_reason="length")),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code = e2e.main(["compare", str(before), str(after)])
+
+    assert code == 1
+    assert "Regressions" in capsys.readouterr().out
+
+
+def test_run_command_writes_rows_and_reports_blocking_findings(
+    e2e: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/models":
+            return httpx.Response(200, json={"data": [{"id": "m1"}]})
+        return httpx.Response(200, json={"choices": []})
+
+    class MockClient(httpx.AsyncClient):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(e2e.httpx, "AsyncClient", MockClient)
+    monkeypatch.delenv("FACTORY_DROID_OPENAI_API_KEY", raising=False)
+    out = tmp_path / "nested" / "run.jsonl"
+
+    code = e2e.main(["run", "--no-stream", "--concurrency", "4", "--out", str(out)])
+
+    rows = e2e.load_rows(out)
+    assert code == 1
+    assert rows
+    assert all(row["model"] == "m1" for row in rows if row["scenario"] != "hostile_unknown_model")
+    assert "Bridge e2e run" in capsys.readouterr().out

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,134 @@
+"""Replay recorded Droid event streams against the bridge, offline.
+
+Each fixture under ``tests/fixtures/events`` is a real (or hand-seeded) model
+dialect plus the contract its live run satisfied. Replaying them keeps every
+finding from a live matrix run as a free regression test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+import pytest
+
+from factory_droid_openai.app import create_app
+from factory_droid_openai.config import Settings
+from factory_droid_openai.runner import (
+    ReasoningDelta,
+    RunComplete,
+    RunEvent,
+    RunRequest,
+    SessionStarted,
+    StatusUpdate,
+    TextDelta,
+    Usage,
+    UsageUpdate,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from types import ModuleType
+
+    from factory_droid_openai.app import RunnerFactory
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "events"
+FIXTURES = sorted(FIXTURE_DIR.glob("*.jsonl"))
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "e2e_matrix.py"
+
+
+@pytest.fixture(scope="module")
+def e2e() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("e2e_matrix", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses resolve string annotations through sys.modules, so a module
+    # loaded straight from a path has to register before it executes.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReplayRunner:
+    """Feeds recorded events back into the bridge in the order Droid sent them."""
+
+    def __init__(self, events: list[RunEvent]) -> None:
+        self.events = events
+        self.closed = False
+
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+        del request
+        try:
+            for event in self.events:
+                yield event
+        finally:
+            self.closed = True
+
+
+def _usage(payload: dict[str, Any]) -> Usage:
+    details = payload.get("prompt_tokens_details") or {}
+    return Usage(
+        input_tokens=int(payload.get("prompt_tokens", 0)),
+        output_tokens=int(payload.get("completion_tokens", 0)),
+        cache_read_tokens=int(details.get("cached_tokens", 0)),
+    )
+
+
+def _event(record: dict[str, Any]) -> RunEvent:
+    kind = record["kind"]
+    if kind == "text_delta":
+        return TextDelta(record["text"])
+    if kind == "reasoning_delta":
+        return ReasoningDelta(record["text"])
+    if kind == "usage":
+        return UsageUpdate(_usage(record["usage"]))
+    if kind == "run_complete":
+        return RunComplete(_usage(record["usage"]))
+    if kind == "status":
+        return StatusUpdate(record["state"])
+    if kind == "session_started":
+        return SessionStarted("replay-session")
+    raise AssertionError(f"unknown recorded event kind: {kind}")
+
+
+def _scenario(e2e: ModuleType, meta: dict[str, Any]) -> Any:
+    for scenario in e2e.scenarios():
+        if scenario.name == meta["scenario"] and scenario.stream == meta["stream"]:
+            return scenario
+    raise AssertionError(f"fixture references an unknown scenario: {meta['scenario']}")
+
+
+def test_the_fixture_directory_is_not_empty() -> None:
+    assert FIXTURES, "replay fixtures are the offline safety net; do not delete them all"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda path: path.stem)
+async def test_recorded_events_keep_satisfying_the_contract(
+    e2e: ModuleType,
+    tmp_path: Path,
+    path: Path,
+) -> None:
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+    meta, *events = records
+    scenario = _scenario(e2e, meta)
+    runner = ReplayRunner([_event(record) for record in events])
+    app = create_app(
+        Settings(workdir=tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://replay",
+    ) as client:
+        bridge = e2e.Bridge(base_url="http://replay", api_key=None, client=client)
+        observation = await bridge.run("factory-droid", scenario)
+
+    verdict, detail = e2e.classify(scenario, observation)
+    assert verdict == meta["expect_verdict"], f"{path.name}: {detail}"


### PR DESCRIPTION
## Summary

Live-model findings were previously reproduced by hand, so every model quirk
cost another round of manual requests. This adds the loop that replaces it:
run a fixed matrix, classify the results, freeze what it found as offline
fixtures.

- `scripts/e2e_matrix.py run` - 15 scenarios (baseline, client tools, hostile
  input), each non-hostile one in both JSON and SSE mode, against every model
  the bridge lists. One JSONL row per request.
- Verdict classification separates blame: only `bridge_defect` fails a run;
  `model_behavior`, `account_policy`, `capacity`, `provider_unavailable`,
  `backend_timeout`, and `harness_timeout` describe the environment.
- `report` renders markdown (verdicts, blocking findings, per-scenario and
  per-model tool-call compliance). `compare` diffs two runs and exits non-zero
  on any pass to non-pass transition, which makes it the A/B tool for prompt
  and parser changes.
- `_run_events` records every SDK event as a `droid.event` line through the
  existing payload tracer, so recording inherits redaction, `0600` permissions,
  symlink rejection, and the size cap. Session ids are never written, and the
  whole thing stays off unless `FACTORY_DROID_OPENAI_TRACE_PAYLOADS` is set.
- `scripts/e2e_fixtures.py build` joins a trace with a matrix run by request id
  and writes `tests/fixtures/events/*.jsonl`.
- `tests/test_replay.py` replays every fixture through the ASGI app and judges
  it with the same classifier the live matrix uses. The seeded
  `tool_required--seed.jsonl` fixture ends without `RunComplete`, so the
  tool-call hang fixed in #45 is now caught offline.
- Bug reports ask for the model id and, optionally, the recorded
  `droid.event` lines; the PR template asks for a fixture when behavior was
  found against a live model.

Live runs stay in `traces/`, which is gitignored: rows and traces carry model
output and account-specific denials. Fixtures are committed and reviewed.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
- 784 tests passed, 100% branch coverage (46 new tests)
- `openapi.json` unchanged: no routes or schemas changed.

## Security and compatibility

- No credentials, private prompt data, or build artifacts committed.
- Response shapes unchanged; recording only observes the event stream.
- Factory-native tools remain blocked.
