### PR TITLE
fix: retry native tool disable settlement

### DIFF
--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -335,6 +335,8 @@ class Observation:
 # reports that as a protocol error like every other unmet contract. Only the
 # message separates model non-compliance from an actual parser bug.
 _TOOL_CHOICE_IGNORED = "did not produce the required tool call"
+_UNAVAILABLE_TOOL = " is not available"
+_TRAILING_TOOL_TEXT = "unexpected text after tool call"
 
 
 def _content_semantic_error(content: str) -> str | None:
@@ -366,8 +368,14 @@ def _error_verdict(observation: Observation) -> tuple[str, str] | None:
         return ACCOUNT_POLICY, "model unavailable for this account"
     if error_type == "factory_native_tool_blocked":
         return MODEL_BEHAVIOR, "model attempted a Factory-native tool"
-    if error_type == "factory_protocol_error" and _TOOL_CHOICE_IGNORED in observation.error_message:
-        return MODEL_BEHAVIOR, "model ignored tool_choice=required"
+    if error_type == "factory_protocol_error":
+        if _TOOL_CHOICE_IGNORED in observation.error_message:
+            return MODEL_BEHAVIOR, "model ignored tool_choice=required"
+        if (
+            _UNAVAILABLE_TOOL in observation.error_message
+            or _TRAILING_TOOL_TEXT in observation.error_message
+        ):
+            return MODEL_BEHAVIOR, "model emitted an invalid tool-call response"
     if observation.status == 429:
         return CAPACITY, "bridge queue is full"
     if observation.status == 503:
@@ -405,6 +413,8 @@ def classify(scenario: Scenario, observation: Observation) -> tuple[str, str]:
     if observation.finish_reason not in scenario.expect_finish:
         if observation.finish_reason == "tool_calls":
             return MODEL_BEHAVIOR, "model called a tool when none was required"
+        if observation.finish_reason == "length" and scenario.expect_tool_call:
+            return MODEL_BEHAVIOR, "model truncated its tool-call response"
         return BRIDGE_DEFECT, f"unexpected finish_reason {observation.finish_reason}"
     if scenario.expect_tool_call and observation.tool_calls == 0:
         return MODEL_BEHAVIOR, "model produced no client tool call"

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -413,8 +413,11 @@ def classify(scenario: Scenario, observation: Observation) -> tuple[str, str]:
     if observation.finish_reason not in scenario.expect_finish:
         if observation.finish_reason == "tool_calls":
             return MODEL_BEHAVIOR, "model called a tool when none was required"
-        if observation.finish_reason == "length" and scenario.expect_tool_call:
-            return MODEL_BEHAVIOR, "model truncated its tool-call response"
+        if scenario.expect_tool_call and observation.tool_calls == 0:
+            if observation.finish_reason == "length":
+                return MODEL_BEHAVIOR, "model truncated its tool-call response"
+            if observation.finish_reason == "stop":
+                return MODEL_BEHAVIOR, "model produced no client tool call"
         return BRIDGE_DEFECT, f"unexpected finish_reason {observation.finish_reason}"
     if scenario.expect_tool_call and observation.tool_calls == 0:
         return MODEL_BEHAVIOR, "model produced no client tool call"

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -19,6 +19,8 @@ _RPC_TIMEOUT_SECONDS = 30.0
 # metadata RPCs. The caller's own timeout still bounds the operation.
 _COMPACTION_TIMEOUT_SECONDS = 300.0
 _MCP_POLL_SECONDS = 0.1
+_TOOL_DISABLE_RETRIES = 3
+_TOOL_DISABLE_RETRY_SECONDS = 0.1
 _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
 
 
@@ -121,25 +123,31 @@ class DroidRpcExtension:
         if not tools:
             raise DroidClientError("Droid returned an empty native tool catalog")
         tool_ids = sorted({_required_str(tool, "id") for tool in tools})
