### PR TITLE
fix(telemetry): send unified collector envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,8 +1207,9 @@ disk, and never fails a client request.
 
 Collected fields:
 
-- bridge version, Python major and minor version, operating system family, and
-  CPU architecture
+- fixed application identifier (`factory_droid_openai`), telemetry event schema
+  version, bridge version, runtime family (`python`), Python major and minor
+  version, operating system family, and CPU architecture
 - route category, streaming mode, outcome category, request count, and aggregate
   duration
 - coarse latency buckets by route, payload-size buckets by route, and normalized

--- a/src/factory_droid_openai/telemetry.py
+++ b/src/factory_droid_openai/telemetry.py
@@ -344,8 +344,11 @@ def _runtime_metadata(app_version: str) -> dict[str, object]:
     }.get(platform.machine().lower(), "other")
     return {
         "schema": 1,
+        "app": "factory_droid_openai",
+        "event_schema": 1,
         "app_version": app_version,
-        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "runtime": "python",
+        "runtime_version": f"{sys.version_info.major}.{sys.version_info.minor}",
         "os": operating_system,
         "arch": architecture,
     }

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from typing import Any, cast
@@ -123,8 +124,11 @@ async def test_reporter_sends_startup_and_metric_deltas(
     assert 0 < timeout <= DEFAULT_TELEMETRY_TIMEOUT_SECONDS
     assert startup == {
         "schema": 1,
+        "app": "factory_droid_openai",
+        "event_schema": 1,
         "app_version": "1.5.0",
-        "python_version": _runtime_metadata("unused")["python_version"],
+        "runtime": "python",
+        "runtime_version": _runtime_metadata("unused")["runtime_version"],
         "os": "darwin",
         "arch": "arm64",
         "events": [{"name": "bridge_started", "count": 1}],
@@ -620,6 +624,12 @@ def test_runtime_metadata_normalizes_platform(
 
     metadata = _runtime_metadata("1.5.0")
 
+    assert metadata["schema"] == 1
+    assert metadata["app"] == "factory_droid_openai"
+    assert metadata["event_schema"] == 1
+    assert metadata["app_version"] == "1.5.0"
+    assert metadata["runtime"] == "python"
+    assert metadata["runtime_version"] == f"{sys.version_info.major}.{sys.version_info.minor}"
     assert metadata["os"] == expected_os
     assert metadata["arch"] == expected_arch
 


### PR DESCRIPTION
## Summary

- migrate telemetry requests to the shared collector envelope
- identify bridge events with fixed `app`, `event_schema`, `runtime`, and `runtime_version` metadata
- preserve existing event aggregation and privacy behavior
- document the unified envelope fields

## Payload metadata

```json
{
  "schema": 1,
  "app": "factory-droid-openai",
  "event_schema": 1,
  "runtime": "python",
  "runtime_version": "<major.minor>"
}
```

## Validation

- focused telemetry suite: 28 tests passed with 100% coverage
- full suite: 1,106 tests passed with 100% coverage
- Ruff, formatting, mypy, OpenAPI validation, lock check, and package build passed

## Deployment note

Deploy unified collector routing before releasing this bridge version. Legacy bridge payloads remain accepted by the collector.
