### PR TITLE
fix: contain malformed tool calls and unsafe warm-session reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,13 @@ jobs:
       - name: Validate OpenAPI contract
         run: uv run openapi-spec-validator openapi.json
 
+      # Validating the committed file cannot catch a file that no longer
+      # matches the routes and schemas that produced it.
+      - name: Verify OpenAPI contract is regenerated
+        run: |
+          uv run python scripts/generate_openapi.py
+          git diff --exit-code openapi.json
+
       - name: Validate PromptScript targets
         run: |
           prs validate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,12 @@ to the next model in both transport modes. Use
 `--switch-settle-seconds SECONDS` when the bridge needs a different refill
 window. Switch rows include `source_model` and prime-request diagnostics.
 
+To verify explicit session continuity as well, start the bridge with
+`FACTORY_DROID_OPENAI_SESSION_CONTINUITY=true` and add
+`--test-session-continuity` to the matrix command. That phase creates a session
+with one model and confirms that continuing its ID with the next model is
+rejected instead of silently running under mismatched settings.
+
 ```bash
 uv run python scripts/e2e_matrix.py report traces/run-a.jsonl
 uv run python scripts/e2e_matrix.py compare traces/run-a.jsonl traces/run-b.jsonl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,13 @@ the run; `model_behavior`, `account_policy`, `capacity`,
 `provider_unavailable`, and `backend_timeout` describe the environment, not the
 code. Re-render a report or diff two runs after a change:
 
+After the parallel per-model cases, the harness runs a serialized model-switch
+ring against the same bridge process. Each pair primes the warm pool with one
+model, waits five seconds for refill, then sends a required tool-call request
+to the next model in both transport modes. Use
+`--switch-settle-seconds SECONDS` when the bridge needs a different refill
+window. Switch rows include `source_model` and prime-request diagnostics.
+
 ```bash
 uv run python scripts/e2e_matrix.py report traces/run-a.jsonl
 uv run python scripts/e2e_matrix.py compare traces/run-a.jsonl traces/run-b.jsonl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,8 @@ window. Switch rows include `source_model` and prime-request diagnostics.
 To verify explicit session continuity as well, start the bridge with
 `FACTORY_DROID_OPENAI_SESSION_CONTINUITY=true` and add
 `--test-session-continuity` to the matrix command. That phase creates a session
-with one model and confirms that continuing its ID with the next model is
-rejected instead of silently running under mismatched settings.
+with one model and confirms that continuing its ID with different settings is
+rejected instead of silently running under a stale model or reasoning effort.
 
 ```bash
 uv run python scripts/e2e_matrix.py report traces/run-a.jsonl

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,8 @@ RUN if [ -n "${BRIDGE_VERSION}" ]; then \
 # working directory (Factory-native tools are disabled), so a read-only host
 # mount at /work is safe. Sessions live in the per-user Factory config dir.
 RUN useradd --create-home --uid 1000 droid \
- && chown -R droid:droid /work
+ && mkdir -p /home/droid/.factory \
+ && chown -R droid:droid /work /home/droid/.factory
 USER droid
 WORKDIR /work
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,10 @@ argument key, or prose after a call still fails the turn. A payload truncated
 before its close marker ends with `finish_reason="length"`. A closed malformed
 call or a mangled OpenAI `tool_calls` fragment ends with `finish_reason="stop"`
 and a plain-text bridge notice. The malformed JSON and the call are dropped,
-never executed or returned to the client. When an earlier call in the same
+never executed or returned to the client. The notice names no tool-call
+format, because anything it named would itself be tool-call-shaped text in
+assistant content: recovery is the client's retry, not the model's next turn.
+When an earlier call in the same
 turn did complete, the turn keeps `finish_reason="tool_calls"` so the client
 runs the call it already received. Qwen3's XML form declares no argument
 types, so a scalar value stays the string the model wrote unless it wrote a
@@ -463,10 +466,15 @@ docker compose up -d
 
 The file must be readable by container user `uid 1000`. Keep it outside the
 repository when it contains custom-model credentials. Request model,
-reasoning effort, Auto interaction mode, autonomy Off, and disabled Droid
-tools are pinned by the bridge and override matching session defaults.
-Mounting this file does not mount other profile files such as
-`system-prompt.md`, skills, or hooks.
+reasoning effort, Auto interaction mode, autonomy Off, disabled Droid tools,
+and disabled MCP servers are pinned by the bridge and override matching
+session defaults. Mounting this file does not mount other profile files such
+as `system-prompt.md`, skills, or hooks.
+
+Everything else the file declares still applies to the Droid subprocess. The
+bridge pins the tool and autonomy surface, not every setting, so review the
+file before mounting it and prefer a reduced copy that carries only the
+custom-model entries the bridge needs.
 
 Never publish the bridge port to a non-loopback interface without a
 configured `FACTORY_DROID_OPENAI_API_KEY`. See
@@ -1351,9 +1359,11 @@ Warm sessions are keyed by the model and reasoning effort they were
 initialized with. An exact match serves a turn with no extra round trip.
 A compatible session can be repointed at another model or explicit reasoning
 effort, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
-`pool.retune` plus `droid.session_retuned`. Kimi model switches always use a
-fresh or exact-match warm session so Kimi-specific protocol state cannot cross
-the boundary. Requests that ask for the model alias, or for the model's
+`pool.retune` plus `droid.session_retuned`. A retune only swaps the model id,
+so the tool-call template the session was initialized with survives it: model
+families that frame calls in their own special tokens always use a fresh or
+exact-match warm session instead. Kimi is the one such family today, matched
+by the same family table telemetry labels use. Requests that ask for the model alias, or for the model's
 default reasoning effort on a session that carries an explicit one, also log
 `pool.miss`. The pool tracks the settings recent traffic used, so repeat
 traffic converges on exact matches.

--- a/README.md
+++ b/README.md
@@ -279,13 +279,15 @@ text. Every accepted form lives in one table in
 | `name","key":"value"...}` with the opening `{"name":"` bytes lost | GLM, only with `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX=true` |
 
 Translation never widens validation. An unknown tool name, a duplicate
-argument key, or prose after a call still fails the turn. A truncated payload,
-or one no decoder can parse, ends the turn with `finish_reason="length"`
-instead; the partial or malformed call is dropped, never executed. When an
-earlier call in the same turn did complete, the turn keeps
-`finish_reason="tool_calls"` so the client runs the call it already received. Qwen3's
-XML form declares no argument types, so a scalar value stays the string the
-model wrote unless it wrote a JSON object or array.
+argument key, or prose after a call still fails the turn. A payload truncated
+before its close marker ends with `finish_reason="length"`. A closed malformed
+call or a mangled OpenAI `tool_calls` fragment ends with `finish_reason="stop"`
+and a plain-text bridge notice. The malformed JSON and the call are dropped,
+never executed or returned to the client. When an earlier call in the same
+turn did complete, the turn keeps `finish_reason="tool_calls"` so the client
+runs the call it already received. Qwen3's XML form declares no argument
+types, so a scalar value stays the string the model wrote unless it wrote a
+JSON object or array.
 
 Two forms are not supported:
 
@@ -1279,7 +1281,7 @@ surface.
 | `factory_droid_openai_model_quarantines_total` | Models withheld after Droid refused them |
 | `factory_droid_openai_warm_sessions` | Warm Droid sessions ready now |
 | `factory_droid_openai_warm_session_hits_total` | Requests served from a warm session |
-| `factory_droid_openai_warm_session_retunes_total` | Warm sessions repointed at another model |
+| `factory_droid_openai_warm_session_retunes_total` | Warm sessions repointed at another model or effort |
 | `factory_droid_openai_warm_session_misses_total` | Requests that had to start their own session |
 | `factory_droid_openai_warm_session_failures_total` | Failed warm-up attempts |
 | `factory_droid_openai_pending_reaps` | Droid teardowns still running in the background |
@@ -1317,13 +1319,14 @@ refills.
 
 Warm sessions are keyed by the model and reasoning effort they were
 initialized with. An exact match serves a turn with no extra round trip.
-Otherwise the bridge repoints a session warmed for another model at the
-requested one, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
-`pool.retune` plus `droid.session_retuned`. Requests that ask for the model
-alias, or for the model's default reasoning effort on a session that carries
-an explicit one, cannot be expressed as an update and still log `pool.miss`.
-The pool tracks the settings recent traffic used, so repeat traffic converges
-on exact matches.
+A compatible session can be repointed at another model or explicit reasoning
+effort, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
+`pool.retune` plus `droid.session_retuned`. Kimi model switches always use a
+fresh or exact-match warm session so Kimi-specific protocol state cannot cross
+the boundary. Requests that ask for the model alias, or for the model's
+default reasoning effort on a session that carries an explicit one, also log
+`pool.miss`. The pool tracks the settings recent traffic used, so repeat
+traffic converges on exact matches.
 
 Teardown runs after the response is finished, so session close and the second
 `droid exec` needs to exit no longer delay the last token. Set
@@ -1365,9 +1368,9 @@ DEBUG    2026-07-27T14:10:12+0200 event=droid.cleanup request_id=chatcmpl-8f2a c
 ```
 
 `droid.connected` and `droid_startup_ms` only appear on a cold session,
-`pool.retune` and `droid.session_retuned` only when a session warmed for
-another model is reused, and cleanup is logged after the response because it
-is detached.
+`pool.retune` and `droid.session_retuned` only when a compatible session is
+reused with other settings, and cleanup is logged after the response because
+it is detached.
 
 Phase fields, in the order they occur:
 
@@ -1376,7 +1379,7 @@ Phase fields, in the order they occur:
 | `prompt_ms` | Transcript and tool-schema serialization in the bridge |
 | `queue_ms` | Waiting for a Droid concurrency slot |
 | `droid_startup_ms` | `droid exec` process spawn and SDK handshake |
-| `retune_ms` | Repointing a warm session at the requested model |
+| `retune_ms` | Repointing a warm session at the requested settings |
 | `session_ready_ms` | Elapsed until the Droid session accepts a prompt |
 | `prompt_sent_ms` | Elapsed until the prompt was handed to Droid |
 | `ttft_ms` | Elapsed until the first text or reasoning delta |
@@ -1559,11 +1562,11 @@ request timeout, and bridge logs.
 ### One slow request after switching models
 
 The warm pool holds sessions for the model and reasoning effort recent traffic
-used. A session warmed for another model is repointed in milliseconds and logs
-`pool.retune`, so only requests that cannot be expressed as a settings
-update - the model alias, or a model default effort on a session with an
-explicit one - pay full startup and log `pool.miss` with a multi-second
-`session_ready_ms`. Raise `FACTORY_DROID_OPENAI_WARM_SESSIONS` when clients
+used. Most compatible model switches log `pool.retune` and complete in
+milliseconds. Kimi switches intentionally start a fresh session when no exact
+warm session exists, then log `pool.miss` with a multi-second
+`session_ready_ms`; this prevents Kimi-specific protocol state from leaking
+across the switch. Raise `FACTORY_DROID_OPENAI_WARM_SESSIONS` when clients
 alternate between models faster than the pool refills.
 
 ### Every request logs a forced kill

--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,10 @@ header, and announced in the first streaming chunk.
 Only sessions this bridge process created can be continued. Session IDs
 stored by the local Droid CLI - including your own interactive sessions - are
 rejected with HTTP `404`, so a client cannot read back conversations it does
-not own. Restarting the bridge clears the set of continuable sessions.
+not own. A continuation must use the model that created the session; selecting
+another model returns HTTP `400`. Start a new session and resend the transcript
+when switching models. Restarting the bridge clears the set of continuable
+sessions.
 
 The same guard applies to the Factory session extension endpoints. They are
 available only when continuity is enabled and only for IDs created by the

--- a/README.md
+++ b/README.md
@@ -1318,7 +1318,7 @@ surface.
 | `factory_droid_openai_model_quarantines_total` | Models withheld after Droid refused them |
 | `factory_droid_openai_warm_sessions` | Warm Droid sessions ready now |
 | `factory_droid_openai_warm_session_hits_total` | Requests served from a warm session |
-| `factory_droid_openai_warm_session_retunes_total` | Warm sessions repointed at another model or effort |
+| `factory_droid_openai_warm_session_retunes_total` | Warm sessions repointed at another reasoning effort, labelled `reason="effort"` |
 | `factory_droid_openai_warm_session_misses_total` | Requests that had to start their own session |
 | `factory_droid_openai_warm_session_failures_total` | Failed warm-up attempts |
 | `factory_droid_openai_pending_reaps` | Droid teardowns still running in the background |
@@ -1356,15 +1356,16 @@ refills.
 
 Warm sessions are keyed by the model and reasoning effort they were
 initialized with. An exact match serves a turn with no extra round trip.
-A compatible session can be repointed at another model or explicit reasoning
-effort, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
-`pool.retune` plus `droid.session_retuned`. A retune only swaps the model id,
-so the tool-call template the session was initialized with survives it: model
-families that frame calls in their own special tokens always use a fresh or
-exact-match warm session instead. Kimi is the one such family today, matched
-by the same family table telemetry labels use. Requests that ask for the
-model alias, or for the model's default reasoning effort on a session that
-carries an explicit one, also log `pool.miss`. The pool tracks the settings
+A session warmed for the same model can be repointed at another explicit
+reasoning effort, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
+`pool.retune` plus `droid.session_retuned`. A model change never retunes: a
+retune swaps the model id while the session keeps the tool-call template it
+was initialized with, and that template belongs to the model rather than to
+its family, so no denylist of families would be safe either. Kimi K2 frames
+calls in `<|tool_calls_section_begin|>` where K3 uses `<|open|>tools<|sep|>`.
+Requests that ask for a different model, for the model alias, or for the
+model's default reasoning effort on a session that carries an explicit one,
+log `pool.miss` and wait for a fresh session. The pool tracks the settings
 recent traffic used, so repeat traffic converges on exact matches.
 
 Teardown runs after the response is finished, so session close and the second
