### PR TITLE
fix: harden message-shaped output parsing

### DIFF
--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -29,6 +29,8 @@ from typing import Any
 
 import httpx
 
+from factory_droid_openai.dialects import strip_code_fence
+
 DEFAULT_BASE_URL = "http://127.0.0.1:8787"
 _WEATHER_TOOL: dict[str, Any] = {
     "type": "function",
@@ -337,7 +339,7 @@ _TOOL_CHOICE_IGNORED = "did not produce the required tool call"
 
 def _content_semantic_error(content: str) -> str | None:
     """Reject serialized OpenAI transcript objects returned as final text."""
-    stripped = content.strip()
+    stripped = strip_code_fence(content.strip())
     try:
         payload = json.loads(stripped)
     except ValueError:

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1287,21 +1287,25 @@ def create_app(
                 metrics.record_features(("warm_session",))
                 run_request = replace(run_request, warm_session=warm_session)
 
+        def message_parser() -> ToolCallStreamParser:
+            return ToolCallStreamParser(
+                plan.allowed_tool_names,
+                require_tool_call=plan.require_tool_call,
+                max_tool_calls=(
+                    resolved_settings.max_tool_calls if payload.parallel_tool_calls else 1
+                ),
+                repair_lost_prefix=resolved_settings.repair_lost_prefix,
+                parse_message_json=structured is None,
+                trace_payload=payload_tracer.trace,
+            )
+
         if payload.stream:
             request.state.stream_outcome = "pending"
             event_stream = _stream_completion(
                 request_id=request_id,
                 created=created,
                 model=payload.model,
-                parser=ToolCallStreamParser(
-                    plan.allowed_tool_names,
-                    require_tool_call=plan.require_tool_call,
-                    max_tool_calls=(
-                        resolved_settings.max_tool_calls if payload.parallel_tool_calls else 1
-                    ),
-                    repair_lost_prefix=resolved_settings.repair_lost_prefix,
-                    trace_payload=payload_tracer.trace,
-                ),
+                parser=message_parser(),
                 runner=runner,
                 run_request=run_request,
                 lease=lease,
@@ -1358,17 +1362,7 @@ def create_app(
                         request=request,
                         runner=choice_runner,
                         run_request=choice_request,
-                        parser=ToolCallStreamParser(
-                            plan.allowed_tool_names,
-                            require_tool_call=plan.require_tool_call,
-                            max_tool_calls=(
-                                resolved_settings.max_tool_calls
-                                if payload.parallel_tool_calls
-                                else 1
-                            ),
-                            repair_lost_prefix=resolved_settings.repair_lost_prefix,
-                            trace_payload=payload_tracer.trace,
-                        ),
+                        parser=message_parser(),
                         metrics=metrics,
                         request_started_at=request_started_at,
                         stop_sequences=payload.stop_sequences,
@@ -1554,6 +1548,19 @@ async def _collect_completion(
     result = CollectedCompletion()
     stop_buffer = StopSequenceBuffer(stop_sequences)
     observed_ttft = False
+
+    def record_malformed(exc: MalformedToolCallError) -> None:
+        result.malformed_note = _malformed_tool_call_note(exc)
+        result.completed = True
+        log_warning(
+            "chat.malformed",
+            stream=False,
+            error_type="factory_protocol_error",
+            reason=str(exc),
+            tool_name=exc.tool_name,
+            payload_bytes=exc.payload_bytes,
+        )
+
     async with contextlib.aclosing(
         _run_events(
             runner,
@@ -1581,16 +1588,7 @@ async def _collect_completion(
                     # client stops auto-continuing, and a resubmitted
                     # transcript tells the model how to re-emit the call. The
                     # malformed call is dropped, never executed.
-                    result.malformed_note = _malformed_tool_call_note(exc)
-                    result.completed = True
-                    log_warning(
-                        "chat.malformed",
-                        stream=False,
-                        error_type="factory_protocol_error",
-                        reason=str(exc),
-                        tool_name=exc.tool_name,
-                        payload_bytes=exc.payload_bytes,
-                    )
+                    record_malformed(exc)
                     break
                 if stop_buffer.triggered:
                     # Leaving the loop closes the runner generator, which
@@ -1628,6 +1626,8 @@ async def _collect_completion(
             # finish would re-raise on the same garbage.
             try:
                 _apply_emissions(result, parser.finish(), stop_buffer)
+            except MalformedToolCallError as exc:
+                record_malformed(exc)
             except IncompleteToolCallError as exc:
                 # Same contract as the streaming path: a turn that died inside
                 # a tool-call payload returns completed output with

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import math
 import re
 import uuid
 from dataclasses import dataclass, field
@@ -42,8 +41,9 @@ if TYPE_CHECKING:
 _MAX_TOOL_PAYLOAD_BYTES = 1_000_000
 _ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
 _UNPARSED_HEAD_CHARS = 64
-_TRANSCRIPT_MESSAGE_PATTERN = re.compile(r'\{\s*"role"\s*:')
-_TRANSCRIPT_PREFIX = '{"role":'
+_MESSAGE_JSON_PATTERN = re.compile(r'\{\s*"(?:role|content|tool_calls|id|type)"\s*:')
+_MESSAGE_JSON_KEYS = ("role", "content", "tool_calls", "id", "type")
+_MAX_MESSAGE_JSON_PREFIX_CHARS = 64
 
 __all__ = [
     "TOOL_CALL_CLOSE",
@@ -308,6 +308,7 @@ class ToolCallStreamParser:
         require_tool_call: bool = False,
         max_tool_calls: int = 1,
         repair_lost_prefix: bool = False,
+        parse_message_json: bool = True,
         trace_payload: PayloadTrace | None = None,
     ) -> None:
         self._allowed_tool_names = allowed_tool_names
@@ -317,13 +318,18 @@ class ToolCallStreamParser:
         if repair_lost_prefix:
             self._payload_decoders = (*PAYLOAD_DECODERS, LOST_PREFIX_DECODER)
         self._trace_payload: PayloadTrace = trace_payload or NULL_PAYLOAD_TRACER.trace
+        self._parse_message_json = parse_message_json
         self._text_tail = ""
         self._payload_chunks: list[str] = []
         self._payload_bytes = 0
         self._close_tail = ""
-        self._transcript_buffer = ""
+        self._message_json_chunks: list[str] = []
+        self._message_json_bytes = 0
+        self._message_json_depth = 0
+        self._message_json_in_string = False
+        self._message_json_escaped = False
         self._capturing = False
-        self._capturing_transcript = False
+        self._capturing_message_json = False
         self._ignore_transcript_tail = False
         self._done = False
         self._saw_tool_call = False
@@ -345,8 +351,8 @@ class ToolCallStreamParser:
             return []
         if self._capturing:
             return self._consume_tool_payload(chunk)
-        if self._capturing_transcript:
-            return self._consume_transcript_json(chunk)
+        if self._capturing_message_json:
+            return self._consume_message_json(chunk)
         return self._consume_text(chunk)
 
     def finish(self) -> list[ProtocolEmission]:
@@ -361,10 +367,9 @@ class ToolCallStreamParser:
                     payload_bytes=len(payload.encode("utf-8")),
                 )
             emissions.extend(self._emit_tool_calls(recovered))
-        if self._capturing_transcript:
-            payload = self._transcript_buffer
-            self._transcript_buffer = ""
-            self._capturing_transcript = False
+        if self._capturing_message_json:
+            payload = "".join(self._message_json_chunks)
+            self._reset_message_json()
             raise self._transcript_error(payload)
         if self._text_tail:
             # After a tool call only whitespace may separate further calls; any
@@ -379,18 +384,26 @@ class ToolCallStreamParser:
             raise ProtocolError("the model did not produce the required tool call")
         return emissions
 
-    def _consume_text(self, chunk: str) -> list[ProtocolEmission]:
+    def _consume_text(
+        self,
+        chunk: str,
+        *,
+        parse_message_json: bool | None = None,
+    ) -> list[ProtocolEmission]:
+        detect_message_json = (
+            self._parse_message_json if parse_message_json is None else parse_message_json
+        )
         value = self._text_tail + chunk
         self._text_tail = ""
         found = find_open_marker(value)
-        transcript_match = _TRANSCRIPT_MESSAGE_PATTERN.search(value)
+        message_match = _MESSAGE_JSON_PATTERN.search(value) if detect_message_json else None
         emissions: list[ProtocolEmission] = []
-        if transcript_match is not None and (found is None or transcript_match.start() < found[0]):
-            prefix = value[: transcript_match.start()]
+        if message_match is not None and (found is None or message_match.start() < found[0]):
+            prefix = value[: message_match.start()]
             if prefix:
                 emissions.extend(self._emit_text_before_marker(prefix))
-            self._capturing_transcript = True
-            emissions.extend(self._consume_transcript_json(value[transcript_match.start() :]))
+            self._capturing_message_json = True
+            emissions.extend(self._consume_message_json(value[message_match.start() :]))
             return emissions
 
         if found is not None:
@@ -408,8 +421,9 @@ class ToolCallStreamParser:
         held = max(
             _partial_marker_suffix_length(value, dialect.open_marker) for dialect in MARKER_DIALECTS
         )
-        partial_transcript = _partial_transcript_prefix_length(value)
-        held = max(held, partial_transcript)
+        if detect_message_json:
+            partial_message = _partial_message_json_prefix_length(value)
+            held = max(held, partial_message)
         if self._saw_tool_call:
             held = max(held, len(self._trailing_partial(value)))
         emit_length = len(value) - held
@@ -420,37 +434,72 @@ class ToolCallStreamParser:
         self._text_tail = value[emit_length:]
         return self._emit_text_before_marker(text)
 
-    def _consume_transcript_json(self, chunk: str) -> list[ProtocolEmission]:
-        value = self._transcript_buffer + chunk
-        self._transcript_buffer = ""
-        payload_bytes = len(value.encode("utf-8"))
-        if payload_bytes > _MAX_TOOL_PAYLOAD_BYTES:
-            raise self._transcript_error(value)
+    def _consume_message_json(self, chunk: str) -> list[ProtocolEmission]:
+        end = self._message_json_end(chunk)
+        committed = chunk if end is None else chunk[:end]
+        self._append_message_json(committed)
+        if end is None:
+            return []
 
+        raw = "".join(self._message_json_chunks)
+        trailing = chunk[end:]
+        self._reset_message_json()
         try:
-            values, remainder = _decode_json_prefix(value)
-        except ValueError as exc:
-            raise self._transcript_error(value) from exc
-        emissions: list[ProtocolEmission] = []
-        for parsed, raw in values:
-            if isinstance(parsed, dict) and parsed.get("role") == "tool":
-                raise self._transcript_error(raw)
-            if isinstance(parsed, dict) and parsed.get("role") == "assistant":
-                if parsed.get("tool_calls"):
-                    emissions.extend(self._assistant_message_tool_calls(parsed, raw))
-                elif isinstance(parsed.get("content"), str):
-                    emissions.append(TextEmission(parsed["content"]))
-                else:
-                    raise self._transcript_error(raw)
-                self._transcript_buffer = ""
-                self._capturing_transcript = False
-                self._ignore_transcript_tail = True
-                self._done = True
-                return emissions
-            raise self._transcript_error(raw)
+            parsed = parse_strict_json(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise self._transcript_error(raw) from exc
 
-        self._transcript_buffer = remainder
-        self._capturing_transcript = bool(remainder)
+        role = parsed.get("role")
+        if role in {"tool", "user"}:
+            raise self._transcript_error(raw)
+        if role != "assistant" or not parsed.get("tool_calls"):
+            return self._emit_plain_json(raw, trailing)
+
+        emissions = self._assistant_message_tool_calls(parsed, raw)
+        self._ignore_transcript_tail = True
+        self._done = True
+        return emissions
+
+    def _message_json_end(self, chunk: str) -> int | None:
+        for index, char in enumerate(chunk):
+            if self._message_json_in_string:
+                if self._message_json_escaped:
+                    self._message_json_escaped = False
+                elif char == "\\":
+                    self._message_json_escaped = True
+                elif char == '"':
+                    self._message_json_in_string = False
+                continue
+            if char == '"':
+                self._message_json_in_string = True
+            elif char in "{[":
+                self._message_json_depth += 1
+            elif char in "}]":
+                self._message_json_depth -= 1
+                if self._message_json_depth == 0:
+                    return index + 1
+        return None
+
+    def _append_message_json(self, value: str) -> None:
+        self._message_json_bytes += len(value.encode("utf-8"))
+        if self._message_json_bytes > _MAX_TOOL_PAYLOAD_BYTES:
+            payload_bytes = self._message_json_bytes
+            self._reset_message_json()
+            raise self._transcript_error("", payload_bytes=payload_bytes)
+        self._message_json_chunks.append(value)
+
+    def _reset_message_json(self) -> None:
+        self._message_json_chunks.clear()
+        self._message_json_bytes = 0
+        self._message_json_depth = 0
+        self._message_json_in_string = False
+        self._message_json_escaped = False
+        self._capturing_message_json = False
+
+    def _emit_plain_json(self, raw: str, trailing: str) -> list[ProtocolEmission]:
+        emissions = self._emit_text_before_marker(raw)
+        if trailing:
+            emissions.extend(self._consume_text(trailing, parse_message_json=False))
         return emissions
 
     def _assistant_message_tool_calls(
@@ -492,11 +541,16 @@ class ToolCallStreamParser:
             )
         return emissions
 
-    def _transcript_error(self, payload: str) -> MalformedToolCallError:
+    def _transcript_error(
+        self,
+        payload: str,
+        *,
+        payload_bytes: int | None = None,
+    ) -> MalformedToolCallError:
         return MalformedToolCallError(
             "model echoed an OpenAI transcript instead of emitting a tool call",
             tool_name=None,
-            payload_bytes=len(payload.encode("utf-8")),
+            payload_bytes=len(payload.encode("utf-8")) if payload_bytes is None else payload_bytes,
         )
 
     def _emit_text_before_marker(self, text: str) -> list[ProtocolEmission]:
@@ -795,50 +849,31 @@ def _partial_marker_suffix_length(value: str, marker: str) -> int:
     return 0
 
 
-def _partial_transcript_prefix_length(value: str) -> int:
-    limit = min(len(value), len(_TRANSCRIPT_PREFIX) - 1)
-    for length in range(limit, 0, -1):
-        if value.endswith(_TRANSCRIPT_PREFIX[:length]):
-            return length
-    return 0
+def _partial_message_json_prefix_length(value: str) -> int:
+    start = value.rfind("{", max(0, len(value) - _MAX_MESSAGE_JSON_PREFIX_CHARS))
+    if start < 0:
+        return 0
+    candidate = value[start:]
 
+    index = 1
+    while index < len(candidate) and candidate[index].isspace():
+        index += 1
+    if index == len(candidate):
+        return len(candidate)
+    if candidate[index] != '"':
+        return 0
 
-def _decode_json_prefix(value: str) -> tuple[list[tuple[Any, str]], str]:
-    decoder = json.JSONDecoder(
-        object_pairs_hook=_strict_object,
-        parse_constant=_strict_constant,
-        parse_float=lambda raw: _strict_float(raw),
-    )
-    values: list[tuple[Any, str]] = []
-    index = 0
-    while True:
-        while index < len(value) and value[index].isspace():
-            index += 1
-        if index >= len(value):
-            return values, ""
-        try:
-            parsed, end = decoder.raw_decode(value, index)
-        except json.JSONDecodeError:
-            return values, value[index:]
-        values.append((parsed, value[index:end]))
-        index = end
+    index += 1
+    closing_quote = candidate.find('"', index)
+    if closing_quote < 0:
+        key_prefix = candidate[index:]
+        return (
+            len(candidate) if any(key.startswith(key_prefix) for key in _MESSAGE_JSON_KEYS) else 0
+        )
+    if candidate[index:closing_quote] not in _MESSAGE_JSON_KEYS:
+        return 0
 
-
-def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ValueError(f"duplicate key '{key}'")
-        result[key] = value
-    return result
-
-
-def _strict_constant(value: str) -> None:
-    raise ValueError(f"non-JSON numeric constant '{value}'")
-
-
-def _strict_float(raw: str) -> float:
-    parsed = float(raw)
-    if not math.isfinite(parsed):
-        raise ValueError(f"non-finite number '{raw}'")
-    return parsed
+    index = closing_quote + 1
+    while index < len(candidate) and candidate[index].isspace():
+        index += 1
+    return len(candidate) if index == len(candidate) else 0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1786,6 +1786,32 @@ async def test_non_streaming_malformed_tool_call_stops_with_note(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_incomplete_message_json_stops_with_note(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta('{"role":"assistant","tool_calls":'),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ]
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"].startswith("[bridge notice: dropped a malformed tool call")
+    assert "tool_calls" not in choice["message"]
+
+
+@pytest.mark.asyncio
 async def test_streaming_malformed_tool_call_without_prior_text(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
@@ -2962,6 +2988,57 @@ async def test_json_schema_response_format_is_enforced_and_forwarded(
         "type": "json_schema",
         "schema": schema,
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_response_format_preserves_message_shaped_json(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    message = '{"role":"assistant","content":"done"}'
+    runner = FakeRunner(
+        [
+            TextDelta(message[:12]),
+            TextDelta(message[12:]),
+            RunComplete(Usage()),
+        ]
+    )
+    schema = {
+        "type": "object",
+        "properties": {
+            "role": {"const": "assistant"},
+            "content": {"type": "string"},
+        },
+        "required": ["role", "content"],
+        "additionalProperties": False,
+    }
+    payload = _payload(
+        stream=stream,
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "message", "schema": schema},
+        },
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        chunks = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith('data: {"')
+        ]
+        content = "".join(
+            choice["delta"].get("content") or ""
+            for chunk in chunks
+            for choice in chunk.get("choices", [])
+        )
+    else:
+        content = response.json()["choices"][0]["message"]["content"]
+    assert content == message
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -89,6 +89,14 @@ def test_contract_satisfied_is_a_pass(e2e: ModuleType) -> None:
             '{"messages":[],"tools":[]} continuation garbage',
             "assistant reproduced the OpenAI transcript",
         ),
+        (
+            '```json\n{"messages":[{"role":"user","content":"hi"}],"tools":[]}\n```',
+            "assistant reproduced the OpenAI transcript",
+        ),
+        (
+            '```\n{"role":"assistant","content":"copied"}\n```',
+            "assistant reproduced an OpenAI assistant message",
+        ),
         ("[1,2,3]", None),
         ("ordinary answer", None),
     ],

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from factory_droid_openai import logs
+from factory_droid_openai import logs, protocol
 from factory_droid_openai.models import ChatCompletionRequest
 from factory_droid_openai.protocol import (
     _MAX_TOOL_PAYLOAD_BYTES,
@@ -20,7 +20,6 @@ from factory_droid_openai.protocol import (
     TextEmission,
     ToolCallEmission,
     ToolCallStreamParser,
-    _decode_json_prefix,
     build_prompt,
     parse_strict_json,
 )
@@ -798,21 +797,139 @@ def test_stream_parser_rejects_an_oversized_transcript_message() -> None:
 
     with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
         parser.feed('{"role":"assistant","content":"' + ("x" * 1_000_001))
+    assert parser.finish() == []
 
 
-def test_stream_parser_accepts_assistant_message_content_without_tool_calls() -> None:
+def test_stream_parser_preserves_assistant_message_content_without_tool_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    message = '{"role":"assistant","content":"done"}'
+
+    emissions = parser.feed(message)
+
+    assert emissions == [TextEmission(message)]
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        (
+            '{ "role" : "assistant", "tool_calls": '
+            '[{"function":{"name":"weather","arguments":"{}"}}]}'
+        ),
+        (
+            '{"content":null,"tool_calls":'
+            '[{"function":{"name":"weather","arguments":"{}"}}],"role":"assistant"}'
+        ),
+    ],
+)
+def test_stream_parser_recognizes_message_json_across_layouts(message: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    emissions: list[object] = []
+
+    for char in message:
+        emissions.extend(parser.feed(char))
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "weather"
+
+
+def test_stream_parser_preserves_prose_that_quotes_an_assistant_message() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    text = 'Example: {"role":"assistant","content":"done"}'
+
+    emissions = parser.feed(text)
+    emissions.extend(parser.finish())
+
+    assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == text
+
+
+def test_stream_parser_rejects_incomplete_reordered_message_json() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 
-    emissions = parser.feed('{"role":"assistant","content":"done"}')
+    assert parser.feed('{ "content":') == []
+    with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+        parser.finish()
 
-    assert emissions == [TextEmission("done")]
 
-
-def test_stream_parser_holds_a_split_transcript_prefix() -> None:
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{ "answer": invalid}',
+        '{"role":"assistant","content":"done"} trailing',
+    ],
+)
+def test_stream_parser_preserves_plain_json_candidates(text: str) -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 
-    assert parser.feed('{"rol') == []
-    assert parser.feed('e":"assistant","content":"done"}') == [TextEmission("done")]
+    emissions = parser.feed(text)
+    emissions.extend(parser.finish())
+
+    assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == text
+
+
+def test_stream_parser_preserves_nested_message_fields() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    text = '{"content":"ok","metadata":{"role":"tool","tool_calls":[]}}'
+
+    assert parser.feed(text) == [TextEmission(text)]
+
+
+def test_stream_parser_handles_many_adjacent_json_objects_iteratively() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    text = '{"role":"assistant","content":"ok"}' + '{"x":1}' * 1_500
+
+    emissions = parser.feed(text)
+    emissions.extend(parser.finish())
+
+    assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == text
+
+
+def test_stream_parser_keeps_a_bounded_partial_message_prefix() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    emissions: list[object] = []
+    widest_tail = 0
+
+    for _ in range(1_000):
+        emissions.extend(parser.feed("{ "))
+        widest_tail = max(widest_tail, len(parser._text_tail))
+    emissions.extend(parser.finish())
+
+    assert widest_tail <= 64
+    assert (
+        "".join(item.text for item in emissions if isinstance(item, TextEmission)) == "{ " * 1_000
+    )
+
+
+def test_stream_parser_releases_non_message_object_prefix() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    assert parser.feed("{x") == [TextEmission("{x")]
+
+
+def test_stream_parser_decodes_message_json_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    original = protocol.parse_strict_json
+
+    def counted_parse(value: str) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(protocol, "parse_strict_json", counted_parse)
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    message = (
+        '{"content":null,"tool_calls":'
+        '[{"function":{"name":"weather","arguments":{}}}],"role":"assistant"}'
+    )
+
+    for char in message:
+        parser.feed(char)
+
+    assert calls == 1
 
 
 def test_stream_parser_drops_copied_tool_messages_after_assistant_json() -> None:
@@ -838,7 +955,6 @@ def test_stream_parser_drops_copied_tool_messages_after_assistant_json() -> None
         '{"role":"tool","content":"copied","tool_call_id":"call_model"}',
         '{"role":"assistant","tool_calls":[{"function":{"name":"weather","arguments":"[]"}}]}',
         '{"role":"assistant","tool_calls":"not a list"}',
-        '{"role":"assistant"}',
         '{"role":"assistant","tool_calls":[7]}',
         '{"role":"assistant","tool_calls":[{"function":"bad"}]}',
         '{"role":"assistant","tool_calls":[{"function":{"name":7}}]}',
@@ -902,29 +1018,19 @@ def test_stream_parser_rejects_non_finite_assistant_arguments(payload: str) -> N
         parser.feed(payload)
 
 
-def test_decode_json_prefix_skips_leading_whitespace() -> None:
-    values, remainder = _decode_json_prefix('  {"role":"assistant","content":"done"}')
-
-    assert values == [
-        (
-            {"role": "assistant", "content": "done"},
-            '{"role":"assistant","content":"done"}',
-        )
-    ]
-    assert remainder == ""
-
-
 @pytest.mark.parametrize("payload", ['{"role":NaN}', '{"role":1e999}'])
-def test_decode_json_prefix_rejects_non_finite_values(payload: str) -> None:
-    with pytest.raises(ValueError, match=r"non-JSON numeric constant|non-finite number"):
-        _decode_json_prefix(payload)
+def test_stream_parser_rejects_non_finite_message_values(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+        parser.feed(payload)
 
 
-def test_decode_json_prefix_keeps_finite_float() -> None:
-    values, remainder = _decode_json_prefix('{"role":1.5}')
+def test_stream_parser_preserves_non_message_json() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    payload = '{"role":1.5}'
 
-    assert values == [({"role": 1.5}, '{"role":1.5}')]
-    assert remainder == ""
+    assert parser.feed(payload) == [TextEmission(payload)]
 
 
 def test_stream_parser_repairs_lost_prefix_wrapped_form() -> None:


### PR DESCRIPTION
## Summary

- Detect message-shaped assistant tool calls across key layouts and chunk boundaries.
- Preserve structured output and ordinary message-shaped JSON content.
- Replace repeated incomplete-JSON decoding with bounded incremental scanning.
- Handle malformed payloads consistently in streaming and non-streaming responses.
- Detect fenced transcript JSON in the live matrix.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1155 passed, 100% coverage
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`

Follow-up to #53 review findings.
