### PR TITLE
fix(protocol): keep mangled tool-call detection active after plain JSON

### DIFF
--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -412,11 +412,16 @@ class ToolCallStreamParser:
         detect_message_json = (
             self._parse_message_json if parse_message_json is None else parse_message_json
         )
+        # Mangled tool-call detection stays tied to the parser's init setting,
+        # not the per-call flag: _emit_plain_json disables message-JSON
+        # re-detection in its trailing but a transcript echo there still fails
+        # closed.
+        detect_mangled = self._parse_message_json
         value = self._text_tail + chunk
         self._text_tail = ""
         found = find_open_marker(value)
         message_match = _MESSAGE_JSON_PATTERN.search(value) if detect_message_json else None
-        mangled_match = _MANGLED_TOOL_CALLS_PATTERN.search(value) if detect_message_json else None
+        mangled_match = _MANGLED_TOOL_CALLS_PATTERN.search(value) if detect_mangled else None
         emissions: list[ProtocolEmission] = []
         if (
             message_match is not None
@@ -460,8 +465,8 @@ class ToolCallStreamParser:
             _partial_marker_suffix_length(value, dialect.open_marker) for dialect in MARKER_DIALECTS
         )
         if detect_message_json:
-            partial_message = _partial_message_json_prefix_length(value)
-            held = max(held, partial_message)
+            held = max(held, _partial_message_json_prefix_length(value))
+        if detect_mangled:
             held = max(held, _partial_mangled_tool_calls_prefix_length(value))
         if self._saw_tool_call:
             held = max(held, len(self._trailing_partial(value)))

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -911,6 +911,42 @@ def test_stream_parser_stops_mangled_tool_calls_without_an_id_or_lower_case(
         assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == prefix
 
 
+@pytest.mark.parametrize("separator", ["_", " "])
+def test_stream_parser_detects_mangled_tool_calls_after_plain_json(separator: str) -> None:
+    # A non-tool-call assistant message followed by a mangled tool_calls echo
+    # in the same chunk: _emit_plain_json disables message-JSON re-detection
+    # in the trailing but mangled detection must stay active.
+    plain = '{"role":"assistant","content":"hi"}'
+    mangled = (
+        f'"tool{separator}calls":"call_1","type":"function","function":'
+        '("name":"weather","arguments":("city":"Gdansk"))'
+    )
+    value = f"{plain}{mangled}"
+
+    for split in range(1, len(value)):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+        emissions: list[object] = []
+
+        with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+            _feed_parser_to_finish(parser, emissions, value[:split], value[split:])
+
+        assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == plain
+
+
+def test_stream_parser_skips_mangled_detection_when_message_json_disabled() -> None:
+    # Structured-output mode disables message-JSON detection entirely, which
+    # also disables mangled tool-call detection.
+    parser = ToolCallStreamParser(frozenset({"weather"}), parse_message_json=False)
+    text = '"tool_calls":"call_1","function":("name":"weather")'
+
+    emissions: list[object] = []
+    for char in text:
+        emissions.extend(parser.feed(char))
+    emissions.extend(parser.finish())
+
+    assert "".join(item.text for item in emissions if isinstance(item, TextEmission)) == text
+
+
 def test_stream_parser_preserves_tool_calls_phrase_without_json_separator() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
     text = 'The label "tool calls": remains ordinary prose.'


### PR DESCRIPTION
## Problem

`_emit_plain_json` passed `parse_message_json=False` to `_consume_text` for trailing after a non-tool-call message JSON. This also disabled mangled tool-call detection. A Kimi-style transcript echo in that trailing was emitted as text instead of failing closed.

## Fix

Split `detect_mangled` from `detect_message_json` in `_consume_text`:
- `detect_message_json` — controlled by per-call flag (disables message-JSON re-detection in trailing)
- `detect_mangled` — tied to parser init setting `self._parse_message_json`

Mangled tool-call detection stays active whenever the parser was initialized with `parse_message_json=True`. Structured-output mode (`parse_message_json=False` at init) still disables both, preserving existing behavior.

## Tests

- `test_stream_parser_detects_mangled_tool_calls_after_plain_json` — parametrized `_`/space separator, all split points. Non-tool-call assistant JSON + mangled echo. Asserts `MalformedToolCallError` raised, plain JSON emitted, mangled tail never reaches client.
- `test_stream_parser_skips_mangled_detection_when_message_json_disabled` — `parse_message_json=False` (structured output mode). Mangled pattern emitted as text, no error. Covers `detect_mangled=False` branch.

## Validation

- ruff check: pass
- ruff format: pass
- mypy strict: pass
- pytest: 1204 passed
- coverage: 100%
- openapi-spec-validator: OK
- uv lock --check: pass
- uv build: pass