@@ -1407,9 +1408,9 @@ DEBUG    2026-07-27T14:10:12+0200 event=droid.cleanup request_id=chatcmpl-8f2a c
 ```
 
 `droid.connected` and `droid_startup_ms` only appear on a cold session,
-`pool.retune` and `droid.session_retuned` only when a compatible session is
-reused with other settings, and cleanup is logged after the response because
-it is detached.
+`pool.retune` and `droid.session_retuned` only when a session warmed for the
+same model is reused at another reasoning effort, and cleanup is logged after
+the response because it is detached.
 
 Phase fields, in the order they occur:
 
@@ -1601,12 +1602,12 @@ request timeout, and bridge logs.
 ### One slow request after switching models
 
 The warm pool holds sessions for the model and reasoning effort recent traffic
-used. Most compatible model switches log `pool.retune` and complete in
-milliseconds. Kimi switches intentionally start a fresh session when no exact
-warm session exists, then log `pool.miss` with a multi-second
-`session_ready_ms`; this prevents Kimi-specific protocol state from leaking
-across the switch. Raise `FACTORY_DROID_OPENAI_WARM_SESSIONS` when clients
-alternate between models faster than the pool refills.
+used. A model switch intentionally starts a fresh session when no exact warm
+session exists, then logs `pool.miss` with a multi-second `session_ready_ms`;
+this prevents the tool-call template of the previous model from leaking across
+the switch. Only a reasoning-effort change on the same model logs `pool.retune`
+and completes in milliseconds. Raise `FACTORY_DROID_OPENAI_WARM_SESSIONS` when
+clients alternate between models faster than the pool refills.
 
 ### Every request logs a forced kill
 

--- a/README.md
+++ b/README.md
@@ -1079,10 +1079,10 @@ header, and announced in the first streaming chunk.
 Only sessions this bridge process created can be continued. Session IDs
 stored by the local Droid CLI - including your own interactive sessions - are
 rejected with HTTP `404`, so a client cannot read back conversations it does
-not own. A continuation must use the model that created the session; selecting
-another model returns HTTP `400`. Start a new session and resend the transcript
-when switching models. Restarting the bridge clears the set of continuable
-sessions.
+not own. A continuation must use the model and reasoning effort that created
+the session; changing either returns HTTP `400`. Start a new session and resend
+the transcript when switching settings. Restarting the bridge clears the set
+of continuable sessions.
 
 The same guard applies to the Factory session extension endpoints. They are
 available only when continuity is enabled and only for IDs created by the

--- a/README.md
+++ b/README.md
@@ -286,11 +286,10 @@ and a plain-text bridge notice. The malformed JSON and the call are dropped,
 never executed or returned to the client. The notice names no tool-call
 format, because anything it named would itself be tool-call-shaped text in
 assistant content: recovery is the client's retry, not the model's next turn.
-When an earlier call in the same
-turn did complete, the turn keeps `finish_reason="tool_calls"` so the client
-runs the call it already received. Qwen3's XML form declares no argument
-types, so a scalar value stays the string the model wrote unless it wrote a
-JSON object or array.
+When an earlier call in the same turn did complete, the turn keeps
+`finish_reason="tool_calls"` so the client runs the call it already received.
+Qwen3's XML form declares no argument types, so a scalar value stays the
+string the model wrote unless it wrote a JSON object or array.
 
 Two forms are not supported:
 
@@ -1363,10 +1362,10 @@ effort, which takes 4-18 ms instead of a 2.4-3.2 s startup, and logs
 so the tool-call template the session was initialized with survives it: model
 families that frame calls in their own special tokens always use a fresh or
 exact-match warm session instead. Kimi is the one such family today, matched
-by the same family table telemetry labels use. Requests that ask for the model alias, or for the model's
-default reasoning effort on a session that carries an explicit one, also log
-`pool.miss`. The pool tracks the settings recent traffic used, so repeat
-traffic converges on exact matches.
+by the same family table telemetry labels use. Requests that ask for the
+model alias, or for the model's default reasoning effort on a session that
+carries an explicit one, also log `pool.miss`. The pool tracks the settings
+recent traffic used, so repeat traffic converges on exact matches.
 
 Teardown runs after the response is finished, so session close and the second
 `droid exec` needs to exit no longer delay the last token. Set

--- a/README.md
+++ b/README.md
@@ -441,6 +441,33 @@ Authentication inside a container uses `FACTORY_API_KEY` only. Interactive
 and pass it as an environment variable. The bridge never reads or copies
 that credential; the Droid subprocess inherits it directly.
 
+The container has its own Factory home, so host
+`~/.factory/settings.json` is not loaded automatically. Mount only that file
+read-only when the Droid subprocess should use your CLI settings:
+
+```bash
+docker run -d --rm --pull=always --name droid-bridge \
+  -p 127.0.0.1:8787:8787 \
+  -e FACTORY_API_KEY="$FACTORY_API_KEY" \
+  -e FACTORY_DROID_OPENAI_API_KEY="$FACTORY_DROID_OPENAI_API_KEY" \
+  -v "$HOME/.factory/settings.json:/home/droid/.factory/settings.json:ro" \
+  ghcr.io/mrwogu/factory-droid-openai:latest
+```
+
+With Compose, uncomment the settings entry in `docker-compose.yml` and set:
+
+```bash
+export FACTORY_DROID_SETTINGS_FILE="$HOME/.factory/settings.json"
+docker compose up -d
+```
+
+The file must be readable by container user `uid 1000`. Keep it outside the
+repository when it contains custom-model credentials. Request model,
+reasoning effort, Auto interaction mode, autonomy Off, and disabled Droid
+tools are pinned by the bridge and override matching session defaults.
+Mounting this file does not mount other profile files such as
+`system-prompt.md`, skills, or hooks.
+
 Never publish the bridge port to a non-loopback interface without a
 configured `FACTORY_DROID_OPENAI_API_KEY`. See
 [SECURITY.md](SECURITY.md) before any remote deployment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@
 #   Mount your project at /work so Droid sees it as the working directory.
 #   The bridge disables all Factory-native tools, so the mount can be
 #   read-only. Remove the volumes block below if you do not need a workdir.
+#   Set FACTORY_DROID_SETTINGS_FILE to mount one Droid settings.json read-only.
 #
 # Usage:
 #   export FACTORY_API_KEY=fk-...
@@ -33,10 +34,10 @@ services:
       # FACTORY_DROID_OPENAI_TIMEOUT_SECONDS: "600"
       # FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS: "300"
       # FACTORY_DROID_OPENAI_TELEMETRY: "false"
-    # Optional: expose your project to Droid as /work. Read-only is safe
-    # because Factory-native tools are disabled. Uncomment to mount a workdir.
+    # Optional read-only mounts. Uncomment `volumes` and either entry needed.
     # volumes:
     #   - ./:/work:ro
+    #   - ${FACTORY_DROID_SETTINGS_FILE:?set FACTORY_DROID_SETTINGS_FILE}:/home/droid/.factory/settings.json:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/health"]

--- a/openapi.json
+++ b/openapi.json
@@ -123,7 +123,7 @@
           "max_completion_tokens": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "integer"
               },
               {
@@ -135,7 +135,7 @@
           "max_tokens": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "integer"
               },
               {
@@ -157,7 +157,7 @@
           },
           "n": {
             "default": 1,
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "N",
             "type": "integer"
           },
@@ -237,7 +237,7 @@
           "timeout": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
@@ -1131,6 +1131,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1160,16 +1170,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1236,6 +1236,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1265,16 +1275,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1349,6 +1349,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1378,16 +1388,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1464,6 +1464,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1493,16 +1503,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1569,6 +1569,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1598,16 +1608,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1674,6 +1674,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1703,16 +1713,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1766,6 +1766,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1795,16 +1805,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1879,6 +1879,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1908,16 +1918,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -23,6 +23,7 @@ import re
 import statistics
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -33,6 +34,7 @@ import httpx
 from factory_droid_openai.dialects import strip_code_fence
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8787"
+RowCallback = Callable[[dict[str, Any]], None] | None
 _WEATHER_TOOL: dict[str, Any] = {
     "type": "function",
     "function": {
@@ -755,7 +757,7 @@ def _model_ring(models: list[str]) -> tuple[tuple[str, str], ...]:
 def _record(
     rows: list[dict[str, Any]],
     record: dict[str, Any],
-    on_row: Any,
+    on_row: RowCallback,
 ) -> None:
     rows.append(record)
     if on_row is not None:
@@ -768,7 +770,7 @@ async def run_matrix(
     plan: list[Scenario],
     *,
     concurrency: int,
-    on_row: Any = None,
+    on_row: RowCallback = None,
 ) -> list[dict[str, Any]]:
     """Run every applicable (model, scenario) pair and return the rows."""
     jobs: list[tuple[str, Scenario]] = []
@@ -796,7 +798,7 @@ async def run_switch_matrix(
     plan: list[Scenario],
     *,
     settle_seconds: float,
-    on_row: Any = None,
+    on_row: RowCallback = None,
 ) -> list[dict[str, Any]]:
     """Run ordered model transitions against one bridge warm pool."""
     rows: list[dict[str, Any]] = []
@@ -815,10 +817,13 @@ async def run_continuation_switch_matrix(
     models: list[str],
     plan: list[Scenario],
     *,
-    on_row: Any = None,
+    on_row: RowCallback = None,
 ) -> list[dict[str, Any]]:
     """Attempt model changes on bridge-created continuation sessions."""
     rows: list[dict[str, Any]] = []
+    if not plan:
+        # The phase is opt-in, so an empty plan must not prime a single model.
+        return rows
     for source, target in _model_ring(models):
         prime = await bridge.run(source, _SWITCH_PRIME)
         for scenario in plan:

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -344,6 +344,18 @@ def switch_scenarios(*, streaming: bool = True) -> list[Scenario]:
     return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
 
 
+def continuation_switch_scenarios(*, streaming: bool = True) -> list[Scenario]:
+    """Rejected model changes on an explicit session continuation."""
+    scenario = Scenario(
+        name="session_model_switch",
+        body={"messages": [{"role": "user", "content": "Reply with exactly: CONTINUED"}]},
+        expect_status=(400,),
+        expect_finish=(),
+        expect_content=False,
+    )
+    return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
+
+
 @dataclass(frozen=True, slots=True)
 class Observation:
     """What one request produced, before it is judged."""
@@ -356,6 +368,7 @@ class Observation:
     tool_calls: int = 0
     content_chars: int = 0
     request_id: str | None = None
+    session_id: str | None = None
     duration_ms: float = 0.0
     ttft_ms: float | None = None
     stream_done: bool = False
@@ -507,6 +520,7 @@ def _completion_observation(
     content = message.get("content") or ""
     error_type, error_message = _error_fields(body)
     semantic_error = _content_semantic_error(content) if isinstance(content, str) else None
+    session_id = body.get("factory_droid_session_id")
     return Observation(
         status=status,
         error_type=error_type,
@@ -516,6 +530,7 @@ def _completion_observation(
         tool_calls=len(tool_calls) if isinstance(tool_calls, list) else 0,
         content_chars=len(content) if isinstance(content, str) else 0,
         request_id=headers.get("x-request-id"),
+        session_id=session_id if isinstance(session_id, str) else None,
         duration_ms=duration_ms,
     )
 
@@ -535,6 +550,7 @@ def _stream_observation(
     error_message = ""
     stream_done = False
     ttft_ms: float | None = None
+    session_id: str | None = None
     for elapsed_ms, raw in events:
         if raw == "[DONE]":
             stream_done = True
@@ -554,6 +570,9 @@ def _stream_observation(
         error_message = error_message or chunk_error_message
         for choice in chunk.get("choices") or []:
             delta = choice.get("delta") or {}
+            announced_session = delta.get("factory_droid_session_id")
+            if isinstance(announced_session, str):
+                session_id = announced_session
             text = delta.get("content") or ""
             if text:
                 content_chars += len(text)
@@ -573,6 +592,7 @@ def _stream_observation(
         tool_calls=tool_calls,
         content_chars=content_chars,
         request_id=headers.get("x-request-id"),
+        session_id=session_id,
         duration_ms=duration_ms,
         ttft_ms=ttft_ms,
         stream_done=stream_done,
@@ -701,11 +721,32 @@ def row(model: str, scenario: Scenario, observation: Observation) -> dict[str, A
         "tool_calls": observation.tool_calls,
         "content_chars": observation.content_chars,
         "request_id": observation.request_id,
+        "session_id": observation.session_id,
         "duration_ms": round(observation.duration_ms, 1),
         "ttft_ms": None if observation.ttft_ms is None else round(observation.ttft_ms, 1),
         "verdict": verdict,
         "detail": detail,
     }
+
+
+def _transition_row(
+    source: str,
+    target: str,
+    scenario: Scenario,
+    observation: Observation,
+    prime: Observation,
+) -> dict[str, Any]:
+    record = row(target, scenario, observation)
+    prime_verdict, prime_detail = classify(_SWITCH_PRIME, prime)
+    record.update(
+        {
+            "source_model": source,
+            "prime_status": prime.status,
+            "prime_verdict": prime_verdict,
+            "prime_detail": prime_detail,
+        }
+    )
+    return record
 
 
 async def run_matrix(
@@ -756,16 +797,43 @@ async def run_switch_matrix(
             prime = await bridge.run(source, _SWITCH_PRIME)
             await asyncio.sleep(max(0.0, settle_seconds))
             observation = await bridge.run(target, scenario)
-            record = row(target, scenario, observation)
-            prime_verdict, prime_detail = classify(_SWITCH_PRIME, prime)
-            record.update(
-                {
-                    "source_model": source,
-                    "prime_status": prime.status,
-                    "prime_verdict": prime_verdict,
-                    "prime_detail": prime_detail,
-                }
-            )
+            record = _transition_row(source, target, scenario, observation, prime)
+            rows.append(record)
+            if on_row is not None:
+                on_row(record)
+    return rows
+
+
+async def run_continuation_switch_matrix(
+    bridge: Bridge,
+    models: list[str],
+    plan: list[Scenario],
+    *,
+    on_row: Any = None,
+) -> list[dict[str, Any]]:
+    """Attempt model changes on bridge-created continuation sessions."""
+    if len(models) < 2:
+        return []
+    rows: list[dict[str, Any]] = []
+    targets = models[1:] + models[:1]
+    for source, target in zip(models, targets, strict=True):
+        for scenario in plan:
+            prime = await bridge.run(source, _SWITCH_PRIME)
+            if prime.session_id is None:
+                observation = Observation(
+                    status=0,
+                    transport_error="session continuity returned no session id",
+                )
+            else:
+                continued = replace(
+                    scenario,
+                    body={
+                        **scenario.body,
+                        "factory_droid_session_id": prime.session_id,
+                    },
+                )
+                observation = await bridge.run(target, continued)
+            record = _transition_row(source, target, scenario, observation, prime)
             rows.append(record)
             if on_row is not None:
                 on_row(record)
@@ -923,6 +991,7 @@ class RunOptions:
     concurrency: int = 2
     streaming: bool = True
     switch_settle_seconds: float = 5.0
+    test_session_continuity: bool = False
     out: Path | None = None
 
 
@@ -934,9 +1003,15 @@ async def _run(options: RunOptions) -> int:
         models = options.models or await bridge.models()
         plan = scenarios(streaming=options.streaming)
         switch_plan = switch_scenarios(streaming=options.streaming)
+        continuation_plan = (
+            continuation_switch_scenarios(streaming=options.streaming)
+            if options.test_session_continuity
+            else []
+        )
         print(
             f"{len(models)} models x {len(plan)} scenarios + "
-            f"{len(switch_plan)} switch scenarios -> {out}",
+            f"{len(switch_plan)} warm switches + "
+            f"{len(continuation_plan)} continuation switches -> {out}",
             file=sys.stderr,
         )
         with out.open("a", encoding="utf-8") as handle:
@@ -961,6 +1036,14 @@ async def _run(options: RunOptions) -> int:
                     on_row=write,
                 )
             )
+            rows.extend(
+                await run_continuation_switch_matrix(
+                    bridge,
+                    models,
+                    continuation_plan,
+                    on_row=write,
+                )
+            )
     print(render_report(rows))
     return 1 if summarize(rows)["blocking"] else 0
 
@@ -975,6 +1058,7 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--concurrency", type=int, default=2)
     run_parser.add_argument("--no-stream", action="store_true")
     run_parser.add_argument("--switch-settle-seconds", type=float, default=5.0)
+    run_parser.add_argument("--test-session-continuity", action="store_true")
     run_parser.add_argument("--out", type=Path, default=None)
 
     report_parser = sub.add_parser("report", help="render a markdown report from a JSONL run")
@@ -999,6 +1083,7 @@ def main(argv: list[str] | None = None) -> int:
         concurrency=args.concurrency,
         streaming=not args.no_stream,
         switch_settle_seconds=args.switch_settle_seconds,
+        test_session_continuity=args.test_session_continuity,
         out=args.out,
     )
     return asyncio.run(_run(options))

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -96,6 +96,8 @@ class Scenario:
     expect_finish: tuple[str, ...] = ("stop",)
     expect_tool_call: bool = False
     expect_content: bool = True
+    expect_error_type: str | None = None
+    expect_error_contains: str | None = None
     timeout_seconds: float = 120.0
 
 
@@ -103,6 +105,25 @@ _SWITCH_PRIME = Scenario(
     name="model_switch_prime",
     body={"messages": [{"role": "user", "content": "Reply with exactly: READY"}]},
 )
+
+
+def _required_weather_scenario(name: str) -> Scenario:
+    return Scenario(
+        name=name,
+        body={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the weather in Gdansk? Use the tool.",
+                }
+            ],
+            "tools": [_WEATHER_TOOL],
+            "tool_choice": "required",
+        },
+        expect_finish=("tool_calls",),
+        expect_tool_call=True,
+        expect_content=False,
+    )
 
 
 def _baseline_scenarios() -> list[Scenario]:
@@ -152,17 +173,7 @@ def _tool_scenarios() -> list[Scenario]:
             expect_tool_call=True,
             expect_content=False,
         ),
-        Scenario(
-            name="tool_required",
-            body={
-                "messages": [{"role": "user", "content": prompt}],
-                "tools": [_WEATHER_TOOL],
-                "tool_choice": "required",
-            },
-            expect_finish=("tool_calls",),
-            expect_tool_call=True,
-            expect_content=False,
-        ),
+        _required_weather_scenario("tool_required"),
         Scenario(
             name="tool_parallel",
             body={
@@ -306,41 +317,14 @@ def scenarios(*, streaming: bool = True) -> list[Scenario]:
     for scenario in base:
         built.append(scenario)
         if streaming:
-            built.append(
-                Scenario(
-                    name=scenario.name,
-                    body=scenario.body,
-                    stream=True,
-                    per_model=scenario.per_model,
-                    expect_status=scenario.expect_status,
-                    expect_finish=scenario.expect_finish,
-                    expect_tool_call=scenario.expect_tool_call,
-                    expect_content=scenario.expect_content,
-                    timeout_seconds=scenario.timeout_seconds,
-                )
-            )
+            built.append(replace(scenario, stream=True))
     built.extend(_hostile_scenarios())
     return built
 
 
 def switch_scenarios(*, streaming: bool = True) -> list[Scenario]:
     """Tool-call contracts run after a model transition."""
-    scenario = Scenario(
-        name="model_switch_tool_required",
-        body={
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "What is the weather in Gdansk? Use the tool.",
-                }
-            ],
-            "tools": [_WEATHER_TOOL],
-            "tool_choice": "required",
-        },
-        expect_finish=("tool_calls",),
-        expect_tool_call=True,
-        expect_content=False,
-    )
+    scenario = _required_weather_scenario("model_switch_tool_required")
     return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
 
 
@@ -352,6 +336,8 @@ def continuation_switch_scenarios(*, streaming: bool = True) -> list[Scenario]:
         expect_status=(400,),
         expect_finish=(),
         expect_content=False,
+        expect_error_type="invalid_request_error",
+        expect_error_contains="session settings do not match",
     )
     return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
 
@@ -445,6 +431,13 @@ def classify(scenario: Scenario, observation: Observation) -> tuple[str, str]:
             f"unexpected status {observation.status} ({error_type})",
         )
     if observation.status != 200:
+        if scenario.expect_error_type is not None and error_type != scenario.expect_error_type:
+            return BRIDGE_DEFECT, f"unexpected error type {error_type}"
+        if (
+            scenario.expect_error_contains is not None
+            and scenario.expect_error_contains not in observation.error_message
+        ):
+            return BRIDGE_DEFECT, "expected error message marker is missing"
         return SUCCESS, f"rejected with {observation.status} as expected"
     if scenario.stream and not observation.stream_done:
         return BRIDGE_DEFECT, "stream ended without [DONE]"
@@ -746,7 +739,27 @@ def _transition_row(
             "prime_detail": prime_detail,
         }
     )
+    if prime_verdict != SUCCESS:
+        record["verdict"] = prime_verdict
+        record["detail"] = f"source-model prime failed: {prime_detail}"
     return record
+
+
+def _model_ring(models: list[str]) -> tuple[tuple[str, str], ...]:
+    if len(models) < 2:
+        return ()
+    targets = models[1:] + models[:1]
+    return tuple(zip(models, targets, strict=True))
+
+
+def _record(
+    rows: list[dict[str, Any]],
+    record: dict[str, Any],
+    on_row: Any,
+) -> None:
+    rows.append(record)
+    if on_row is not None:
+        on_row(record)
 
 
 async def run_matrix(
@@ -771,9 +784,7 @@ async def run_matrix(
         async with semaphore:
             observation = await bridge.run(model, scenario)
         record = row(model, scenario, observation)
-        rows.append(record)
-        if on_row is not None:
-            on_row(record)
+        _record(rows, record, on_row)
 
     await asyncio.gather(*(execute(model, scenario) for model, scenario in jobs))
     return rows
@@ -788,19 +799,14 @@ async def run_switch_matrix(
     on_row: Any = None,
 ) -> list[dict[str, Any]]:
     """Run ordered model transitions against one bridge warm pool."""
-    if len(models) < 2:
-        return []
     rows: list[dict[str, Any]] = []
-    targets = models[1:] + models[:1]
-    for source, target in zip(models, targets, strict=True):
+    for source, target in _model_ring(models):
         for scenario in plan:
             prime = await bridge.run(source, _SWITCH_PRIME)
             await asyncio.sleep(max(0.0, settle_seconds))
             observation = await bridge.run(target, scenario)
             record = _transition_row(source, target, scenario, observation, prime)
-            rows.append(record)
-            if on_row is not None:
-                on_row(record)
+            _record(rows, record, on_row)
     return rows
 
 
@@ -812,13 +818,10 @@ async def run_continuation_switch_matrix(
     on_row: Any = None,
 ) -> list[dict[str, Any]]:
     """Attempt model changes on bridge-created continuation sessions."""
-    if len(models) < 2:
-        return []
     rows: list[dict[str, Any]] = []
-    targets = models[1:] + models[:1]
-    for source, target in zip(models, targets, strict=True):
+    for source, target in _model_ring(models):
+        prime = await bridge.run(source, _SWITCH_PRIME)
         for scenario in plan:
-            prime = await bridge.run(source, _SWITCH_PRIME)
             if prime.session_id is None:
                 observation = Observation(
                     status=0,
@@ -834,9 +837,7 @@ async def run_continuation_switch_matrix(
                 )
                 observation = await bridge.run(target, continued)
             record = _transition_row(source, target, scenario, observation, prime)
-            rows.append(record)
-            if on_row is not None:
-                on_row(record)
+            _record(rows, record, on_row)
     return rows
 
 

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -19,10 +19,11 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import statistics
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -56,6 +57,10 @@ _CLOCK_TOOL: dict[str, Any] = {
         },
     },
 }
+_MANGLED_TOOL_CALL_OUTPUT = re.compile(
+    r'"tool(?:_|\s+)calls"\s*:\s*(?:"id"\s*:\s*)?"call_',
+    re.IGNORECASE,
+)
 
 # Verdicts that do not indicate a bridge defect still fail a scenario; only
 # BLOCKING ones mean the bridge itself has to change.
@@ -92,6 +97,12 @@ class Scenario:
     expect_tool_call: bool = False
     expect_content: bool = True
     timeout_seconds: float = 120.0
+
+
+_SWITCH_PRIME = Scenario(
+    name="model_switch_prime",
+    body={"messages": [{"role": "user", "content": "Reply with exactly: READY"}]},
+)
 
 
 def _baseline_scenarios() -> list[Scenario]:
@@ -312,6 +323,27 @@ def scenarios(*, streaming: bool = True) -> list[Scenario]:
     return built
 
 
+def switch_scenarios(*, streaming: bool = True) -> list[Scenario]:
+    """Tool-call contracts run after a model transition."""
+    scenario = Scenario(
+        name="model_switch_tool_required",
+        body={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is the weather in Gdansk? Use the tool.",
+                }
+            ],
+            "tools": [_WEATHER_TOOL],
+            "tool_choice": "required",
+        },
+        expect_finish=("tool_calls",),
+        expect_tool_call=True,
+        expect_content=False,
+    )
+    return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
+
+
 @dataclass(frozen=True, slots=True)
 class Observation:
     """What one request produced, before it is judged."""
@@ -342,6 +374,8 @@ _TRAILING_TOOL_TEXT = "unexpected text after tool call"
 def _content_semantic_error(content: str) -> str | None:
     """Reject serialized OpenAI transcript objects returned as final text."""
     stripped = strip_code_fence(content.strip())
+    if _MANGLED_TOOL_CALL_OUTPUT.search(stripped):
+        return "assistant exposed malformed OpenAI tool-call output"
     try:
         payload = json.loads(stripped)
     except ValueError:
@@ -704,6 +738,40 @@ async def run_matrix(
     return rows
 
 
+async def run_switch_matrix(
+    bridge: Bridge,
+    models: list[str],
+    plan: list[Scenario],
+    *,
+    settle_seconds: float,
+    on_row: Any = None,
+) -> list[dict[str, Any]]:
+    """Run ordered model transitions against one bridge warm pool."""
+    if len(models) < 2:
+        return []
+    rows: list[dict[str, Any]] = []
+    targets = models[1:] + models[:1]
+    for source, target in zip(models, targets, strict=True):
+        for scenario in plan:
+            prime = await bridge.run(source, _SWITCH_PRIME)
+            await asyncio.sleep(max(0.0, settle_seconds))
+            observation = await bridge.run(target, scenario)
+            record = row(target, scenario, observation)
+            prime_verdict, prime_detail = classify(_SWITCH_PRIME, prime)
+            record.update(
+                {
+                    "source_model": source,
+                    "prime_status": prime.status,
+                    "prime_verdict": prime_verdict,
+                    "prime_detail": prime_detail,
+                }
+            )
+            rows.append(record)
+            if on_row is not None:
+                on_row(record)
+    return rows
+
+
 def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate verdicts, blocking failures and latency for a run."""
     counts = dict.fromkeys(VERDICTS, 0)
@@ -783,8 +851,13 @@ def _group_by(rows: list[dict[str, Any]], key: str) -> dict[str, list[dict[str, 
     return grouped
 
 
-def _key(record: dict[str, Any]) -> tuple[str, str, bool]:
-    return (str(record["model"]), str(record["scenario"]), bool(record["stream"]))
+def _key(record: dict[str, Any]) -> tuple[str, str, str, bool]:
+    return (
+        str(record.get("source_model") or ""),
+        str(record["model"]),
+        str(record["scenario"]),
+        bool(record["stream"]),
+    )
 
 
 def compare(before: list[dict[str, Any]], after: list[dict[str, Any]]) -> dict[str, Any]:
@@ -849,6 +922,7 @@ class RunOptions:
     models: list[str] = field(default_factory=list)
     concurrency: int = 2
     streaming: bool = True
+    switch_settle_seconds: float = 5.0
     out: Path | None = None
 
 
@@ -859,7 +933,12 @@ async def _run(options: RunOptions) -> int:
         bridge = Bridge(base_url=options.base_url, api_key=options.api_key, client=client)
         models = options.models or await bridge.models()
         plan = scenarios(streaming=options.streaming)
-        print(f"{len(models)} models x {len(plan)} scenarios -> {out}", file=sys.stderr)
+        switch_plan = switch_scenarios(streaming=options.streaming)
+        print(
+            f"{len(models)} models x {len(plan)} scenarios + "
+            f"{len(switch_plan)} switch scenarios -> {out}",
+            file=sys.stderr,
+        )
         with out.open("a", encoding="utf-8") as handle:
 
             def write(record: dict[str, Any]) -> None:
@@ -872,6 +951,15 @@ async def _run(options: RunOptions) -> int:
                 plan,
                 concurrency=options.concurrency,
                 on_row=write,
+            )
+            rows.extend(
+                await run_switch_matrix(
+                    bridge,
+                    models,
+                    switch_plan,
+                    settle_seconds=options.switch_settle_seconds,
+                    on_row=write,
+                )
             )
     print(render_report(rows))
     return 1 if summarize(rows)["blocking"] else 0
@@ -886,6 +974,7 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--models", default="", help="comma separated; default is discovery")
     run_parser.add_argument("--concurrency", type=int, default=2)
     run_parser.add_argument("--no-stream", action="store_true")
+    run_parser.add_argument("--switch-settle-seconds", type=float, default=5.0)
     run_parser.add_argument("--out", type=Path, default=None)
 
     report_parser = sub.add_parser("report", help="render a markdown report from a JSONL run")
@@ -909,6 +998,7 @@ def main(argv: list[str] | None = None) -> int:
         models=[value for value in args.models.split(",") if value],
         concurrency=args.concurrency,
         streaming=not args.no_stream,
+        switch_settle_seconds=args.switch_settle_seconds,
         out=args.out,
     )
     return asyncio.run(_run(options))

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -111,6 +111,7 @@ _PAYLOAD_SIZE_BUCKETS = (
     (102_400, "10kb_100kb"),
     (1_048_576, "100kb_1mb"),
 )
+
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
         "model": ChatCompletionResponse,
@@ -866,6 +867,7 @@ def create_app(
 
     def require_known_session(session_id: str) -> SessionKey:
         if not resolved_settings.session_continuity:
+            log_warning("session.rejected", status=400, phase="session_continuity")
             raise BridgeHTTPError(
                 "Session continuity is disabled on this bridge.",
                 status_code=400,
@@ -873,6 +875,7 @@ def create_app(
             )
         key = sessions.key(session_id)
         if key is None:
+            log_warning("session.rejected", status=404, phase="session_unknown")
             raise BridgeHTTPError(
                 "Unknown Factory Droid session. Only sessions created by this "
                 "bridge process can be used.",
@@ -1139,11 +1142,34 @@ def create_app(
             log_warning("chat.rejected", status=rejection.status_code, phase="options")
             return rejection
 
+        reasoning_effort = _effective_reasoning_effort(payload, resolved_settings)
+        try:
+            reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+        except RunnerError as exc:
+            request.state.telemetry_error_type = exc.error_type
+            log_warning("chat.rejected", status=exc.status_code, phase="reasoning_effort")
+            return _error_response(str(exc), exc.status_code, exc.error_type)
+
+        requested_key = SessionKey.from_request(
+            model=payload.model,
+            model_alias=resolved_settings.model_alias,
+            reasoning_effort=reasoning_effort,
+        )
+
+        # Settled before the transcript is serialized so a mismatch cannot be
+        # masked by a payload-size rejection and costs no prompt work.
         session_id: str | None = None
-        continued_key: SessionKey | None = None
         if payload.factory_droid_session_id is not None:
             session_id = payload.factory_droid_session_id
-            continued_key = require_known_session(session_id)
+            if require_known_session(session_id) != requested_key:
+                request.state.telemetry_error_type = "invalid_request_error"
+                log_warning("chat.rejected", status=400, phase="session_settings")
+                return _error_response(
+                    "Factory Droid session settings do not match the request. "
+                    "Start a new session to switch model or reasoning effort.",
+                    400,
+                    "invalid_request_error",
+                )
 
         try:
             structured = _prepare_output_format(
@@ -1185,28 +1211,6 @@ def create_app(
             prompt_ms=timeline.mark("prompt_ms"),
         )
         payload_tracer.trace("chat.prompt", plan.prompt, model=payload.model)
-
-        reasoning_effort = _effective_reasoning_effort(payload, resolved_settings)
-        try:
-            reasoning_effort = normalize_reasoning_effort(reasoning_effort)
-        except RunnerError as exc:
-            request.state.telemetry_error_type = exc.error_type
-            log_warning("chat.rejected", status=exc.status_code, phase="reasoning_effort")
-            return _error_response(str(exc), exc.status_code, exc.error_type)
-
-        requested_key = SessionKey.from_request(
-            model=payload.model,
-            model_alias=resolved_settings.model_alias,
-            reasoning_effort=reasoning_effort,
-        )
-        if continued_key is not None and continued_key != requested_key:
-            request.state.telemetry_error_type = "invalid_request_error"
-            return _error_response(
-                "Factory Droid session settings do not match the request. "
-                "Start a new session to switch model or reasoning effort.",
-                400,
-                "invalid_request_error",
-            )
 
         quarantined = quarantine.reason(payload.model)
         if quarantined is not None:
@@ -1278,7 +1282,7 @@ def create_app(
             raise
 
         if session_id is None:
-            warm_session = pool.acquire(run_request.session_key())
+            warm_session = pool.acquire(requested_key)
             if warm_session is not None:
                 metrics.record_features(("warm_session",))
                 run_request = replace(run_request, warm_session=warm_session)

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -308,23 +308,20 @@ class SessionRegistry:
 
     def __init__(self, max_entries: int) -> None:
         self._max_entries = max_entries
-        self._sessions: OrderedDict[str, str] = OrderedDict()
+        self._sessions: OrderedDict[str, SessionKey] = OrderedDict()
 
-    def remember(self, session_id: str, model: str) -> None:
+    def remember(self, session_id: str, key: SessionKey) -> None:
         self._sessions.pop(session_id, None)
-        self._sessions[session_id] = model
+        self._sessions[session_id] = key
         while len(self._sessions) > self._max_entries:
             self._sessions.popitem(last=False)
 
-    def model(self, session_id: str) -> str | None:
-        model = self._sessions.get(session_id)
-        if model is None:
+    def key(self, session_id: str) -> SessionKey | None:
+        key = self._sessions.get(session_id)
+        if key is None:
             return None
         self._sessions.move_to_end(session_id)
-        return model
-
-    def knows(self, session_id: str) -> bool:
-        return self.model(session_id) is not None
+        return key
 
     def forget(self, session_id: str) -> None:
         self._sessions.pop(session_id, None)
@@ -875,22 +872,22 @@ def create_app(
                 ttl_seconds=resolved_settings.model_quarantine_seconds,
             )
 
-    def require_known_session(session_id: str) -> str:
+    def require_known_session(session_id: str) -> SessionKey:
         if not resolved_settings.session_continuity:
             raise BridgeHTTPError(
                 "Session continuity is disabled on this bridge.",
                 status_code=400,
                 error_type="invalid_request_error",
             )
-        model = sessions.model(session_id)
-        if model is None:
+        key = sessions.key(session_id)
+        if key is None:
             raise BridgeHTTPError(
                 "Unknown Factory Droid session. Only sessions created by this "
-                "bridge process can be managed.",
+                "bridge process can be used.",
                 status_code=404,
                 error_type="session_not_found",
             )
-        return model
+        return key
 
     @application.get(
         "/health",
@@ -1033,7 +1030,7 @@ def create_app(
         session_id: str,
         payload: CompactSessionRequest,
     ) -> CompactSessionResponse:
-        model = require_known_session(session_id)
+        key = require_known_session(session_id)
         result = await run_factory_operation(
             lambda runner, remaining: runner.compact_session(
                 session_id,
@@ -1041,7 +1038,7 @@ def create_app(
                 timeout_seconds=remaining,
             )
         )
-        sessions.remember(result.new_session_id, model)
+        sessions.remember(result.new_session_id, key)
         return CompactSessionResponse(
             session_id=result.new_session_id,
             removed_count=result.removed_count,
@@ -1056,14 +1053,14 @@ def create_app(
         summary="Fork a Factory Droid session",
     )
     async def fork_session(session_id: str) -> ForkSessionResponse:
-        model = require_known_session(session_id)
+        key = require_known_session(session_id)
         new_session_id = await run_factory_operation(
             lambda runner, remaining: runner.fork_session(
                 session_id,
                 timeout_seconds=remaining,
             )
         )
-        sessions.remember(new_session_id, model)
+        sessions.remember(new_session_id, key)
         return ForkSessionResponse(session_id=new_session_id)
 
     @application.patch(
@@ -1151,33 +1148,10 @@ def create_app(
             return rejection
 
         session_id: str | None = None
+        continued_key: SessionKey | None = None
         if payload.factory_droid_session_id is not None:
-            if not resolved_settings.session_continuity:
-                request.state.telemetry_error_type = "invalid_request_error"
-                return _error_response(
-                    "Session continuity is disabled on this bridge.",
-                    400,
-                    "invalid_request_error",
-                )
-            session_model = sessions.model(payload.factory_droid_session_id)
-            if session_model is None:
-                request.state.telemetry_error_type = "session_not_found"
-                return _error_response(
-                    "Unknown Factory Droid session. Only sessions created by this "
-                    "bridge process can be continued.",
-                    404,
-                    "session_not_found",
-                )
-            if session_model != payload.model:
-                request.state.telemetry_error_type = "invalid_request_error"
-                return _error_response(
-                    f"Factory Droid session uses model '{session_model}', but the "
-                    f"request selected '{payload.model}'. Start a new session to "
-                    "switch models.",
-                    400,
-                    "invalid_request_error",
-                )
             session_id = payload.factory_droid_session_id
+            continued_key = require_known_session(session_id)
 
         try:
             structured = _prepare_output_format(
@@ -1227,6 +1201,20 @@ def create_app(
             request.state.telemetry_error_type = exc.error_type
             log_warning("chat.rejected", status=exc.status_code, phase="reasoning_effort")
             return _error_response(str(exc), exc.status_code, exc.error_type)
+
+        requested_key = SessionKey.from_request(
+            model=payload.model,
+            model_alias=resolved_settings.model_alias,
+            reasoning_effort=reasoning_effort,
+        )
+        if continued_key is not None and continued_key != requested_key:
+            request.state.telemetry_error_type = "invalid_request_error"
+            return _error_response(
+                "Factory Droid session settings do not match the request. "
+                "Start a new session to switch model or reasoning effort.",
+                400,
+                "invalid_request_error",
+            )
 
         quarantined = quarantine.reason(payload.model)
         if quarantined is not None:
@@ -1337,7 +1325,7 @@ def create_app(
                 emit_status=payload.factory_droid_status,
                 session_callback=lambda started_id: sessions.remember(
                     started_id,
-                    payload.model,
+                    requested_key,
                 ),
                 expose_session=resolved_settings.session_continuity,
                 structured=structured,
@@ -1400,7 +1388,7 @@ def create_app(
                     elif result.malformed_note is not None:
                         request.state.stream_outcome = "malformed"
                     if result.session_id is not None:
-                        sessions.remember(result.session_id, payload.model)
+                        sessions.remember(result.session_id, requested_key)
                         started_session = result.session_id
                     if structured is not None:
                         _validate_structured_output(result.text, structured)

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -308,19 +308,23 @@ class SessionRegistry:
 
     def __init__(self, max_entries: int) -> None:
         self._max_entries = max_entries
-        self._sessions: OrderedDict[str, None] = OrderedDict()
+        self._sessions: OrderedDict[str, str] = OrderedDict()
 
-    def remember(self, session_id: str) -> None:
+    def remember(self, session_id: str, model: str) -> None:
         self._sessions.pop(session_id, None)
-        self._sessions[session_id] = None
+        self._sessions[session_id] = model
         while len(self._sessions) > self._max_entries:
             self._sessions.popitem(last=False)
 
-    def knows(self, session_id: str) -> bool:
-        if session_id not in self._sessions:
-            return False
+    def model(self, session_id: str) -> str | None:
+        model = self._sessions.get(session_id)
+        if model is None:
+            return None
         self._sessions.move_to_end(session_id)
-        return True
+        return model
+
+    def knows(self, session_id: str) -> bool:
+        return self.model(session_id) is not None
 
     def forget(self, session_id: str) -> None:
         self._sessions.pop(session_id, None)
@@ -871,20 +875,22 @@ def create_app(
                 ttl_seconds=resolved_settings.model_quarantine_seconds,
             )
 
-    def require_known_session(session_id: str) -> None:
+    def require_known_session(session_id: str) -> str:
         if not resolved_settings.session_continuity:
             raise BridgeHTTPError(
                 "Session continuity is disabled on this bridge.",
                 status_code=400,
                 error_type="invalid_request_error",
             )
-        if not sessions.knows(session_id):
+        model = sessions.model(session_id)
+        if model is None:
             raise BridgeHTTPError(
                 "Unknown Factory Droid session. Only sessions created by this "
                 "bridge process can be managed.",
                 status_code=404,
                 error_type="session_not_found",
             )
+        return model
 
     @application.get(
         "/health",
@@ -1027,7 +1033,7 @@ def create_app(
         session_id: str,
         payload: CompactSessionRequest,
     ) -> CompactSessionResponse:
-        require_known_session(session_id)
+        model = require_known_session(session_id)
         result = await run_factory_operation(
             lambda runner, remaining: runner.compact_session(
                 session_id,
@@ -1035,7 +1041,7 @@ def create_app(
                 timeout_seconds=remaining,
             )
         )
-        sessions.remember(result.new_session_id)
+        sessions.remember(result.new_session_id, model)
         return CompactSessionResponse(
             session_id=result.new_session_id,
             removed_count=result.removed_count,
@@ -1050,14 +1056,14 @@ def create_app(
         summary="Fork a Factory Droid session",
     )
     async def fork_session(session_id: str) -> ForkSessionResponse:
-        require_known_session(session_id)
+        model = require_known_session(session_id)
         new_session_id = await run_factory_operation(
             lambda runner, remaining: runner.fork_session(
                 session_id,
                 timeout_seconds=remaining,
             )
         )
-        sessions.remember(new_session_id)
+        sessions.remember(new_session_id, model)
         return ForkSessionResponse(session_id=new_session_id)
 
     @application.patch(
@@ -1153,13 +1159,23 @@ def create_app(
                     400,
                     "invalid_request_error",
                 )
-            if not sessions.knows(payload.factory_droid_session_id):
+            session_model = sessions.model(payload.factory_droid_session_id)
+            if session_model is None:
                 request.state.telemetry_error_type = "session_not_found"
                 return _error_response(
                     "Unknown Factory Droid session. Only sessions created by this "
                     "bridge process can be continued.",
                     404,
                     "session_not_found",
+                )
+            if session_model != payload.model:
+                request.state.telemetry_error_type = "invalid_request_error"
+                return _error_response(
+                    f"Factory Droid session uses model '{session_model}', but the "
+                    f"request selected '{payload.model}'. Start a new session to "
+                    "switch models.",
+                    400,
+                    "invalid_request_error",
                 )
             session_id = payload.factory_droid_session_id
 
@@ -1319,7 +1335,10 @@ def create_app(
                 include_usage=bool(payload.stream_options and payload.stream_options.include_usage),
                 stop_sequences=payload.stop_sequences,
                 emit_status=payload.factory_droid_status,
-                session_callback=sessions.remember,
+                session_callback=lambda started_id: sessions.remember(
+                    started_id,
+                    payload.model,
+                ),
                 expose_session=resolved_settings.session_continuity,
                 structured=structured,
                 failure_callback=note_runner_failure,
@@ -1381,7 +1400,7 @@ def create_app(
                     elif result.malformed_note is not None:
                         request.state.stream_outcome = "malformed"
                     if result.session_id is not None:
-                        sessions.remember(result.session_id)
+                        sessions.remember(result.session_id, payload.model)
                         started_session = result.session_id
                     if structured is not None:
                         _validate_structured_output(result.text, structured)

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1581,13 +1581,10 @@ async def _collect_completion(
                     emissions = parser.feed(event.text)
                     _apply_emissions(result, emissions, stop_buffer)
                 except MalformedToolCallError as exc:
-                    # The payload closed but no decoder could parse it, so
-                    # continuing the turn would only make the model repeat the
-                    # same garbage. Answer with finish_reason="stop" plus a
-                    # visible note naming the expected format instead: the
-                    # client stops auto-continuing, and a resubmitted
-                    # transcript tells the model how to re-emit the call. The
-                    # malformed call is dropped, never executed.
+                    # The parser found a malformed call or transcript fragment,
+                    # so continuing would only expose or repeat garbage. A
+                    # plain-text note plus finish_reason="stop" prevents client
+                    # continuation loops. The call is dropped, never executed.
                     record_malformed(exc)
                     break
                 if stop_buffer.triggered:
@@ -1942,11 +1939,10 @@ async def _stream_completion(
             if include_usage:
                 yield _sse(_usage_chunk(request_id, created, model, usage))
         except MalformedToolCallError as exc:
-            # The payload closed but no decoder could parse it. A length
-            # finish would make the client ask the model to "continue", which
-            # only repeats the same garbage in a loop, so answer with
-            # finish_reason="stop" plus a visible note naming the expected
-            # format. The malformed call is dropped, never executed.
+            # The parser found a malformed call or transcript fragment. A
+            # length finish would make the client ask the model to continue,
+            # exposing or repeating garbage. Return a plain-text note with
+            # finish_reason="stop"; the call is dropped, never executed.
             outcome = "malformed"
             log_warning(
                 "chat.malformed",
@@ -2312,18 +2308,15 @@ def _reject_remote_schema_refs(value: Any) -> None:
 
 
 def _malformed_tool_call_note(exc: MalformedToolCallError) -> str:
-    """Client- and model-readable explanation for a dropped malformed call.
+    """Client-readable explanation for a dropped malformed call.
 
-    The note becomes assistant content, so a client that resubmits the
-    transcript hands the model the exact format to re-emit instead of
-    repeating the payload no decoder could parse.
+    The note becomes assistant content, so it must not contain tool-call JSON
+    that clients may render or models may copy into the next turn.
     """
     tool = f' for tool "{exc.tool_name}"' if exc.tool_name else ""
     return (
-        f"[bridge notice: dropped a malformed tool call{tool} "
-        f"({exc.payload_bytes} bytes, undecodable payload). To call a tool, emit "
-        '<tool_call>{"name":"<tool_name>","arguments":{...}}</tool_call> '
-        "with exactly one JSON object between the markers.]"
+        f"[bridge notice: dropped a malformed tool call{tool}. "
+        "Retry the request if a tool call is still needed.]"
     )
 
 

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -76,6 +76,7 @@ from factory_droid_openai.runner import (
     Usage,
     UsageUpdate,
     WarmSession,
+    model_family,
     normalize_reasoning_effort,
 )
 from factory_droid_openai.strictjson import (
@@ -110,15 +111,6 @@ _PAYLOAD_SIZE_BUCKETS = (
     (102_400, "10kb_100kb"),
     (1_048_576, "100kb_1mb"),
 )
-_MODEL_FAMILY_PREFIXES = (
-    (("gpt-", "o1", "o3", "o4"), "gpt"),
-    (("gemini",), "gemini"),
-    (("claude",), "claude"),
-    (("qwen",), "qwen"),
-    (("kimi",), "kimi"),
-    (("deepseek",), "deepseek"),
-)
-
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
         "model": ChatCompletionResponse,
@@ -1119,7 +1111,7 @@ def create_app(
         # Requests rejected before the handler (validation, auth, request size)
         # never reach this line, so they stay reported as "not_applicable".
         request.state.telemetry_mode = "stream" if payload.stream else "non_stream"
-        request.state.telemetry_model_family = _model_family(payload.model)
+        request.state.telemetry_model_family = model_family(payload.model)
         timeout_seconds = min(
             payload.timeout or resolved_settings.timeout_seconds,
             resolved_settings.timeout_seconds,
@@ -2443,16 +2435,6 @@ def _latency_bucket(seconds: float) -> str:
         if seconds < upper:
             return bucket
     return "gt_30s"
-
-
-def _model_family(model: str) -> str:
-    normalized = model.strip().lower()
-    if normalized == "factory-droid":
-        return "factory_default"
-    for prefixes, family in _MODEL_FAMILY_PREFIXES:
-        if normalized.startswith(prefixes):
-            return family
-    return "other"
 
 
 def _json_content_type(scope: Scope) -> bool:

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -12,6 +12,10 @@ from factory_droid_openai.payloadlog import PAYLOAD_TRACE_MODES
 
 _REASONING_EFFORTS: tuple[str, ...] = tuple(effort.value for effort in ReasoningEffort)
 
+# The model name that means "whatever Droid defaults to" instead of a concrete
+# Droid model id.
+DEFAULT_MODEL_ALIAS = "factory-droid"
+
 # Droid does not always emit a completion event after a client-side tool call,
 # so the bridge stops waiting this long after one arrives. Raise it when a
 # model spreads parallel calls over slower gaps than this.
@@ -54,7 +58,7 @@ class Settings:
     model_quarantine_seconds: float = 900.0
     worktree: str | None = None
     append_system_prompt_file: Path | None = None
-    model_alias: str = "factory-droid"
+    model_alias: str = DEFAULT_MODEL_ALIAS
     # Overrides any reasoning_effort a request carries when set.
     reasoning_effort: str | None = None
     log_level: str = "info"
@@ -301,7 +305,7 @@ class Settings:
             model_quarantine_seconds=model_quarantine_seconds,
             worktree=worktree,
             append_system_prompt_file=append_system_prompt_file,
-            model_alias=os.getenv("FACTORY_DROID_OPENAI_MODEL_ALIAS", "factory-droid"),
+            model_alias=os.getenv("FACTORY_DROID_OPENAI_MODEL_ALIAS", DEFAULT_MODEL_ALIAS),
             reasoning_effort=reasoning_effort,
             log_level=log_level,
             log_format=log_format,

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -97,12 +97,10 @@ class DroidRpcExtension:
         model_id: str,
         reasoning_effort: str | None,
     ) -> None:
-        """Repoint an initialized session at another model and effort.
+        """Apply a model id and optional reasoning effort to a session.
 
-        Droid applies this without restarting the process, so a warm session
-        can serve a model it was not initialized with. Interaction mode and
-        autonomy level are resent so the bridge invariants stay pinned; the
-        disabled native tool list is preserved by Droid.
+        Interaction mode and autonomy level are resent so bridge invariants
+        stay pinned; the disabled native tool list is preserved by Droid.
         """
         params: dict[str, Any] = {
             "modelId": model_id,

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -4,6 +4,12 @@ import threading
 from collections import Counter
 from dataclasses import dataclass
 
+# The only settings change a warm session can absorb, since a model change
+# waits for a fresh session. The label is rendered even at zero so a dashboard
+# keeps its series between restarts.
+WARM_RETUNE_EFFORT = "effort"
+_WARM_RETUNE_REASONS = (WARM_RETUNE_EFFORT,)
+
 
 @dataclass(frozen=True, slots=True)
 class RequestMetric:
@@ -42,7 +48,7 @@ class BridgeMetrics:
         self._model_quarantines = 0
         self._warm_sessions = 0
         self._warm_hits = 0
-        self._warm_retunes = 0
+        self._warm_retunes: Counter[str] = Counter()
         self._warm_misses = 0
         self._warm_failures = 0
         self._pending_reaps = 0
@@ -123,9 +129,9 @@ class BridgeMetrics:
         with self._lock:
             self._warm_hits += 1
 
-    def increment_warm_retunes(self) -> None:
+    def increment_warm_retunes(self, reason: str) -> None:
         with self._lock:
-            self._warm_retunes += 1
+            self._warm_retunes[reason] += 1
 
     def increment_warm_misses(self) -> None:
         with self._lock:
@@ -162,7 +168,7 @@ class BridgeMetrics:
                         "model_quarantine": self._model_quarantines,
                         "warm_hit": self._warm_hits,
                         "warm_miss": self._warm_misses,
-                        "warm_retune": self._warm_retunes,
+                        "warm_retune": self._warm_retunes.total(),
                         "warm_failure": self._warm_failures,
                     }.items()
                 )
@@ -172,6 +178,10 @@ class BridgeMetrics:
     def render(self) -> str:
         with self._lock:
             request_totals = sorted(self._request_totals.items())
+            warm_retunes = [
+                (reason, self._warm_retunes[reason])
+                for reason in sorted({*_WARM_RETUNE_REASONS, *self._warm_retunes})
+            ]
             values = {
                 "request_duration_sum": self._request_duration_sum,
                 "request_duration_count": self._request_duration_count,
@@ -190,7 +200,6 @@ class BridgeMetrics:
                 "model_quarantines": self._model_quarantines,
                 "warm_sessions": self._warm_sessions,
                 "warm_hits": self._warm_hits,
-                "warm_retunes": self._warm_retunes,
                 "warm_misses": self._warm_misses,
                 "warm_failures": self._warm_failures,
                 "pending_reaps": self._pending_reaps,
@@ -242,7 +251,10 @@ class BridgeMetrics:
             "# TYPE factory_droid_openai_warm_session_hits_total counter",
             f"factory_droid_openai_warm_session_hits_total {values['warm_hits']}",
             "# TYPE factory_droid_openai_warm_session_retunes_total counter",
-            f"factory_droid_openai_warm_session_retunes_total {values['warm_retunes']}",
+            *[
+                f'factory_droid_openai_warm_session_retunes_total{{reason="{reason}"}} {count}'
+                for reason, count in warm_retunes
+            ],
             "# TYPE factory_droid_openai_warm_session_misses_total counter",
             f"factory_droid_openai_warm_session_misses_total {values['warm_misses']}",
             "# TYPE factory_droid_openai_warm_session_failures_total counter",

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -82,9 +82,9 @@ class WarmSessionPool:
     Sessions are keyed by the settings they were initialized with. An exact
     key match serves a turn with no extra round trip; otherwise a compatible
     session may be repointed at another model or explicit reasoning effort.
-    Kimi model switches wait for a fresh session so its protocol state cannot
-    cross the boundary. A session serves at most one turn, which keeps the
-    bridge stateless.
+    Model families whose tool-call template survives a retune wait for a fresh
+    session instead, so that template cannot cross the boundary. A session
+    serves at most one turn, which keeps the bridge stateless.
     """
 
     def __init__(

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import warning as log_warning
+from factory_droid_openai.metrics import WARM_RETUNE_EFFORT
 from factory_droid_openai.runner import DroidRunner, SessionKey, WarmSession
 
 RunnerFactory = Callable[[], DroidRunner]
@@ -19,7 +20,7 @@ class PoolMetrics(Protocol):
 
     def increment_warm_hits(self) -> None: ...
 
-    def increment_warm_retunes(self) -> None: ...
+    def increment_warm_retunes(self, reason: str) -> None: ...
 
     def increment_warm_misses(self) -> None: ...
 
@@ -80,11 +81,11 @@ class WarmSessionPool:
     """Keeps initialized Droid sessions ready so requests skip session startup.
 
     Sessions are keyed by the settings they were initialized with. An exact
-    key match serves a turn with no extra round trip; otherwise a compatible
-    session may be repointed at another model or explicit reasoning effort.
-    Model families whose tool-call template survives a retune wait for a fresh
-    session instead, so that template cannot cross the boundary. A session
-    serves at most one turn, which keeps the bridge stateless.
+    key match serves a turn with no extra round trip; otherwise a session
+    warmed for the same model can be repointed at another explicit reasoning
+    effort. A model change waits for a fresh or exact-match session, because
+    the tool-call template Droid installed at session start survives a retune.
+    A session serves at most one turn, which keeps the bridge stateless.
     """
 
     def __init__(
@@ -171,11 +172,12 @@ class WarmSessionPool:
             self._publish()
             if self._metrics is not None:
                 self._metrics.increment_warm_hits()
-                self._metrics.increment_warm_retunes()
+                self._metrics.increment_warm_retunes(WARM_RETUNE_EFFORT)
             log_debug(
                 "pool.retune",
                 model=key.model_id,
-                warmed_for=session.key.model_id,
+                reason=WARM_RETUNE_EFFORT,
+                warmed_for_effort=session.key.reasoning_effort,
                 warm_sessions=self._total(),
             )
             return session

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -80,10 +80,11 @@ class WarmSessionPool:
     """Keeps initialized Droid sessions ready so requests skip session startup.
 
     Sessions are keyed by the settings they were initialized with. An exact
-    key match serves a turn with no extra round trip; otherwise a session
-    warmed for another model is handed over and the runner repoints it, which
-    costs milliseconds instead of a fresh process. A session serves at most
-    one turn, which keeps the bridge stateless.
+    key match serves a turn with no extra round trip; otherwise a compatible
+    session may be repointed at another model or explicit reasoning effort.
+    Kimi model switches wait for a fresh session so its protocol state cannot
+    cross the boundary. A session serves at most one turn, which keeps the
+    bridge stateless.
     """
 
     def __init__(
@@ -194,7 +195,7 @@ class WarmSessionPool:
         return None
 
     def _take_retunable(self, key: SessionKey) -> WarmSession | None:
-        """Borrow a session warmed for other settings the runner can repoint."""
+        """Borrow a session the runner can safely repoint."""
         for warmed_key, queue in self._sessions.items():
             if warmed_key == key or not key.can_retune_from(warmed_key):
                 continue

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -44,8 +44,16 @@ _UNPARSED_HEAD_CHARS = 64
 _MESSAGE_JSON_PATTERN = re.compile(r'\{\s*"(?:role|content|tool_calls|id|type)"\s*:')
 _MESSAGE_JSON_KEYS = ("role", "content", "tool_calls", "id", "type")
 _MAX_MESSAGE_JSON_PREFIX_CHARS = 64
-_MANGLED_TOOL_CALLS_PATTERN = re.compile(r'"tool(?:_|\s+)calls"\s*:\s*"id"\s*:\s*"call_')
+# A retuned session can emit the transcript's own "tool_calls" key with its
+# opening bracket lost, so the id follows the key as a bare string. The call id
+# itself is optional in the wreckage, and the case is whatever the template
+# produced, so both stay tolerated: this only decides what fails closed.
+_MANGLED_TOOL_CALLS_PATTERN = re.compile(
+    r'"tool(?:_|\s+)calls"\s*:\s*(?:"id"\s*:\s*)?"call_',
+    re.IGNORECASE,
+)
 _MANGLED_TOOL_CALLS_START = '"tool'
+_MANGLED_TOOL_CALLS_TAILS = ((":", '"id"', ":", '"call_'), (":", '"call_'))
 
 __all__ = [
     "TOOL_CALL_CLOSE",
@@ -923,6 +931,9 @@ def _partial_mangled_tool_calls_prefix_length(value: str) -> int:
 
 
 def _is_mangled_tool_calls_prefix(value: str) -> bool:
+    # The pattern is case-insensitive, and every literal below is lower case,
+    # so one fold up front keeps the walk comparing like with like.
+    value = value.lower()
     consumed = _consume_literal_prefix(value, 0, _MANGLED_TOOL_CALLS_START)
     if consumed is None:
         return False
@@ -946,7 +957,14 @@ def _is_mangled_tool_calls_prefix(value: str) -> bool:
     if ended:
         return True
 
-    for literal in (":", '"id"', ":", '"call_'):
+    return any(
+        _is_literal_sequence_prefix(value, index, tail) for tail in _MANGLED_TOOL_CALLS_TAILS
+    )
+
+
+def _is_literal_sequence_prefix(value: str, start: int, literals: tuple[str, ...]) -> bool:
+    index = start
+    for literal in literals:
         while index < len(value) and value[index].isspace():
             index += 1
         if index == len(value):

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -44,6 +44,8 @@ _UNPARSED_HEAD_CHARS = 64
 _MESSAGE_JSON_PATTERN = re.compile(r'\{\s*"(?:role|content|tool_calls|id|type)"\s*:')
 _MESSAGE_JSON_KEYS = ("role", "content", "tool_calls", "id", "type")
 _MAX_MESSAGE_JSON_PREFIX_CHARS = 64
+_MANGLED_TOOL_CALLS_PATTERN = re.compile(r'"tool(?:_|\s+)calls"\s*:\s*"id"\s*:\s*"call_')
+_MANGLED_TOOL_CALLS_START = '"tool'
 
 __all__ = [
     "TOOL_CALL_CLOSE",
@@ -335,10 +337,15 @@ class ToolCallStreamParser:
         self._saw_tool_call = False
         self._tool_call_count = 0
         self._dialect = NATIVE_DIALECT
+        self._pending_transcript_error: MalformedToolCallError | None = None
 
     def feed(self, chunk: str) -> list[ProtocolEmission]:
         if not chunk:
             return []
+        if self._pending_transcript_error is not None:
+            error = self._pending_transcript_error
+            self._pending_transcript_error = None
+            raise error
         if self._done:
             if self._ignore_transcript_tail:
                 return []
@@ -358,6 +365,10 @@ class ToolCallStreamParser:
     def finish(self) -> list[ProtocolEmission]:
         """Flushes buffered text and any tool call left without a close marker."""
         emissions: list[ProtocolEmission] = []
+        if self._pending_transcript_error is not None:
+            error = self._pending_transcript_error
+            self._pending_transcript_error = None
+            raise error
         if self._capturing:
             recovered = self._recover_unclosed_tool_call()
             if recovered is None:
@@ -397,13 +408,32 @@ class ToolCallStreamParser:
         self._text_tail = ""
         found = find_open_marker(value)
         message_match = _MESSAGE_JSON_PATTERN.search(value) if detect_message_json else None
+        mangled_match = _MANGLED_TOOL_CALLS_PATTERN.search(value) if detect_message_json else None
         emissions: list[ProtocolEmission] = []
-        if message_match is not None and (found is None or message_match.start() < found[0]):
+        if (
+            message_match is not None
+            and (found is None or message_match.start() < found[0])
+            and (mangled_match is None or message_match.start() < mangled_match.start())
+        ):
             prefix = value[: message_match.start()]
             if prefix:
                 emissions.extend(self._emit_text_before_marker(prefix))
             self._capturing_message_json = True
             emissions.extend(self._consume_message_json(value[message_match.start() :]))
+            return emissions
+
+        if (
+            mangled_match is not None
+            and (found is None or mangled_match.start() < found[0])
+            and (message_match is None or mangled_match.start() < message_match.start())
+        ):
+            prefix = value[: mangled_match.start()]
+            if prefix:
+                emissions.extend(self._emit_text_before_marker(prefix))
+            payload = value[mangled_match.start() :]
+            # Return already verified prose first. The next chunk or finish()
+            # raises before any transcript-shaped tail reaches the client.
+            self._pending_transcript_error = self._transcript_error(payload)
             return emissions
 
         if found is not None:
@@ -424,6 +454,7 @@ class ToolCallStreamParser:
         if detect_message_json:
             partial_message = _partial_message_json_prefix_length(value)
             held = max(held, partial_message)
+            held = max(held, _partial_mangled_tool_calls_prefix_length(value))
         if self._saw_tool_call:
             held = max(held, len(self._trailing_partial(value)))
         emit_length = len(value) - held
@@ -877,3 +908,66 @@ def _partial_message_json_prefix_length(value: str) -> int:
     while index < len(candidate) and candidate[index].isspace():
         index += 1
     return len(candidate) if index == len(candidate) else 0
+
+
+def _partial_mangled_tool_calls_prefix_length(value: str) -> int:
+    window_start = max(0, len(value) - _MAX_MESSAGE_JSON_PREFIX_CHARS)
+    held = 0
+    for start in range(window_start, len(value)):
+        if value[start] != '"':
+            continue
+        candidate = value[start:]
+        if _is_mangled_tool_calls_prefix(candidate):
+            held = max(held, len(candidate))
+    return held
+
+
+def _is_mangled_tool_calls_prefix(value: str) -> bool:
+    consumed = _consume_literal_prefix(value, 0, _MANGLED_TOOL_CALLS_START)
+    if consumed is None:
+        return False
+    index, ended = consumed
+    if ended:
+        return True
+
+    if value[index] == "_":
+        consumed = _consume_literal_prefix(value, index, '_calls"')
+    elif value[index].isspace():
+        while index < len(value) and value[index].isspace():
+            index += 1
+        if index == len(value):
+            return True
+        consumed = _consume_literal_prefix(value, index, 'calls"')
+    else:
+        return False
+    if consumed is None:
+        return False
+    index, ended = consumed
+    if ended:
+        return True
+
+    for literal in (":", '"id"', ":", '"call_'):
+        while index < len(value) and value[index].isspace():
+            index += 1
+        if index == len(value):
+            return True
+        consumed = _consume_literal_prefix(value, index, literal)
+        if consumed is None:
+            return False
+        index, ended = consumed
+        if ended:
+            return True
+    return False
+
+
+def _consume_literal_prefix(
+    value: str,
+    start: int,
+    literal: str,
+) -> tuple[int, bool] | None:
+    remainder = value[start:]
+    if literal.startswith(remainder):
+        return len(value), True
+    if not remainder.startswith(literal):
+        return None
+    return start + len(literal), False

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -32,6 +32,7 @@ from droid_sdk.schemas.enums import (
     ReasoningEffort,
 )
 
+from factory_droid_openai.config import DEFAULT_MODEL_ALIAS
 from factory_droid_openai.droid_rpc import (
     CompactionResult,
     ContextBreakdown,
@@ -72,12 +73,43 @@ _MODEL_DENIED_PATTERN = re.compile(
 # Weaker models do exactly that before answering, which is worth tolerating;
 # every other native tool still fails the turn closed.
 _IGNORED_NATIVE_TOOLS = frozenset({"exitspecmode", "toolsearch"})
-_FRESH_SESSION_MODEL_PREFIXES = ("kimi-",)
+_MODEL_FAMILY_PREFIXES = (
+    (("gpt-", "o1", "o3", "o4"), "gpt"),
+    (("gemini",), "gemini"),
+    (("claude",), "claude"),
+    (("qwen",), "qwen"),
+    (("kimi",), "kimi"),
+    (("deepseek",), "deepseek"),
+)
+# A retune only swaps modelId; Droid keeps the tool-call template the session
+# was initialized with. These families frame calls in special tokens no other
+# family understands, so a cross-family switch would leave the wrong template
+# active and produce mangled calls. They get a fresh session instead.
+_FRESH_SESSION_MODEL_FAMILIES = frozenset({"kimi"})
 
 
 def _is_ignorable_native_tool(tool_name: str) -> bool:
     """Report whether an event names a Droid meta tool the bridge tolerates."""
     return tool_name.replace("-", "").replace("_", "").casefold() in _IGNORED_NATIVE_TOOLS
+
+
+def model_family(model: str) -> str:
+    """Groups a requested model or resolved Droid model id into one family.
+
+    Telemetry labels and the warm-pool retune guard read the same table, so a
+    family the bridge treats as special cannot drift between the two.
+    """
+    normalized = model.strip().lower()
+    if normalized == DEFAULT_MODEL_ALIAS:
+        return "factory_default"
+    for prefixes, family in _MODEL_FAMILY_PREFIXES:
+        if normalized.startswith(prefixes):
+            return family
+    return "other"
+
+
+def _needs_fresh_session(model_id: str | None) -> bool:
+    return model_id is not None and model_family(model_id) in _FRESH_SESSION_MODEL_FAMILIES
 
 
 class RunnerError(RuntimeError):
@@ -116,19 +148,17 @@ class SessionKey:
     def can_retune_from(self, other: SessionKey) -> bool:
         """Whether a session warmed for ``other`` can be repointed at ``self``.
 
-        Kimi model changes need a fresh session because its protocol state can
-        survive a retune. Other model changes and explicit effort changes keep
-        using Droid's fast settings update.
+        A model change in or out of a fresh-session family needs a new session
+        because the template it was initialized with survives a retune. Other
+        model changes and explicit effort changes keep using Droid's fast
+        settings update. ``None`` means "whatever Droid defaults to", which
+        cannot be restored on a session that already carries an explicit value.
         """
         if self.model_id is None:
             return False
         model_changed = self.model_id != other.model_id
         if model_changed and (
-            self.model_id.startswith(_FRESH_SESSION_MODEL_PREFIXES)
-            or (
-                other.model_id is not None
-                and other.model_id.startswith(_FRESH_SESSION_MODEL_PREFIXES)
-            )
+            _needs_fresh_session(self.model_id) or _needs_fresh_session(other.model_id)
         ):
             return False
         return not (self.reasoning_effort is None and other.reasoning_effort is not None)

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -100,6 +100,19 @@ class SessionKey:
     model_id: str | None
     reasoning_effort: str | None
 
+    @classmethod
+    def from_request(
+        cls,
+        *,
+        model: str,
+        model_alias: str,
+        reasoning_effort: str | None,
+    ) -> SessionKey:
+        return cls(
+            model_id=_resolve_model_id(model, model_alias),
+            reasoning_effort=reasoning_effort,
+        )
+
     def can_retune_from(self, other: SessionKey) -> bool:
         """Whether a session warmed for ``other`` can be repointed at ``self``.
 
@@ -149,8 +162,9 @@ class RunRequest:
     warm_session: WarmSession | None = None
 
     def session_key(self) -> SessionKey:
-        return SessionKey(
-            model_id=_resolve_model_id(self.model, self.model_alias),
+        return SessionKey.from_request(
+            model=self.model,
+            model_alias=self.model_alias,
             reasoning_effort=self.reasoning_effort,
         )
 

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -81,11 +81,6 @@ _MODEL_FAMILY_PREFIXES = (
     (("kimi",), "kimi"),
     (("deepseek",), "deepseek"),
 )
-# A retune only swaps modelId; Droid keeps the tool-call template the session
-# was initialized with. These families frame calls in special tokens no other
-# family understands, so a cross-family switch would leave the wrong template
-# active and produce mangled calls. They get a fresh session instead.
-_FRESH_SESSION_MODEL_FAMILIES = frozenset({"kimi"})
 
 
 def _is_ignorable_native_tool(tool_name: str) -> bool:
@@ -96,8 +91,8 @@ def _is_ignorable_native_tool(tool_name: str) -> bool:
 def model_family(model: str) -> str:
     """Groups a requested model or resolved Droid model id into one family.
 
-    Telemetry labels and the warm-pool retune guard read the same table, so a
-    family the bridge treats as special cannot drift between the two.
+    Telemetry labels group traffic by family so a model id never becomes a
+    metric label of its own.
     """
     normalized = model.strip().lower()
     if normalized == DEFAULT_MODEL_ALIAS:
@@ -106,10 +101,6 @@ def model_family(model: str) -> str:
         if normalized.startswith(prefixes):
             return family
     return "other"
-
-
-def _needs_fresh_session(model_id: str | None) -> bool:
-    return model_id is not None and model_family(model_id) in _FRESH_SESSION_MODEL_FAMILIES
 
 
 class RunnerError(RuntimeError):
@@ -148,18 +139,16 @@ class SessionKey:
     def can_retune_from(self, other: SessionKey) -> bool:
         """Whether a session warmed for ``other`` can be repointed at ``self``.
 
-        A model change in or out of a fresh-session family needs a new session
-        because the template it was initialized with survives a retune. Other
-        model changes and explicit effort changes keep using Droid's fast
-        settings update. ``None`` means "whatever Droid defaults to", which
-        cannot be restored on a session that already carries an explicit value.
+        Only the reasoning effort is retunable. A retune swaps the model id
+        while Droid keeps the tool-call template the session was initialized
+        with, and that template belongs to the model rather than to its
+        family: Kimi K2 frames calls in ``<|tool_calls_section_begin|>`` where
+        K3 uses ``<|open|>tools<|sep|>``. Any model change therefore waits for
+        a fresh or exact-match session. ``None`` means "whatever Droid
+        defaults to", which cannot be restored on a session that already
+        carries an explicit value.
         """
-        if self.model_id is None:
-            return False
-        model_changed = self.model_id != other.model_id
-        if model_changed and (
-            _needs_fresh_session(self.model_id) or _needs_fresh_session(other.model_id)
-        ):
+        if self.model_id is None or self.model_id != other.model_id:
             return False
         return not (self.reasoning_effort is None and other.reasoning_effort is not None)
 
@@ -388,16 +377,16 @@ class DroidRunner:
         if key == warm.key:
             return
         model_id = key.model_id
-        if model_id is None or not key.can_retune_from(warm.key):
+        effort = _resolve_reasoning_effort(key.reasoning_effort)
+        if model_id is None or effort is None or not key.can_retune_from(warm.key):
             raise RunnerError(
                 "Warm Droid session cannot be repointed at the requested settings.",
             )
         started = time.perf_counter()
-        effort = _resolve_reasoning_effort(key.reasoning_effort)
         await self._rpc.retune_session(
             warm.client,
             model_id=model_id,
-            reasoning_effort=effort.value if effort is not None else None,
+            reasoning_effort=effort.value,
         )
         previous = warm.key
         warm.key = key

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -72,6 +72,7 @@ _MODEL_DENIED_PATTERN = re.compile(
 # Weaker models do exactly that before answering, which is worth tolerating;
 # every other native tool still fails the turn closed.
 _IGNORED_NATIVE_TOOLS = frozenset({"exitspecmode", "toolsearch"})
+_FRESH_SESSION_MODEL_PREFIXES = ("kimi-",)
 
 
 def _is_ignorable_native_tool(tool_name: str) -> bool:
@@ -102,11 +103,20 @@ class SessionKey:
     def can_retune_from(self, other: SessionKey) -> bool:
         """Whether a session warmed for ``other`` can be repointed at ``self``.
 
-        ``None`` means "whatever Droid defaults to", which cannot be restored
-        on a session that already carries an explicit value, so those keys are
-        only reusable for an exact match.
+        Kimi model changes need a fresh session because its protocol state can
+        survive a retune. Other model changes and explicit effort changes keep
+        using Droid's fast settings update.
         """
         if self.model_id is None:
+            return False
+        model_changed = self.model_id != other.model_id
+        if model_changed and (
+            self.model_id.startswith(_FRESH_SESSION_MODEL_PREFIXES)
+            or (
+                other.model_id is not None
+                and other.model_id.startswith(_FRESH_SESSION_MODEL_PREFIXES)
+            )
+        ):
             return False
         return not (self.reasoning_effort is None and other.reasoning_effort is not None)
 
@@ -336,7 +346,7 @@ class DroidRunner:
         model_id = key.model_id
         if model_id is None or not key.can_retune_from(warm.key):
             raise RunnerError(
-                "Warm Droid session cannot be repointed at the requested model.",
+                "Warm Droid session cannot be repointed at the requested settings.",
             )
         started = time.perf_counter()
         effort = _resolve_reasoning_effort(key.reasoning_effort)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1749,8 +1749,55 @@ async def test_streaming_malformed_tool_call_stops_with_note(tmp_path: Path) -> 
     )
     assert content.startswith("checking \n\n[bridge notice: dropped a malformed tool call")
     assert 'for tool "weather"' in content
-    assert "<tool_call>" in content
+    assert "Retry the request" in content
+    assert "<tool_call>" not in content
     assert 'outcome="malformed",status="200"} 1' in metrics.text
+
+
+@pytest.mark.asyncio
+async def test_streaming_mangled_openai_tool_calls_do_not_leak_json(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(
+                'checking (reset|", "tool calls":"id":"call_1","type":"function",'
+                '"function":("name":"weather","arguments":("city":"Gdansk"))'
+            ),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith('data: {"')
+    ]
+    content = "".join(
+        choice["delta"].get("content") or ""
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+    )
+    assert content.startswith('checking (reset|", \n\n[bridge notice:')
+    assert '"tool calls"' not in content
+    assert '"function"' not in content
+    assert '"arguments"' not in content
+    assert "<tool_call>" not in content
+    finish_chunk = next(
+        chunk
+        for chunk in chunks
+        if chunk["choices"] and chunk["choices"][0]["finish_reason"] is not None
+    )
+    assert finish_chunk["choices"][0]["finish_reason"] == "stop"
 
 
 @pytest.mark.asyncio
@@ -1841,7 +1888,7 @@ async def test_streaming_malformed_tool_call_without_prior_text(tmp_path: Path) 
         for chunk in chunks
         for choice in chunk.get("choices", [])
     )
-    assert content.startswith("[bridge notice: dropped a malformed tool call (")
+    assert content.startswith("[bridge notice: dropped a malformed tool call.")
     assert "for tool" not in content
     finish_chunk = next(
         chunk

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -669,7 +669,7 @@ async def test_overloaded_bridge_rejects_model_and_session_operations(
         session_continuity=True,
         retry_after_seconds=3,
     )
-    app.state.sessions.remember("session-9")
+    app.state.sessions.remember("session-9", "factory-droid")
     async with _client(app) as client:
         active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
         await runner.started.wait()
@@ -700,7 +700,7 @@ async def test_session_operations_time_out_when_the_queue_eats_the_budget(
         max_queue_size=1,
         session_continuity=True,
     )
-    app.state.sessions.remember("session-9")
+    app.state.sessions.remember("session-9", "factory-droid")
     async with _client(app) as client:
         active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
         await runner.started.wait()
@@ -2845,6 +2845,36 @@ async def test_session_id_round_trips_and_drives_a_continuation(
 
 
 @pytest.mark.asyncio
+async def test_session_continuation_rejects_a_model_switch(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            SessionStarted("session-77"),
+            TextDelta("first reply"),
+            RunComplete(Usage()),
+        ]
+    )
+    app = _feature_app(tmp_path, runner, session_continuity=True)
+    async with _client(app) as client:
+        first = await client.post(
+            "/v1/chat/completions",
+            json=_payload(model="model-a"),
+        )
+        switched = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                model="model-b",
+                factory_droid_session_id="session-77",
+            ),
+        )
+
+    assert first.status_code == 200
+    assert switched.status_code == 400
+    assert switched.json()["error"]["type"] == "invalid_request_error"
+    assert "Start a new session to switch models" in switched.json()["error"]["message"]
+    assert len(runner.requests) == 1
+
+
+@pytest.mark.asyncio
 async def test_multiple_choices_cannot_continue_a_session(tmp_path: Path) -> None:
     runner = FakeRunner([SessionStarted("session-9"), RunComplete(Usage())])
     app = _feature_app(tmp_path, runner, session_continuity=True)
@@ -3294,7 +3324,12 @@ async def test_guarded_factory_session_operations(tmp_path: Path) -> None:
     )
     app = _feature_app(tmp_path, runner, session_continuity=True)
     async with _client(app) as client:
-        assert (await client.post("/v1/chat/completions", json=_payload())).status_code == 200
+        assert (
+            await client.post(
+                "/v1/chat/completions",
+                json=_payload(model="model-a"),
+            )
+        ).status_code == 200
         context = await client.get("/v1/factory/sessions/session-77/context")
         compact = await client.post(
             "/v1/factory/sessions/session-77/compact",
@@ -3315,6 +3350,8 @@ async def test_guarded_factory_session_operations(tmp_path: Path) -> None:
     assert rename.json()["status"] == "renamed"
     assert close.json()["status"] == "closed"
     assert missing.status_code == 404
+    assert app.state.sessions.model("session-compact") == "model-a"
+    assert app.state.sessions.model("session-fork") == "model-a"
     assert runner.session_operations == [
         ("context", "session-77", None),
         ("compact", "session-77", "Keep decisions."),
@@ -3409,7 +3446,7 @@ async def test_request_limits_cover_the_factory_session_endpoints(tmp_path: Path
         session_continuity=True,
         max_request_bytes=256,
     )
-    app.state.sessions.remember("session-9")
+    app.state.sessions.remember("session-9", "factory-droid")
     async with _client(app) as client:
         oversized = await client.post(
             "/v1/factory/sessions/session-9/compact",
@@ -3441,11 +3478,11 @@ async def test_factory_session_operations_require_continuity(tmp_path: Path) -> 
 def test_session_registry_evicts_the_oldest_entries() -> None:
     registry = SessionRegistry(2)
 
-    registry.remember("a")
-    registry.remember("b")
+    registry.remember("a", "model-a")
+    registry.remember("b", "model-b")
     assert registry.knows("a") is True
 
-    registry.remember("c")
+    registry.remember("c", "model-c")
 
     assert registry.knows("b") is False
     assert registry.knows("a") is True
@@ -3455,12 +3492,14 @@ def test_session_registry_evicts_the_oldest_entries() -> None:
 def test_session_registry_ignores_duplicate_entries() -> None:
     registry = SessionRegistry(2)
 
-    registry.remember("a")
-    registry.remember("a")
-    registry.remember("b")
+    registry.remember("a", "model-a")
+    registry.remember("a", "model-b")
+    registry.remember("b", "model-b")
 
     assert registry.knows("a") is True
+    assert registry.model("a") == "model-b"
     assert registry.knows("b") is True
+    assert registry.model("missing") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,7 +25,6 @@ from factory_droid_openai.app import (
     _finalize_stream,
     _JsonDepthTracker,
     _latency_bucket,
-    _model_family,
     _payload_size_bucket,
     _request_mode,
     _request_outcome,
@@ -2142,20 +2141,6 @@ def test_request_telemetry_classifies_routes_and_modes() -> None:
     assert (
         _request_mode(cast("Any", {"state": {"telemetry_mode": "unexpected"}})) == "not_applicable"
     )
-
-
-@pytest.mark.parametrize(
-    ("model", "expected"),
-    [
-        ("factory-droid", "factory_default"),
-        ("gpt-5.4", "gpt"),
-        ("gemini-3.1-pro", "gemini"),
-        ("claude-sonnet", "claude"),
-        ("custom-model", "other"),
-    ],
-)
-def test_model_family_is_coarse_and_stable(model: str, expected: str) -> None:
-    assert _model_family(model) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -669,7 +669,7 @@ async def test_overloaded_bridge_rejects_model_and_session_operations(
         session_continuity=True,
         retry_after_seconds=3,
     )
-    app.state.sessions.remember("session-9", "factory-droid")
+    app.state.sessions.remember("session-9", SessionKey(None, None))
     async with _client(app) as client:
         active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
         await runner.started.wait()
@@ -700,7 +700,7 @@ async def test_session_operations_time_out_when_the_queue_eats_the_budget(
         max_queue_size=1,
         session_continuity=True,
     )
-    app.state.sessions.remember("session-9", "factory-droid")
+    app.state.sessions.remember("session-9", SessionKey(None, None))
     async with _client(app) as client:
         active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
         await runner.started.wait()
@@ -2845,7 +2845,7 @@ async def test_session_id_round_trips_and_drives_a_continuation(
 
 
 @pytest.mark.asyncio
-async def test_session_continuation_rejects_a_model_switch(tmp_path: Path) -> None:
+async def test_session_continuation_rejects_settings_switches(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
             SessionStarted("session-77"),
@@ -2866,11 +2866,20 @@ async def test_session_continuation_rejects_a_model_switch(tmp_path: Path) -> No
                 factory_droid_session_id="session-77",
             ),
         )
+        effort_switched = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                model="model-a",
+                reasoning_effort="low",
+                factory_droid_session_id="session-77",
+            ),
+        )
 
     assert first.status_code == 200
-    assert switched.status_code == 400
-    assert switched.json()["error"]["type"] == "invalid_request_error"
-    assert "Start a new session to switch models" in switched.json()["error"]["message"]
+    for rejected in (switched, effort_switched):
+        assert rejected.status_code == 400
+        assert rejected.json()["error"]["type"] == "invalid_request_error"
+        assert "switch model or reasoning effort" in rejected.json()["error"]["message"]
     assert len(runner.requests) == 1
 
 
@@ -3350,8 +3359,9 @@ async def test_guarded_factory_session_operations(tmp_path: Path) -> None:
     assert rename.json()["status"] == "renamed"
     assert close.json()["status"] == "closed"
     assert missing.status_code == 404
-    assert app.state.sessions.model("session-compact") == "model-a"
-    assert app.state.sessions.model("session-fork") == "model-a"
+    expected_key = SessionKey("model-a", None)
+    assert app.state.sessions.key("session-compact") == expected_key
+    assert app.state.sessions.key("session-fork") == expected_key
     assert runner.session_operations == [
         ("context", "session-77", None),
         ("compact", "session-77", "Keep decisions."),
@@ -3446,7 +3456,7 @@ async def test_request_limits_cover_the_factory_session_endpoints(tmp_path: Path
         session_continuity=True,
         max_request_bytes=256,
     )
-    app.state.sessions.remember("session-9", "factory-droid")
+    app.state.sessions.remember("session-9", SessionKey(None, None))
     async with _client(app) as client:
         oversized = await client.post(
             "/v1/factory/sessions/session-9/compact",
@@ -3478,28 +3488,32 @@ async def test_factory_session_operations_require_continuity(tmp_path: Path) -> 
 def test_session_registry_evicts_the_oldest_entries() -> None:
     registry = SessionRegistry(2)
 
-    registry.remember("a", "model-a")
-    registry.remember("b", "model-b")
-    assert registry.knows("a") is True
+    key_a = SessionKey("model-a", None)
+    key_b = SessionKey("model-b", None)
+    registry.remember("a", key_a)
+    registry.remember("b", key_b)
+    assert registry.key("a") == key_a
 
-    registry.remember("c", "model-c")
+    key_c = SessionKey("model-c", None)
+    registry.remember("c", key_c)
 
-    assert registry.knows("b") is False
-    assert registry.knows("a") is True
-    assert registry.knows("c") is True
+    assert registry.key("b") is None
+    assert registry.key("a") == key_a
+    assert registry.key("c") == key_c
 
 
 def test_session_registry_ignores_duplicate_entries() -> None:
     registry = SessionRegistry(2)
 
-    registry.remember("a", "model-a")
-    registry.remember("a", "model-b")
-    registry.remember("b", "model-b")
+    key_a = SessionKey("model-a", None)
+    key_b = SessionKey("model-b", None)
+    registry.remember("a", key_a)
+    registry.remember("a", key_b)
+    registry.remember("b", key_b)
 
-    assert registry.knows("a") is True
-    assert registry.model("a") == "model-b"
-    assert registry.knows("b") is True
-    assert registry.model("missing") is None
+    assert registry.key("a") == key_b
+    assert registry.key("b") == key_b
+    assert registry.key("missing") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -53,6 +53,7 @@ def _scenario(e2e: ModuleType, **overrides: Any) -> Any:
 
 def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleType) -> None:
     plan = e2e.scenarios()
+    switch_plan = e2e.switch_scenarios()
 
     streamed = {scenario.name for scenario in plan if scenario.stream}
     hostile = [scenario for scenario in plan if not scenario.per_model]
@@ -62,6 +63,8 @@ def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleT
     assert all(scenario.expect_status != (200,) for scenario in hostile)
     assert all(not scenario.stream for scenario in hostile)
     assert len(e2e.scenarios(streaming=False)) < len(plan)
+    assert {scenario.stream for scenario in switch_plan} == {False, True}
+    assert len(e2e.switch_scenarios(streaming=False)) == 1
 
 
 def test_contract_satisfied_is_a_pass(e2e: ModuleType) -> None:
@@ -96,6 +99,14 @@ def test_contract_satisfied_is_a_pass(e2e: ModuleType) -> None:
         (
             '```\n{"role":"assistant","content":"copied"}\n```',
             "assistant reproduced an OpenAI assistant message",
+        ),
+        (
+            '"tool calls": "id": "call_123"',
+            "assistant exposed malformed OpenAI tool-call output",
+        ),
+        (
+            '"tool_calls":"call_123"',
+            "assistant exposed malformed OpenAI tool-call output",
         ),
         ("[1,2,3]", None),
         ("ordinary answer", None),
@@ -530,6 +541,84 @@ async def test_matrix_without_models_still_runs_hostile_cases(e2e: ModuleType) -
     assert rows[0]["verdict"] == e2e.SUCCESS
 
 
+@pytest.mark.asyncio
+async def test_switch_matrix_runs_a_serial_model_ring(e2e: ModuleType) -> None:
+    seen_models: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_models.append(json.loads(request.content)["model"])
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    written: list[dict[str, Any]] = []
+    bridge = _bridge(e2e, handler)
+    plan = [_scenario(e2e, name="model_switch")]
+    async with bridge.client:
+        rows = await e2e.run_switch_matrix(
+            bridge,
+            ["m1", "m2", "m3"],
+            plan,
+            settle_seconds=0,
+            on_row=written.append,
+        )
+
+    assert seen_models == ["m1", "m2", "m2", "m3", "m3", "m1"]
+    assert [(row["source_model"], row["model"]) for row in rows] == [
+        ("m1", "m2"),
+        ("m2", "m3"),
+        ("m3", "m1"),
+    ]
+    assert all(row["prime_verdict"] == e2e.SUCCESS for row in rows)
+    assert written == rows
+
+
+@pytest.mark.asyncio
+async def test_switch_matrix_skips_one_model_and_supports_no_callback(e2e: ModuleType) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    bridge = _bridge(e2e, handler)
+    plan = [_scenario(e2e, name="model_switch")]
+    async with bridge.client:
+        assert (
+            await e2e.run_switch_matrix(
+                bridge,
+                ["m1"],
+                plan,
+                settle_seconds=0,
+            )
+            == []
+        )
+        rows = await e2e.run_switch_matrix(
+            bridge,
+            ["m1", "m2"],
+            plan,
+            settle_seconds=0,
+        )
+
+    assert len(rows) == 2
+
+
 def _rows(e2e: ModuleType) -> list[dict[str, Any]]:
     return [
         e2e.row("m1", _scenario(e2e), _observation(e2e)),
@@ -593,8 +682,8 @@ def test_compare_reports_regressions_and_fixes(e2e: ModuleType) -> None:
     rendered = e2e.render_comparison(result)
 
     assert result["shared"] == 2
-    assert [entry["key"] for entry in result["regressions"]] == [("m1", "hello", False)]
-    assert [entry["key"] for entry in result["fixes"]] == [("m2", "hello", False)]
+    assert [entry["key"] for entry in result["regressions"]] == [("", "m1", "hello", False)]
+    assert [entry["key"] for entry in result["fixes"]] == [("", "m2", "hello", False)]
     assert result["only_before"]
     assert result["only_after"]
     assert "## Regressions" in rendered

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -54,6 +54,7 @@ def _scenario(e2e: ModuleType, **overrides: Any) -> Any:
 def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleType) -> None:
     plan = e2e.scenarios()
     switch_plan = e2e.switch_scenarios()
+    continuation_plan = e2e.continuation_switch_scenarios()
 
     streamed = {scenario.name for scenario in plan if scenario.stream}
     hostile = [scenario for scenario in plan if not scenario.per_model]
@@ -65,6 +66,8 @@ def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleT
     assert len(e2e.scenarios(streaming=False)) < len(plan)
     assert {scenario.stream for scenario in switch_plan} == {False, True}
     assert len(e2e.switch_scenarios(streaming=False)) == 1
+    assert {scenario.stream for scenario in continuation_plan} == {False, True}
+    assert len(e2e.continuation_switch_scenarios(streaming=False)) == 1
 
 
 def test_contract_satisfied_is_a_pass(e2e: ModuleType) -> None:
@@ -285,6 +288,7 @@ async def test_bridge_reads_a_json_completion(e2e: ModuleType) -> None:
         return httpx.Response(
             200,
             json={
+                "factory_droid_session_id": "session-json",
                 "choices": [
                     {
                         "index": 0,
@@ -295,7 +299,7 @@ async def test_bridge_reads_a_json_completion(e2e: ModuleType) -> None:
                         },
                         "finish_reason": "tool_calls",
                     }
-                ]
+                ],
             },
             headers={"x-request-id": "req-1"},
         )
@@ -309,12 +313,24 @@ async def test_bridge_reads_a_json_completion(e2e: ModuleType) -> None:
     assert observation.tool_calls == 1
     assert observation.content_chars == 5
     assert observation.request_id == "req-1"
+    assert observation.session_id == "session-json"
 
 
 @pytest.mark.asyncio
 async def test_bridge_reads_a_streamed_completion(e2e: ModuleType) -> None:
     chunks = [
-        {"choices": [{"index": 0, "delta": {"content": "he"}, "finish_reason": None}]},
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "content": "he",
+                        "factory_droid_session_id": "session-stream",
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
         {
             "choices": [
                 {
@@ -345,6 +361,7 @@ async def test_bridge_reads_a_streamed_completion(e2e: ModuleType) -> None:
     assert observation.tool_calls == 1
     assert observation.content_chars == 2
     assert observation.ttft_ms is not None
+    assert observation.session_id == "session-stream"
 
 
 @pytest.mark.asyncio
@@ -619,6 +636,99 @@ async def test_switch_matrix_skips_one_model_and_supports_no_callback(e2e: Modul
     assert len(rows) == 2
 
 
+@pytest.mark.asyncio
+async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) -> None:
+    seen: list[tuple[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        model = body["model"]
+        session_id = body.get("factory_droid_session_id")
+        seen.append((model, session_id))
+        if session_id is not None:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "start a new session",
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "factory_droid_session_id": f"session-{model}",
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "ready"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+
+    written: list[dict[str, Any]] = []
+    bridge = _bridge(e2e, handler)
+    plan = e2e.continuation_switch_scenarios(streaming=False)
+    async with bridge.client:
+        rows = await e2e.run_continuation_switch_matrix(
+            bridge,
+            ["m1", "m2"],
+            plan,
+            on_row=written.append,
+        )
+
+    assert seen == [
+        ("m1", None),
+        ("m2", "session-m1"),
+        ("m2", None),
+        ("m1", "session-m2"),
+    ]
+    assert all(row["verdict"] == e2e.SUCCESS for row in rows)
+    assert written == rows
+
+
+@pytest.mark.asyncio
+async def test_continuation_switch_matrix_reports_missing_session_ids(
+    e2e: ModuleType,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "ready"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    bridge = _bridge(e2e, handler)
+    plan = e2e.continuation_switch_scenarios(streaming=False)
+    async with bridge.client:
+        assert (
+            await e2e.run_continuation_switch_matrix(
+                bridge,
+                ["m1"],
+                plan,
+            )
+            == []
+        )
+        rows = await e2e.run_continuation_switch_matrix(
+            bridge,
+            ["m1", "m2"],
+            plan,
+        )
+
+    assert len(rows) == 2
+    assert all(row["verdict"] == e2e.BRIDGE_DEFECT for row in rows)
+    assert all("no session id" in row["detail"] for row in rows)
+
+
 def _rows(e2e: ModuleType) -> list[dict[str, Any]]:
     return [
         e2e.row("m1", _scenario(e2e), _observation(e2e)),
@@ -699,6 +809,15 @@ def test_comparison_without_changes_stays_quiet(e2e: ModuleType) -> None:
     assert "## Fixes" not in rendered
 
 
+def test_comparison_keeps_transition_sources_distinct(e2e: ModuleType) -> None:
+    first = e2e.row("target", _scenario(e2e), _observation(e2e))
+    first["source_model"] = "source-a"
+    second = e2e.row("target", _scenario(e2e), _observation(e2e))
+    second["source_model"] = "source-b"
+
+    assert e2e.compare([first, second], [first, second])["shared"] == 2
+
+
 def test_report_command_reads_a_jsonl_run(
     e2e: ModuleType,
     tmp_path: Path,
@@ -742,11 +861,13 @@ def test_compare_command_fails_on_regressions(
     assert "Regressions" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize("test_continuity", [False, True])
 def test_run_command_writes_rows_and_reports_blocking_findings(
     e2e: ModuleType,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    test_continuity: bool,
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/v1/models":
@@ -760,8 +881,11 @@ def test_run_command_writes_rows_and_reports_blocking_findings(
     monkeypatch.setattr(e2e.httpx, "AsyncClient", MockClient)
     monkeypatch.delenv("FACTORY_DROID_OPENAI_API_KEY", raising=False)
     out = tmp_path / "nested" / "run.jsonl"
+    args = ["run", "--no-stream", "--concurrency", "4", "--out", str(out)]
+    if test_continuity:
+        args.append("--test-session-continuity")
 
-    code = e2e.main(["run", "--no-stream", "--concurrency", "4", "--out", str(out)])
+    code = e2e.main(args)
 
     rows = e2e.load_rows(out)
     assert code == 1

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import pytest
 
+from factory_droid_openai.protocol import _MANGLED_TOOL_CALLS_PATTERN
+
 if TYPE_CHECKING:
     from types import ModuleType
 
@@ -795,6 +797,38 @@ async def test_continuation_switch_matrix_reports_missing_session_ids(
     assert len(rows) == 2
     assert all(row["verdict"] == e2e.BRIDGE_DEFECT for row in rows)
     assert all("no session id" in row["detail"] for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_continuation_switch_matrix_skips_an_opted_out_plan(e2e: ModuleType) -> None:
+    """An empty plan is the default, so it must not prime a single model."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(json.loads(request.content)["model"])
+        return httpx.Response(200, json={"choices": []})
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        rows = await e2e.run_continuation_switch_matrix(bridge, ["m1", "m2", "m3"], [])
+
+    assert rows == []
+    assert seen == []
+
+
+@pytest.mark.parametrize(
+    "mangled",
+    [
+        '"tool_calls":"id":"call_1"',
+        '"tool_calls":"call_1"',
+        '"tool calls": "id" : "call_1"',
+        '"TOOL_CALLS":"ID":"CALL_1"',
+    ],
+)
+def test_mangled_detector_agrees_with_the_bridge_parser(e2e: ModuleType, mangled: str) -> None:
+    """A shape the harness reports must be one the bridge can actually contain."""
+    assert e2e._MANGLED_TOOL_CALL_OUTPUT.search(mangled) is not None
+    assert _MANGLED_TOOL_CALLS_PATTERN.search(mangled) is not None
 
 
 def _rows(e2e: ModuleType) -> list[dict[str, Any]]:

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -136,12 +136,59 @@ def test_transcript_reproduction_is_a_bridge_defect(e2e: ModuleType) -> None:
 
 
 def test_expected_rejection_is_a_pass(e2e: ModuleType) -> None:
-    scenario = _scenario(e2e, expect_status=(400,))
+    scenario = _scenario(
+        e2e,
+        expect_status=(400,),
+        expect_error_type="invalid_request_error",
+        expect_error_contains="settings do not match",
+    )
 
-    verdict, detail = e2e.classify(scenario, _observation(e2e, status=400, finish_reason=None))
+    verdict, detail = e2e.classify(
+        scenario,
+        _observation(
+            e2e,
+            status=400,
+            error_type="invalid_request_error",
+            error_message="session settings do not match",
+            finish_reason=None,
+        ),
+    )
 
     assert verdict == e2e.SUCCESS
     assert "expected" in detail
+
+
+@pytest.mark.parametrize(
+    ("overrides", "detail"),
+    [
+        ({"error_type": "other"}, "error type"),
+        ({"error_message": "other"}, "message marker"),
+    ],
+)
+def test_expected_rejection_checks_error_contract(
+    e2e: ModuleType,
+    overrides: dict[str, str],
+    detail: str,
+) -> None:
+    scenario = _scenario(
+        e2e,
+        expect_status=(400,),
+        expect_error_type="invalid_request_error",
+        expect_error_contains="settings do not match",
+    )
+    fields: dict[str, Any] = {
+        "status": 400,
+        "error_type": "invalid_request_error",
+        "error_message": "session settings do not match",
+        "finish_reason": None,
+    }
+    fields.update(overrides)
+    observation = _observation(e2e, **fields)
+
+    verdict, reason = e2e.classify(scenario, observation)
+
+    assert verdict == e2e.BRIDGE_DEFECT
+    assert detail in reason
 
 
 @pytest.mark.parametrize(
@@ -636,6 +683,25 @@ async def test_switch_matrix_skips_one_model_and_supports_no_callback(e2e: Modul
     assert len(rows) == 2
 
 
+def test_transition_row_propagates_a_failed_prime(e2e: ModuleType) -> None:
+    record = e2e._transition_row(
+        "source",
+        "target",
+        _scenario(e2e),
+        _observation(e2e),
+        _observation(
+            e2e,
+            status=404,
+            error_type="model_not_found",
+            finish_reason=None,
+        ),
+    )
+
+    assert record["verdict"] == e2e.ACCOUNT_POLICY
+    assert record["prime_verdict"] == e2e.ACCOUNT_POLICY
+    assert "prime failed" in record["detail"]
+
+
 @pytest.mark.asyncio
 async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) -> None:
     seen: list[tuple[str, str | None]] = []
@@ -651,7 +717,7 @@ async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) 
                 json={
                     "error": {
                         "type": "invalid_request_error",
-                        "message": "start a new session",
+                        "message": "session settings do not match",
                     }
                 },
             )
@@ -670,7 +736,7 @@ async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) 
 
     written: list[dict[str, Any]] = []
     bridge = _bridge(e2e, handler)
-    plan = e2e.continuation_switch_scenarios(streaming=False)
+    plan = e2e.continuation_switch_scenarios()
     async with bridge.client:
         rows = await e2e.run_continuation_switch_matrix(
             bridge,
@@ -682,7 +748,9 @@ async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) 
     assert seen == [
         ("m1", None),
         ("m2", "session-m1"),
+        ("m2", "session-m1"),
         ("m2", None),
+        ("m1", "session-m2"),
         ("m1", "session-m2"),
     ]
     assert all(row["verdict"] == e2e.SUCCESS for row in rows)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 KEY = SessionKey(model_id="model-a", reasoning_effort="high")
 OTHER_KEY = SessionKey(model_id="model-b", reasoning_effort=None)
 RETUNE_KEY = SessionKey(model_id="model-b", reasoning_effort="high")
+KIMI_KEY = SessionKey(model_id="kimi-k3", reasoning_effort="high")
 
 
 class FakeTransport:
@@ -384,6 +385,19 @@ async def test_pool_hands_over_a_retunable_session_without_metrics() -> None:
     pool.offer(_session(created_at=asyncio.get_running_loop().time()))
 
     assert pool.acquire(RETUNE_KEY) is not None
+
+
+@pytest.mark.asyncio
+async def test_pool_does_not_retune_a_session_to_kimi() -> None:
+    metrics = BridgeMetrics()
+    pool = _pool(FakeRunner(), size=2, metrics=metrics)
+    pool.note(KEY)
+    pool.offer(_session(created_at=asyncio.get_running_loop().time()))
+
+    assert pool.acquire(KIMI_KEY) is None
+    rendered = metrics.render()
+    assert "factory_droid_openai_warm_session_retunes_total 0" in rendered
+    assert "factory_droid_openai_warm_session_misses_total 1" in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 KEY = SessionKey(model_id="model-a", reasoning_effort="high")
 OTHER_KEY = SessionKey(model_id="model-b", reasoning_effort=None)
-RETUNE_KEY = SessionKey(model_id="model-b", reasoning_effort="high")
-KIMI_KEY = SessionKey(model_id="kimi-k3", reasoning_effort="high")
+RETUNE_KEY = SessionKey(model_id="model-a", reasoning_effort="low")
+CROSS_MODEL_KEY = SessionKey(model_id="model-b", reasoning_effort="high")
 
 
 class FakeTransport:
@@ -373,7 +373,7 @@ async def test_pool_hands_over_a_session_the_runner_can_retune() -> None:
     assert session is not None
     assert session.key == KEY
     rendered = metrics.render()
-    assert "factory_droid_openai_warm_session_retunes_total 1" in rendered
+    assert 'factory_droid_openai_warm_session_retunes_total{reason="effort"} 1' in rendered
     assert "factory_droid_openai_warm_session_hits_total 1" in rendered
     assert "factory_droid_openai_warm_session_misses_total 0" in rendered
 
@@ -388,15 +388,15 @@ async def test_pool_hands_over_a_retunable_session_without_metrics() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pool_does_not_retune_a_session_to_kimi() -> None:
+async def test_pool_does_not_retune_a_session_across_models() -> None:
     metrics = BridgeMetrics()
     pool = _pool(FakeRunner(), size=2, metrics=metrics)
     pool.note(KEY)
     pool.offer(_session(created_at=asyncio.get_running_loop().time()))
 
-    assert pool.acquire(KIMI_KEY) is None
+    assert pool.acquire(CROSS_MODEL_KEY) is None
     rendered = metrics.render()
-    assert "factory_droid_openai_warm_session_retunes_total 0" in rendered
+    assert 'factory_droid_openai_warm_session_retunes_total{reason="effort"} 0' in rendered
     assert "factory_droid_openai_warm_session_misses_total 1" in rendered
 
 
@@ -459,7 +459,7 @@ def test_pool_metrics_contract_carries_no_default_behavior() -> None:
 
     PoolMetrics.set_warm_sessions(metrics, 3)
     PoolMetrics.increment_warm_hits(metrics)
-    PoolMetrics.increment_warm_retunes(metrics)
+    PoolMetrics.increment_warm_retunes(metrics, "effort")
     PoolMetrics.increment_warm_misses(metrics)
     PoolMetrics.increment_warm_failures(metrics)
     PoolMetrics.set_pending_reaps(metrics, 2)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -886,6 +886,31 @@ def test_stream_parser_stops_mangled_openai_tool_calls_before_they_leak(
         assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == prefix
 
 
+@pytest.mark.parametrize(
+    "mangled",
+    [
+        '"tool_calls":"call_1"',
+        '"tool_calls": "id" : "call_1"',
+        '"TOOL_CALLS":"ID":"CALL_1"',
+        '"Tool Calls":"call_1"',
+    ],
+)
+def test_stream_parser_stops_mangled_tool_calls_without_an_id_or_lower_case(
+    mangled: str,
+) -> None:
+    prefix = "safe answer "
+    value = f'{prefix}{mangled},"function":("name":"weather")'
+
+    for split in range(1, len(value)):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+        emissions: list[object] = []
+
+        with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+            _feed_parser_to_finish(parser, emissions, value[:split], value[split:])
+
+        assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == prefix
+
+
 def test_stream_parser_preserves_tool_calls_phrase_without_json_separator() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
     text = 'The label "tool calls": remains ordinary prose.'

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -54,6 +54,16 @@ def _request(**overrides: object) -> ChatCompletionRequest:
     return ChatCompletionRequest.model_validate(payload)
 
 
+def _feed_parser_to_finish(
+    parser: ToolCallStreamParser,
+    emissions: list[object],
+    *chunks: str,
+) -> None:
+    for chunk in chunks:
+        emissions.extend(parser.feed(chunk))
+    emissions.extend(parser.finish())
+
+
 def test_build_prompt_preserves_openai_transcript_and_tools() -> None:
     request = _request(
         messages=[
@@ -392,9 +402,8 @@ def test_stream_parser_handles_every_marker_split() -> None:
 
     for split in range(1, len(value)):
         parser = ToolCallStreamParser(frozenset({"weather"}))
-        emissions = parser.feed(value[:split])
-        emissions.extend(parser.feed(value[split:]))
-        emissions.extend(parser.finish())
+        emissions: list[object] = []
+        _feed_parser_to_finish(parser, emissions, value[:split], value[split:])
 
         text = "".join(
             emission.text for emission in emissions if isinstance(emission, TextEmission)
@@ -437,9 +446,13 @@ def test_stream_parser_handles_every_close_marker_split() -> None:
 
     for split in range(1, len(TOOL_CALL_CLOSE)):
         parser = ToolCallStreamParser(frozenset({"weather"}))
-        emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE[:split]}")
-        emissions.extend(parser.feed(TOOL_CALL_CLOSE[split:]))
-        emissions.extend(parser.finish())
+        emissions: list[object] = []
+        _feed_parser_to_finish(
+            parser,
+            emissions,
+            f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE[:split]}",
+            TOOL_CALL_CLOSE[split:],
+        )
 
         assert len(emissions) == 1
         assert isinstance(emissions[0], ToolCallEmission)
@@ -851,6 +864,50 @@ def test_stream_parser_rejects_incomplete_reordered_message_json() -> None:
     assert parser.feed('{ "content":') == []
     with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
         parser.finish()
+
+
+@pytest.mark.parametrize("separator", [" ", "  ", "\t\n", "_"])
+def test_stream_parser_stops_mangled_openai_tool_calls_before_they_leak(
+    separator: str,
+) -> None:
+    prefix = 'safe answer (reset|", '
+    value = (
+        prefix + f'"tool{separator}calls":"id":"call_1","type":"function","function":'
+        '("name":"weather","arguments":("city":"Gdansk"))'
+    )
+
+    for split in range(1, len(value)):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+        emissions: list[object] = []
+
+        with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+            _feed_parser_to_finish(parser, emissions, value[:split], value[split:])
+
+        assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == prefix
+
+
+def test_stream_parser_preserves_tool_calls_phrase_without_json_separator() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    text = 'The label "tool calls": remains ordinary prose.'
+
+    emissions: list[object] = []
+    for char in text:
+        emissions.extend(parser.feed(char))
+    emissions.extend(parser.finish())
+
+    assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == text
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        '"toolX',
+        '"tool_bad',
+        '"tool calls":"id":"call_x',
+    ],
+)
+def test_mangled_tool_calls_prefix_rejects_non_prefixes(value: str) -> None:
+    assert protocol._is_mangled_tool_calls_prefix(value) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1263,7 +1263,7 @@ async def test_runner_reuses_a_warm_session_without_reinitializing(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_runner_retunes_a_warm_session_to_the_requested_model(tmp_path: Path) -> None:
+async def test_runner_retunes_a_warm_session_to_the_requested_effort(tmp_path: Path) -> None:
     client = FakeClient([TurnComplete()])
     runner = DroidRunner(
         droid_path="droid",
@@ -1271,7 +1271,7 @@ async def test_runner_retunes_a_warm_session_to_the_requested_model(tmp_path: Pa
         client_factory=cast("Any", lambda _path, _cwd: client),
     )
     warm = WarmSession(
-        key=SessionKey(model_id=None, reasoning_effort=None),
+        key=SessionKey(model_id="gpt-5.4", reasoning_effort="high"),
         client=cast("Any", client),
         transport=None,
         session_id="session-1",
@@ -1305,7 +1305,22 @@ async def test_runner_retunes_a_warm_session_to_the_requested_model(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_runner_retune_keeps_the_droid_default_effort(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("warmed_model", "requested_model"),
+    [
+        ("gpt-5.4", "kimi-k3"),
+        ("kimi-k3", "gpt-5.4"),
+        ("kimi-k2.6", "kimi-k3"),
+        ("gpt-5.4", "glm-5.2"),
+        ("claude-opus-5", "gemini-3.1-pro"),
+    ],
+)
+async def test_runner_rejects_a_cross_model_warm_session(
+    tmp_path: Path,
+    warmed_model: str,
+    requested_model: str,
+) -> None:
+    """No model pair may retune, whatever family either side belongs to."""
     client = FakeClient([TurnComplete()])
     runner = DroidRunner(
         droid_path="droid",
@@ -1313,30 +1328,28 @@ async def test_runner_retune_keeps_the_droid_default_effort(tmp_path: Path) -> N
         client_factory=cast("Any", lambda _path, _cwd: client),
     )
     warm = WarmSession(
-        key=SessionKey(model_id=None, reasoning_effort=None),
+        key=SessionKey(model_id=warmed_model, reasoning_effort="high"),
         client=cast("Any", client),
         transport=None,
         session_id="session-1",
         created_at=0.0,
     )
 
-    events = [
-        event
-        async for event in runner.run(
-            _request(model="glm-5.2", reasoning_effort=None, warm_session=warm),
-        )
-    ]
+    with pytest.raises(RunnerError, match="cannot be repointed"):
+        _ = [
+            event
+            async for event in runner.run(
+                _request(model=requested_model, reasoning_effort="high", warm_session=warm),
+            )
+        ]
 
-    assert isinstance(events[-1], RunComplete)
-    assert client.rpc_requests[0][1] == {
-        "modelId": "glm-5.2",
-        "interactionMode": "auto",
-        "autonomyLevel": "off",
-    }
+    assert client.rpc_requests == []
+    assert client.closed is True
 
 
 @pytest.mark.asyncio
-async def test_runner_rejects_a_cross_model_warm_session_for_kimi(tmp_path: Path) -> None:
+async def test_runner_rejects_a_warm_session_for_the_droid_default_model(tmp_path: Path) -> None:
+    """Droid's own default cannot be restored on a session pinned to a model."""
     client = FakeClient([TurnComplete()])
     runner = DroidRunner(
         droid_path="droid",
@@ -1355,7 +1368,7 @@ async def test_runner_rejects_a_cross_model_warm_session_for_kimi(tmp_path: Path
         _ = [
             event
             async for event in runner.run(
-                _request(model="kimi-k3", reasoning_effort="high", warm_session=warm),
+                _request(reasoning_effort="high", warm_session=warm),
             )
         ]
 
@@ -1446,17 +1459,12 @@ async def test_runner_keeps_other_sdk_failures_as_bridge_errors(tmp_path: Path) 
 def test_session_key_retuning_requires_an_expressible_target() -> None:
     default = SessionKey(model_id=None, reasoning_effort=None)
     explicit = SessionKey(model_id="gpt-5.4", reasoning_effort="high")
-    kimi = SessionKey(model_id="kimi-k3", reasoning_effort="high")
 
-    assert explicit.can_retune_from(default) is True
     assert explicit.can_retune_from(SessionKey(model_id="gpt-5.4", reasoning_effort="low")) is True
+    assert explicit.can_retune_from(SessionKey(model_id="gpt-5.4", reasoning_effort=None)) is True
     assert SessionKey(model_id="gpt-5.4", reasoning_effort=None).can_retune_from(explicit) is False
     assert default.can_retune_from(explicit) is False
-    assert SessionKey(model_id="glm-5.2", reasoning_effort="high").can_retune_from(explicit) is True
-    assert kimi.can_retune_from(explicit) is False
-    assert explicit.can_retune_from(kimi) is False
-    assert kimi.can_retune_from(SessionKey(model_id="kimi-k2.6", reasoning_effort="high")) is False
-    assert kimi.can_retune_from(SessionKey(model_id="kimi-k3", reasoning_effort="low")) is True
+    assert explicit.can_retune_from(default) is False
 
 
 @pytest.mark.parametrize(
@@ -1475,16 +1483,25 @@ def test_model_family_is_coarse_and_stable(model: str, expected: str) -> None:
     assert model_family(model) == expected
 
 
-def test_fresh_session_families_follow_the_shared_model_family_table() -> None:
-    """A family spelling telemetry groups as Kimi cannot escape the guard."""
-    explicit = SessionKey(model_id="gpt-5.4", reasoning_effort="high")
+def test_only_the_reasoning_effort_retunes_for_every_family() -> None:
+    """A retune keeps the template Droid installed, so no model pair qualifies."""
+    models = (
+        "gpt-5.4",
+        "gemini-3.1-pro",
+        "claude-opus-5",
+        "qwen3-coder",
+        "kimi-k2.6",
+        "kimi-k3",
+        "deepseek-v3.1",
+        "glm-5.2",
+        "custom-model",
+    )
 
-    for model_id in ("kimi-k3", "kimi_k4", "KIMI-K5"):
-        assert model_family(model_id) == "kimi"
-        assert (
-            SessionKey(model_id=model_id, reasoning_effort="high").can_retune_from(explicit)
-            is False
-        )
+    for warmed in models:
+        for requested in models:
+            assert SessionKey(model_id=requested, reasoning_effort="low").can_retune_from(
+                SessionKey(model_id=warmed, reasoning_effort="high")
+            ) is (warmed == requested)
 
 
 @pytest.mark.asyncio

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1304,7 +1304,7 @@ async def test_runner_retunes_a_warm_session_to_the_requested_model(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_runner_retune_keeps_the_droid_default_effort(tmp_path: Path) -> None:
+async def test_runner_rejects_a_cross_model_warm_session_for_kimi(tmp_path: Path) -> None:
     client = FakeClient([TurnComplete()])
     runner = DroidRunner(
         droid_path="droid",
@@ -1312,26 +1312,23 @@ async def test_runner_retune_keeps_the_droid_default_effort(tmp_path: Path) -> N
         client_factory=cast("Any", lambda _path, _cwd: client),
     )
     warm = WarmSession(
-        key=SessionKey(model_id=None, reasoning_effort=None),
+        key=SessionKey(model_id="gpt-5.4", reasoning_effort="high"),
         client=cast("Any", client),
         transport=None,
         session_id="session-1",
         created_at=0.0,
     )
 
-    events = [
-        event
-        async for event in runner.run(
-            _request(model="glm-5.2", reasoning_effort=None, warm_session=warm),
-        )
-    ]
+    with pytest.raises(RunnerError, match="cannot be repointed"):
+        _ = [
+            event
+            async for event in runner.run(
+                _request(model="kimi-k3", reasoning_effort="high", warm_session=warm),
+            )
+        ]
 
-    assert isinstance(events[-1], RunComplete)
-    assert client.rpc_requests[0][1] == {
-        "modelId": "glm-5.2",
-        "interactionMode": "auto",
-        "autonomyLevel": "off",
-    }
+    assert client.rpc_requests == []
+    assert client.closed is True
 
 
 @pytest.mark.asyncio
@@ -1417,11 +1414,15 @@ async def test_runner_keeps_other_sdk_failures_as_bridge_errors(tmp_path: Path) 
 def test_session_key_retuning_requires_an_expressible_target() -> None:
     default = SessionKey(model_id=None, reasoning_effort=None)
     explicit = SessionKey(model_id="gpt-5.4", reasoning_effort="high")
+    kimi = SessionKey(model_id="kimi-k3", reasoning_effort="high")
 
     assert explicit.can_retune_from(default) is True
-    assert SessionKey(model_id="glm-5.2", reasoning_effort=None).can_retune_from(default) is True
+    assert explicit.can_retune_from(SessionKey(model_id="gpt-5.4", reasoning_effort="low")) is True
+    assert SessionKey(model_id="gpt-5.4", reasoning_effort=None).can_retune_from(explicit) is False
     assert default.can_retune_from(explicit) is False
-    assert SessionKey(model_id="glm-5.2", reasoning_effort=None).can_retune_from(explicit) is False
+    assert SessionKey(model_id="glm-5.2", reasoning_effort="high").can_retune_from(explicit) is True
+    assert kimi.can_retune_from(explicit) is False
+    assert explicit.can_retune_from(kimi) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -53,6 +53,7 @@ from factory_droid_openai.runner import (
     _create_client,
     _ManagedProcessTransport,
     _run_until,
+    model_family,
     sdk_error,
 )
 
@@ -1304,6 +1305,37 @@ async def test_runner_retunes_a_warm_session_to_the_requested_model(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_runner_retune_keeps_the_droid_default_effort(tmp_path: Path) -> None:
+    client = FakeClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort=None),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+    )
+
+    events = [
+        event
+        async for event in runner.run(
+            _request(model="glm-5.2", reasoning_effort=None, warm_session=warm),
+        )
+    ]
+
+    assert isinstance(events[-1], RunComplete)
+    assert client.rpc_requests[0][1] == {
+        "modelId": "glm-5.2",
+        "interactionMode": "auto",
+        "autonomyLevel": "off",
+    }
+
+
+@pytest.mark.asyncio
 async def test_runner_rejects_a_cross_model_warm_session_for_kimi(tmp_path: Path) -> None:
     client = FakeClient([TurnComplete()])
     runner = DroidRunner(
@@ -1423,6 +1455,36 @@ def test_session_key_retuning_requires_an_expressible_target() -> None:
     assert SessionKey(model_id="glm-5.2", reasoning_effort="high").can_retune_from(explicit) is True
     assert kimi.can_retune_from(explicit) is False
     assert explicit.can_retune_from(kimi) is False
+    assert kimi.can_retune_from(SessionKey(model_id="kimi-k2.6", reasoning_effort="high")) is False
+    assert kimi.can_retune_from(SessionKey(model_id="kimi-k3", reasoning_effort="low")) is True
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("factory-droid", "factory_default"),
+        ("gpt-5.4", "gpt"),
+        ("gemini-3.1-pro", "gemini"),
+        ("claude-sonnet", "claude"),
+        ("custom-model", "other"),
+        ("kimi-k3", "kimi"),
+        ("KIMI_K4 ", "kimi"),
+    ],
+)
+def test_model_family_is_coarse_and_stable(model: str, expected: str) -> None:
+    assert model_family(model) == expected
+
+
+def test_fresh_session_families_follow_the_shared_model_family_table() -> None:
+    """A family spelling telemetry groups as Kimi cannot escape the guard."""
+    explicit = SessionKey(model_id="gpt-5.4", reasoning_effort="high")
+
+    for model_id in ("kimi-k3", "kimi_k4", "KIMI-K5"):
+        assert model_family(model_id) == "kimi"
+        assert (
+            SessionKey(model_id=model_id, reasoning_effort="high").can_retune_from(explicit)
+            is False
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -56,7 +56,7 @@ def test_metrics_snapshot_contains_only_telemetry_dimensions() -> None:
     metrics.increment_model_quarantines()
     metrics.increment_warm_hits()
     metrics.increment_warm_misses()
-    metrics.increment_warm_retunes()
+    metrics.increment_warm_retunes("effort")
     metrics.increment_warm_failures()
 
     snapshot = metrics.telemetry_snapshot()


### PR DESCRIPTION
## Summary

Contain malformed tool-call output before it reaches a client, stop a
continuation from running under settings it was not created with, and make
warm-pool model switches safe to reuse.

### Protocol

- detect mangled OpenAI `tool_calls` output before client emission, with or
  without a `"call_..."` id, in any case, and with `_` or whitespace in the key
- hold partial matches back across stream chunk boundaries, emit the prose
  already verified, then fail closed with `finish_reason="stop"`
- drop the tool-call format from the bridge notice: anything it named would
  itself be tool-call-shaped text in assistant content, so recovery is the
  client's retry, not the model's next turn

### Warm pool

- every model change now waits for a fresh or exact-match session, because a
  retune swaps the model id while the session keeps the tool-call template it
  was initialized with
- a family denylist would not be correct either: the template belongs to the
  model, and Kimi K2 frames calls in `<|tool_calls_section_begin|>` where K3
  uses `<|open|>tools<|sep|>`
- retune therefore applies to the reasoning effort alone, and the retune
  counter carries `reason="effort"` so the series stays unambiguous

### Sessions

- track the continuation model and reasoning effort together, rejecting a
  mismatch with HTTP `400` instead of answering under stale settings
- settle that mismatch before the transcript is serialized, so an oversized
  body cannot mask it behind a `413` and a matching request pays no extra
  prompt work
- log every continuity rejection, matching the sibling rejection paths

### Docker

- support a read-only mount of one `/home/droid/.factory/settings.json`
- document that the bridge pins the tool and autonomy surface, not every
  setting the mounted file declares

### E2E matrix

- serialized warm-pool model-switch ring after the parallel per-model cases, in
  both transport modes, with `--switch-settle-seconds`
- opt-in continuation-switch phase behind `--test-session-continuity`; with the
  phase opted out it no longer primes one real completion per model pair
- assert the harness detector and the bridge parser agree on what counts as
  mangled, so the report cannot flag a shape the bridge lets through

### Contract

- regenerate `openapi.json` for the locked FastAPI and Pydantic versions
- add a CI step that regenerates the spec and fails on any diff; validating the
  committed file could not catch a file that no longer matched its routes

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1201
  passed, 100% branch coverage
- `uv run python scripts/generate_openapi.py` - no diff
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
- `podman compose config` - base config and read-only `settings.json` mount
  passed with Podman 6.0.2 and podman-compose 1.6.0

## Known limits

- The mangled-output guard is off when `response_format` is set, because
  structured output legitimately returns JSON. Tools and `response_format`
  cannot be combined unless `tool_choice` is `"none"`, so no tool schema
  reaches the model on that path.
- Dropping cross-model retunes costs the fast path on the first request for a
  model the pool holds no session for: it pays the 2.4-3.2 s startup instead of
  a 4-18 ms settings update. The pool keys on the settings recent traffic used,
  so steady multi-model traffic converges back on exact matches. Set
  `FACTORY_DROID_OPENAI_WARM_SESSIONS=0` to disable warm reuse entirely.