-        await self._request(
-            client,
-            DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
-            {
-                "interactionMode": DroidInteractionMode.Auto.value,
-                "autonomyLevel": AutonomyLevel.Off.value,
-                "enabledToolIds": [],
-                "disabledToolIds": tool_ids,
-            },
-        )
-        remaining = {
-            _required_str(tool, "id")
-            for tool in await self._list_tools(client)
-            if _required_bool(tool, "currentlyAllowed")
+        settings = {
+            "interactionMode": DroidInteractionMode.Auto.value,
+            "autonomyLevel": AutonomyLevel.Off.value,
+            "enabledToolIds": [],
+            "disabledToolIds": tool_ids,
         }
-        unexpected = remaining - _UNAVOIDABLE_TOOL_IDS
-        if unexpected:
-            rendered = ", ".join(sorted(unexpected))
-            raise DroidClientError(f"Failed to disable native Droid tools: {rendered}")
+        unexpected: set[str] = set()
+        for attempt in range(_TOOL_DISABLE_RETRIES):
+            await self._request(
+                client,
+                DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
+                settings,
+            )
+            remaining = {
+                _required_str(tool, "id")
+                for tool in await self._list_tools(client)
+                if _required_bool(tool, "currentlyAllowed")
+            }
+            unexpected = remaining - _UNAVOIDABLE_TOOL_IDS
+            if not unexpected:
+                return
+            if attempt + 1 < _TOOL_DISABLE_RETRIES:
+                await asyncio.sleep(_TOOL_DISABLE_RETRY_SECONDS)
+        rendered = ", ".join(sorted(unexpected))
+        raise DroidClientError(f"Failed to disable native Droid tools: {rendered}")
 
     async def _wait_for_mcp_catalog(self, client: DroidClient) -> None:
         # Off by default: MCP servers that never leave "connecting" would

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -122,25 +122,25 @@ class DroidRpcExtension:
         tools = await self._list_tools(client)
         if not tools:
             raise DroidClientError("Droid returned an empty native tool catalog")
-        tool_ids = sorted({_required_str(tool, "id") for tool in tools})
-        settings = {
-            "interactionMode": DroidInteractionMode.Auto.value,
-            "autonomyLevel": AutonomyLevel.Off.value,
-            "enabledToolIds": [],
-            "disabledToolIds": tool_ids,
-        }
+        tool_ids = {_required_str(tool, "id") for tool in tools}
         unexpected: set[str] = set()
         for attempt in range(_TOOL_DISABLE_RETRIES):
             await self._request(
                 client,
                 DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
-                settings,
+                {
+                    "interactionMode": DroidInteractionMode.Auto.value,
+                    "autonomyLevel": AutonomyLevel.Off.value,
+                    "enabledToolIds": [],
+                    "disabledToolIds": sorted(tool_ids),
+                },
             )
-            remaining = {
-                _required_str(tool, "id")
-                for tool in await self._list_tools(client)
-                if _required_bool(tool, "currentlyAllowed")
-            }
+            remaining: set[str] = set()
+            for tool in await self._list_tools(client):
+                tool_id = _required_str(tool, "id")
+                tool_ids.add(tool_id)
+                if _required_bool(tool, "currentlyAllowed"):
+                    remaining.add(tool_id)
             unexpected = remaining - _UNAVOIDABLE_TOOL_IDS
             if not unexpected:
                 return

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -132,6 +132,39 @@ async def test_disable_native_tools_verifies_exec_and_mcp_catalogs() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disable_native_tools_retries_catalog_settlement() -> None:
+    catalog_reads = 0
+    updates = 0
+
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        nonlocal catalog_reads, updates
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": []}}
+        if method == "droid.list_tools":
+            catalog_reads += 1
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": "read-cli",
+                            "currentlyAllowed": catalog_reads < 3,
+                        },
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            updates += 1
+            return {"result": {}}
+        raise AssertionError(method)
+
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension().disable_native_tools(_client(protocol))
+
+    assert updates == 2
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("tools", "message"),
     [

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -165,6 +165,43 @@ async def test_disable_native_tools_retries_catalog_settlement() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disable_native_tools_disables_tools_added_during_settlement() -> None:
+    disabled: set[str] = set()
+    catalog_reads = 0
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        nonlocal catalog_reads
+        if method == "droid.list_tools":
+            catalog_reads += 1
+            tool_ids = ["read-cli"] if catalog_reads == 1 else ["read-cli", "write-cli"]
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": tool_id,
+                            "currentlyAllowed": tool_id not in disabled,
+                        }
+                        for tool_id in tool_ids
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            disabled.update(params["disabledToolIds"])
+            return {"result": {}}
+        raise AssertionError(method)
+
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension().disable_native_tools(_client(protocol))
+
+    updates = [
+        params for method, params, _ in protocol.calls if method == "droid.update_session_settings"
+    ]
+    assert updates[0]["disabledToolIds"] == ["read-cli"]
+    assert updates[1]["disabledToolIds"] == ["read-cli", "write-cli"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("tools", "message"),
     [

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -181,7 +181,21 @@ def test_failures_land_in_their_own_bucket(
     assert detail
 
 
-def test_missing_tool_call_is_model_behavior_not_a_bridge_defect(e2e: ModuleType) -> None:
+@pytest.mark.parametrize(
+    ("finish_reason", "tool_calls", "expected"),
+    [
+        ("tool_calls", 0, "model_behavior"),
+        ("stop", 0, "model_behavior"),
+        ("length", 0, "model_behavior"),
+        ("length", 1, "bridge_defect"),
+    ],
+)
+def test_tool_call_outcomes_are_classified_by_model_responsibility(
+    e2e: ModuleType,
+    finish_reason: str,
+    tool_calls: int,
+    expected: str,
+) -> None:
     scenario = _scenario(
         e2e,
         expect_finish=("tool_calls",),
@@ -191,26 +205,15 @@ def test_missing_tool_call_is_model_behavior_not_a_bridge_defect(e2e: ModuleType
 
     verdict, _ = e2e.classify(
         scenario,
-        _observation(e2e, finish_reason="tool_calls", tool_calls=0, content_chars=0),
+        _observation(
+            e2e,
+            finish_reason=finish_reason,
+            tool_calls=tool_calls,
+            content_chars=0,
+        ),
     )
 
-    assert verdict == "model_behavior"
-
-
-def test_truncated_expected_tool_call_is_model_behavior(e2e: ModuleType) -> None:
-    scenario = _scenario(
-        e2e,
-        expect_finish=("tool_calls",),
-        expect_tool_call=True,
-        expect_content=False,
-    )
-
-    verdict, _ = e2e.classify(
-        scenario,
-        _observation(e2e, finish_reason="length", tool_calls=0, content_chars=0),
-    )
-
-    assert verdict == "model_behavior"
+    assert verdict == expected
 
 
 def test_a_stream_that_fails_after_its_headers_is_still_judged(e2e: ModuleType) -> None:

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -149,6 +149,22 @@ def test_expected_rejection_is_a_pass(e2e: ModuleType) -> None:
             },
             "model_behavior",
         ),
+        (
+            {
+                "status": 502,
+                "error_type": "factory_protocol_error",
+                "error_message": "tool 'assistant' is not available",
+            },
+            "model_behavior",
+        ),
+        (
+            {
+                "status": 502,
+                "error_type": "factory_protocol_error",
+                "error_message": "unexpected text after tool call (native dialect)",
+            },
+            "model_behavior",
+        ),
         ({"finish_reason": "length"}, "bridge_defect"),
         ({"finish_reason": "tool_calls"}, "model_behavior"),
         ({"content_chars": 0}, "model_behavior"),
@@ -176,6 +192,22 @@ def test_missing_tool_call_is_model_behavior_not_a_bridge_defect(e2e: ModuleType
     verdict, _ = e2e.classify(
         scenario,
         _observation(e2e, finish_reason="tool_calls", tool_calls=0, content_chars=0),
+    )
+
+    assert verdict == "model_behavior"
+
+
+def test_truncated_expected_tool_call_is_model_behavior(e2e: ModuleType) -> None:
+    scenario = _scenario(
+        e2e,
+        expect_finish=("tool_calls",),
+        expect_tool_call=True,
+        expect_content=False,
+    )
+
+    verdict, _ = e2e.classify(
+        scenario,
+        _observation(e2e, finish_reason="length", tool_calls=0, content_chars=0),
     )
 
     assert verdict == "model_behavior"


### PR DESCRIPTION
## Summary
- Retry native-tool disable settings until catalog state settles.
- Classify malformed model tool output and tool-call truncation as model behavior.
- Add regression coverage.

## Validation
- 1146 tests passed, 100% coverage
- Ruff, format check, mypy
- OpenAPI validation, lock check, package build
- Live matrix partial: 505 requests, 0 bridge defects; run timed out during slow model coverage
