### PR TITLE
fix(protocol): recover partial closing markers

### DIFF
--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -240,6 +240,10 @@ def _tool_scenarios() -> list[Scenario]:
                 ],
                 "tools": [_CLOCK_TOOL],
             },
+            # A model may trust the supplied result or retry the call with the
+            # missing city. Both prove the blank argument survived the bridge.
+            expect_finish=("stop", "tool_calls"),
+            expect_content=False,
         ),
     ]
 

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -527,6 +527,24 @@ def _decode_json_object(raw: str) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
+def _decode_json_arg_value_close(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> list[dict[str, Any]] | None:
+    """Repairs strict JSON followed by GLM's mismatched value-close token."""
+    stripped = body.strip()
+    if not stripped.endswith(_ARG_VALUE_CLOSE):
+        return None
+    candidate = stripped[: -len(_ARG_VALUE_CLOSE)].rstrip()
+    try:
+        parsed = parse_strict_json(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict) or parsed.get("name") not in allowed_tool_names:
+        return None
+    return [parsed]
+
+
 def _decode_arg_key_value(
     body: str,
     allowed_tool_names: frozenset[str],  # noqa: ARG001 - uniform decoder signature
@@ -787,6 +805,7 @@ PAYLOAD_DECODERS: tuple[PayloadDecoder, ...] = (
     PayloadDecoder("harmony_commentary", _decode_harmony_commentary),
     PayloadDecoder("deepseek_calls", _decode_deepseek_calls),
     PayloadDecoder("function_parameter_tags", _decode_function_parameter_tags),
+    PayloadDecoder("json_arg_value_close", _decode_json_arg_value_close),
     PayloadDecoder("arg_key_value", _decode_arg_key_value),
     PayloadDecoder("python_call", _decode_python_call),
     PayloadDecoder("arg_key_value_repair", _decode_arg_key_value_repair),

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -676,7 +676,8 @@ class ToolCallStreamParser:
 
     def _recover_unclosed_tool_call(self) -> list[dict[str, Any]] | None:
         """Repairs a tool call whose closing marker never arrived."""
-        payload = "".join(self._payload_chunks) + self._close_tail
+        # A held suffix is a verified close-marker prefix, not payload data.
+        payload = "".join(self._payload_chunks)
         try:
             objects = self._tool_payload_objects(payload)
         except ProtocolError:

--- a/tests/fixtures/events/tool-auto--glm-5-2-stream.jsonl
+++ b/tests/fixtures/events/tool-auto--glm-5-2-stream.jsonl
@@ -1,0 +1,8 @@
+{"kind": "meta", "scenario": "tool_auto", "stream": true, "recorded_model": "glm-5.2", "expect_verdict": "pass"}
+{"kind": "session_started"}
+{"kind": "status", "state": "streaming_assistant_message"}
+{"kind": "usage", "usage": {"prompt_tokens": 709, "completion_tokens": 27, "total_tokens": 736, "prompt_tokens_details": {"cached_tokens": 0}}}
+{"kind": "usage", "usage": {"prompt_tokens": 709, "completion_tokens": 27, "total_tokens": 736, "prompt_tokens_details": {"cached_tokens": 0}}}
+{"kind": "text_delta", "text": "<tool_call>{\"name\":\"weather\",\"arguments\":{\"city\":\"Gdansk\"}}</arg_value>"}
+{"kind": "status", "state": "idle"}
+{"kind": "run_complete", "usage": {"prompt_tokens": 709, "completion_tokens": 27, "total_tokens": 736, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -834,6 +834,53 @@ async def test_streaming_recovers_tool_call_without_close_marker(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_partial_close_marker_recovers_tool_call(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
+                f"{TOOL_CALL_CLOSE[:-1]}"
+            ),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=stream,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith("data: ") and not line.endswith("[DONE]")
+        ]
+        choice = events[-1]["choices"][0]
+        tool_calls = [
+            call for event in events for call in event["choices"][0]["delta"].get("tool_calls", [])
+        ]
+    else:
+        choice = response.json()["choices"][0]
+        tool_calls = choice["message"]["tool_calls"]
+    assert choice["finish_reason"] == "tool_calls"
+    assert len(tool_calls) == 1
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "Hel"}
+
+
+@pytest.mark.asyncio
 async def test_streaming_tool_call_does_not_need_turn_complete(tmp_path: Path) -> None:
     runner = FakeRunner(
         [

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -835,15 +835,18 @@ async def test_streaming_recovers_tool_call_without_close_marker(tmp_path: Path)
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stream", [False, True])
-async def test_partial_close_marker_recovers_tool_call(
+@pytest.mark.parametrize("close_prefix_length", range(len(TOOL_CALL_CLOSE)))
+async def test_every_partial_close_marker_recovers_tool_call(
     tmp_path: Path,
     stream: bool,
+    close_prefix_length: int,
 ) -> None:
     runner = FakeRunner(
         [
+            ReasoningDelta("planning"),
             TextDelta(
                 f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}'
-                f"{TOOL_CALL_CLOSE[:-1]}"
+                f"{TOOL_CALL_CLOSE[:close_prefix_length]}"
             ),
             RunComplete(Usage()),
         ]
@@ -872,12 +875,19 @@ async def test_partial_close_marker_recovers_tool_call(
         tool_calls = [
             call for event in events for call in event["choices"][0]["delta"].get("tool_calls", [])
         ]
+        reasoning = "".join(
+            event["choices"][0]["delta"].get("reasoning", "")
+            for event in events
+            if event["choices"]
+        )
     else:
         choice = response.json()["choices"][0]
         tool_calls = choice["message"]["tool_calls"]
+        reasoning = choice["message"]["reasoning"]
     assert choice["finish_reason"] == "tool_calls"
     assert len(tool_calls) == 1
     assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "Hel"}
+    assert reasoning == "planning"
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -72,6 +72,31 @@ def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleT
     assert len(e2e.continuation_switch_scenarios(streaming=False)) == 1
 
 
+def test_blank_argument_scenarios_accept_answer_or_tool_retry(e2e: ModuleType) -> None:
+    scenarios = [
+        scenario for scenario in e2e.scenarios() if scenario.name == "tool_blank_arguments"
+    ]
+
+    assert {scenario.stream for scenario in scenarios} == {False, True}
+    for scenario in scenarios:
+        answered = _observation(
+            e2e,
+            finish_reason="stop",
+            content_chars=12,
+            stream_done=scenario.stream,
+        )
+        retried = _observation(
+            e2e,
+            finish_reason="tool_calls",
+            tool_calls=1,
+            content_chars=0,
+            stream_done=scenario.stream,
+        )
+
+        assert e2e.classify(scenario, answered)[0] == e2e.SUCCESS
+        assert e2e.classify(scenario, retried)[0] == e2e.SUCCESS
+
+
 def test_contract_satisfied_is_a_pass(e2e: ModuleType) -> None:
     verdict, _ = e2e.classify(_scenario(e2e), _observation(e2e))
 

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -229,6 +229,94 @@ async def test_official_openai_client_parses_function_tool_call(
 
 
 @pytest.mark.asyncio
+async def test_official_openai_client_recovers_partial_tool_close(
+    tmp_path: Path,
+) -> None:
+    marker = (
+        f'{TOOL_CALL_OPEN}{{"name":"get_weather","arguments":{{"city":"Gdansk"}}}}'
+        f"{TOOL_CALL_CLOSE[:-1]}"
+    )
+    runner = ScriptedRunner([TextDelta(marker), RunComplete(Usage())])
+    client, http_client = _sdk_client(tmp_path, runner)
+    async with http_client:
+        completion = await client.chat.completions.create(
+            model="factory-droid",
+            messages=[{"role": "user", "content": "Check the weather"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+
+    message = completion.choices[0].message
+    assert completion.choices[0].finish_reason == "tool_calls"
+    assert message.content is None
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    tool_call = message.tool_calls[0]
+    assert tool_call.type == "function"
+    assert tool_call.function.name == "get_weather"
+    assert tool_call.function.arguments == '{"city":"Gdansk"}'
+
+
+@pytest.mark.asyncio
+async def test_official_openai_stream_recovers_partial_tool_close(
+    tmp_path: Path,
+) -> None:
+    marker = (
+        f'{TOOL_CALL_OPEN}{{"name":"get_weather","arguments":{{"city":"Gdansk"}}}}'
+        f"{TOOL_CALL_CLOSE[:-1]}"
+    )
+    runner = ScriptedRunner([TextDelta(marker), RunComplete(Usage())])
+    client, http_client = _sdk_client(tmp_path, runner)
+    async with http_client:
+        stream = await client.chat.completions.create(
+            model="factory-droid",
+            messages=[{"role": "user", "content": "Check the weather"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            stream=True,
+        )
+        chunks = [chunk async for chunk in stream]
+
+    tool_calls = [
+        call
+        for chunk in chunks
+        for choice in chunk.choices
+        for call in choice.delta.tool_calls or ()
+    ]
+    finish_reasons = [
+        choice.finish_reason
+        for chunk in chunks
+        for choice in chunk.choices
+        if choice.finish_reason is not None
+    ]
+    assert finish_reasons == ["tool_calls"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function is not None
+    assert tool_calls[0].function.name == "get_weather"
+    assert tool_calls[0].function.arguments == '{"city":"Gdansk"}'
+
+
+@pytest.mark.asyncio
 async def test_official_openai_client_parses_payload_limit_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1773,6 +1773,23 @@ def test_stream_parser_translates_kimi_sections() -> None:
     assert json.loads(emissions[0].arguments) == {"city": "Gdansk"}
 
 
+def test_stream_parser_recovers_kimi_call_with_partial_section_close() -> None:
+    for split in range(1, len(_KIMI_SECTION_CLOSE)):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+
+        assert (
+            parser.feed(
+                f"{_KIMI_SECTION_OPEN}{_KIMI_CALL}{_KIMI_SECTION_CLOSE[:split]}",
+            )
+            == []
+        )
+        emissions = parser.finish()
+
+        assert len(emissions) == 1
+        assert isinstance(emissions[0], ToolCallEmission)
+        assert json.loads(emissions[0].arguments) == {"city": "Gdansk"}
+
+
 def test_stream_parser_translates_multiple_kimi_calls() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=2)
 
@@ -2314,6 +2331,38 @@ def test_stream_parser_recovers_tool_call_without_close_marker() -> None:
     assert len(emissions) == 1
     assert isinstance(emissions[0], ToolCallEmission)
     assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+def test_stream_parser_recovers_tool_call_with_partial_close_marker() -> None:
+    payload = '{"name":"weather","arguments":{"city":"Hel"}}'
+
+    for split in range(1, len(TOOL_CALL_CLOSE)):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+
+        assert (
+            parser.feed(
+                f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE[:split]}",
+            )
+            == []
+        )
+        emissions = parser.finish()
+
+        assert len(emissions) == 1
+        assert isinstance(emissions[0], ToolCallEmission)
+        assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+def test_stream_parser_counts_partial_close_marker_in_incomplete_payload() -> None:
+    payload = '{"name":"weather","arguments":{"city":"Hel"'
+    partial_close = TOOL_CALL_CLOSE[:-1]
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}{partial_close}")
+
+    with pytest.raises(IncompleteToolCallError) as excinfo:
+        parser.finish()
+
+    assert excinfo.value.payload_bytes == len((payload + partial_close).encode("utf-8"))
 
 
 def test_recovered_tool_call_satisfies_a_required_tool_call() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2352,6 +2352,53 @@ def test_stream_parser_recovers_tool_call_with_partial_close_marker() -> None:
         assert json.loads(emissions[0].arguments) == {"city": "Hel"}
 
 
+@pytest.mark.parametrize("close_marker", ["", TOOL_CALL_CLOSE])
+def test_stream_parser_recovers_json_with_glm_value_close(close_marker: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}'
+        f"</arg_value>{close_marker}"
+    )
+
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"city": "Gdansk"}
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "</arg_key>",
+        "</arg_value>junk",
+        "junk</arg_value>",
+        "</arg_value></arg_value>",
+    ],
+)
+def test_stream_parser_rejects_other_json_close_residue(suffix: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    parser.feed(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}{suffix}')
+
+    with pytest.raises(IncompleteToolCallError):
+        parser.finish()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "[]</arg_value>",
+        '{"name":"unknown","arguments":{}}</arg_value>',
+    ],
+)
+def test_stream_parser_rejects_invalid_glm_value_close_payloads(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    with pytest.raises(IncompleteToolCallError):
+        parser.finish()
+
+
 def test_stream_parser_counts_partial_close_marker_in_incomplete_payload() -> None:
     payload = '{"name":"weather","arguments":{"city":"Hel"'
     partial_close = TOOL_CALL_CLOSE[:-1]

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -85,6 +85,11 @@ _DECODER_FIXTURES = (
         {"city": "Gdansk"},
     ),
     RecoveryFixture(
+        "json_arg_value_close",
+        _NATIVE_CALL + "</arg_value>",
+        {"city": "Gdansk"},
+    ),
+    RecoveryFixture(
         "arg_key_value",
         "weather<arg_key>city</arg_key><arg_value>Gdansk</arg_value>",
         {"city": "Gdansk"},
@@ -224,13 +229,14 @@ def test_every_decoder_recovers_from_every_partial_native_close_marker(
     fixture: RecoveryFixture,
 ) -> None:
     for prefix_length in range(len(TOOL_CALL_CLOSE)):
-        variants: list[str] = []
-        parser = ToolCallStreamParser(
-            frozenset({"weather"}),
-            trace_payload=_variant_tracer(variants),
-        )
-        emissions = parser.feed(TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE[:prefix_length])
-        assert emissions == []
+        stream = TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE[:prefix_length]
+        for chunk_size in _CHUNK_SIZES:
+            variants: list[str] = []
+            parser = ToolCallStreamParser(
+                frozenset({"weather"}),
+                trace_payload=_variant_tracer(variants),
+            )
+            assert _feed_in_chunks(parser, stream, chunk_size) == []
 
-        _assert_tool_call(parser.finish(), fixture.expected_arguments)
-        assert variants == [fixture.name]
+            _assert_tool_call(parser.finish(), fixture.expected_arguments)
+            assert variants == [fixture.name]

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from factory_droid_openai.dialects import MARKER_DIALECTS, PAYLOAD_DECODERS, MarkerDialect
+from factory_droid_openai.protocol import (
+    TOOL_CALL_CLOSE,
+    TOOL_CALL_OPEN,
+    IncompleteToolCallError,
+    ProtocolError,
+    TextEmission,
+    ToolCallEmission,
+    ToolCallStreamParser,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+_DS_BAR = "\uff5c"
+_DS_BLOCK = "\u2581"
+_DEEPSEEK_CALL_OPEN = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}begin{_DS_BAR}>"
+_DEEPSEEK_CALL_CLOSE = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}end{_DS_BAR}>"
+_DEEPSEEK_SEP = f"<{_DS_BAR}tool{_DS_BLOCK}sep{_DS_BAR}>"
+
+_PIPE_TAG_CALL = (
+    '<|open|>call tool="weather" index="1"<|sep|>'
+    '<|open|>argument key="city" type="string"<|sep|>Gdansk<|close|>argument<|sep|>'
+    "<|close|>call<|sep|>"
+)
+_KIMI_CALL = (
+    '<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{"city":"Gdansk"}'
+    "<|tool_call_end|>"
+)
+_HARMONY_CALL = 'functions.weather <|constrain|>json<|message|>{"city":"Gdansk"}'
+_DEEPSEEK_CALL = (
+    f'{_DEEPSEEK_CALL_OPEN}weather{_DEEPSEEK_SEP}{{"city":"Gdansk"}}{_DEEPSEEK_CALL_CLOSE}'
+)
+_INTERNLM_CALL = '{"name":"weather","parameters":{"city":"Gdansk"}}'
+_NATIVE_CALL = '{"name":"weather","arguments":{"city":"Gdansk"}}'
+_CHUNK_SIZES = (1, 2, 5, 13, 64)
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryFixture:
+    name: str
+    payload: str
+    expected_arguments: dict[str, Any]
+    diagnostic_tool_name: str | None = None
+
+
+_MARKER_FIXTURES = {
+    fixture.name: fixture
+    for fixture in (
+        RecoveryFixture(
+            "native",
+            _NATIVE_CALL,
+            {"city": "Gdansk"},
+            diagnostic_tool_name="weather",
+        ),
+        RecoveryFixture("pipe_tag", _PIPE_TAG_CALL, {"city": "Gdansk"}),
+        RecoveryFixture("kimi_k2", _KIMI_CALL, {"city": "Gdansk"}),
+        RecoveryFixture("harmony", _HARMONY_CALL, {"city": "Gdansk"}),
+        RecoveryFixture("deepseek", _DEEPSEEK_CALL, {"city": "Gdansk"}),
+        RecoveryFixture(
+            "internlm2",
+            _INTERNLM_CALL,
+            {"city": "Gdansk"},
+            diagnostic_tool_name="weather",
+        ),
+    )
+}
+
+_DECODER_FIXTURES = (
+    RecoveryFixture("pipe_tag_tokens", _PIPE_TAG_CALL, {"city": "Gdansk"}),
+    RecoveryFixture("kimi_sections", _KIMI_CALL, {"city": "Gdansk"}),
+    RecoveryFixture("harmony_commentary", _HARMONY_CALL, {"city": "Gdansk"}),
+    RecoveryFixture("deepseek_calls", _DEEPSEEK_CALL, {"city": "Gdansk"}),
+    RecoveryFixture(
+        "function_parameter_tags",
+        "<function=weather><parameter=city>Gdansk</parameter></function>",
+        {"city": "Gdansk"},
+    ),
+    RecoveryFixture(
+        "arg_key_value",
+        "weather<arg_key>city</arg_key><arg_value>Gdansk</arg_value>",
+        {"city": "Gdansk"},
+    ),
+    RecoveryFixture("python_call", 'weather({"city":"Gdansk"})', {"city": "Gdansk"}),
+    RecoveryFixture(
+        "arg_key_value_repair",
+        'weather<arg_key>city":"Gdansk"}',
+        {"city": "Gdansk"},
+    ),
+    RecoveryFixture("bare_name", 'weather\n{"city":"Gdansk"}', {"city": "Gdansk"}),
+    RecoveryFixture("bare_call", 'weather{"city":"Gdansk"}', {"city": "Gdansk"}),
+)
+
+
+def _assert_tool_call(
+    emissions: Sequence[object],
+    expected_arguments: dict[str, Any],
+) -> None:
+    assert len(emissions) == 1
+    emission = emissions[0]
+    assert isinstance(emission, ToolCallEmission)
+    assert emission.name == "weather"
+    assert json.loads(emission.arguments) == expected_arguments
+
+
+def _variant_tracer(variants: list[str]) -> Callable[..., None]:
+    def trace(_event: str, _payload: str, **fields: Any) -> None:
+        variant = fields.get("variant")
+        if isinstance(variant, str):
+            variants.append(variant)
+
+    return trace
+
+
+def _feed_in_chunks(
+    parser: ToolCallStreamParser,
+    stream: str,
+    chunk_size: int,
+) -> list[object]:
+    emissions: list[object] = []
+    for index in range(0, len(stream), chunk_size):
+        emissions.extend(parser.feed(stream[index : index + chunk_size]))
+    return emissions
+
+
+def test_marker_recovery_matrix_matches_every_registered_dialect() -> None:
+    assert set(_MARKER_FIXTURES) == {dialect.name for dialect in MARKER_DIALECTS}
+
+
+@pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
+def test_every_dialect_recovers_from_every_partial_close_marker(
+    dialect: MarkerDialect,
+) -> None:
+    fixture = _MARKER_FIXTURES[dialect.name]
+
+    for prefix_length in range(len(dialect.close_marker)):
+        stream = dialect.open_marker + fixture.payload + dialect.close_marker[:prefix_length]
+        for chunk_size in _CHUNK_SIZES:
+            parser = ToolCallStreamParser(frozenset({"weather"}))
+            assert _feed_in_chunks(parser, stream, chunk_size) == []
+
+            _assert_tool_call(parser.finish(), fixture.expected_arguments)
+
+
+@pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
+def test_every_dialect_handles_every_two_chunk_boundary(
+    dialect: MarkerDialect,
+) -> None:
+    fixture = _MARKER_FIXTURES[dialect.name]
+    stream = dialect.open_marker + fixture.payload + dialect.close_marker
+
+    for boundary in range(len(stream) + 1):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+        emissions = parser.feed(stream[:boundary])
+        emissions.extend(parser.feed(stream[boundary:]))
+        emissions.extend(parser.finish())
+
+        _assert_tool_call(emissions, fixture.expected_arguments)
+
+
+@pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
+def test_every_partial_open_marker_remains_plain_text(
+    dialect: MarkerDialect,
+) -> None:
+    for prefix_length in range(1, len(dialect.open_marker)):
+        text = "literal " + dialect.open_marker[:prefix_length]
+        parser = ToolCallStreamParser(frozenset())
+        emissions = parser.feed(text)
+        emissions.extend(parser.finish())
+
+        assert (
+            "".join(emission.text for emission in emissions if isinstance(emission, TextEmission))
+            == text
+        )
+
+
+@pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
+def test_every_dialect_rejects_text_after_a_completed_call(
+    dialect: MarkerDialect,
+) -> None:
+    fixture = _MARKER_FIXTURES[dialect.name]
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+        parser.feed(dialect.open_marker + fixture.payload + dialect.close_marker + "unexpected")
+
+
+@pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
+def test_every_dialect_keeps_truncated_payload_diagnostics(
+    dialect: MarkerDialect,
+) -> None:
+    fixture = _MARKER_FIXTURES[dialect.name]
+    truncated_payload = fixture.payload[:-1]
+
+    for prefix_length in range(len(dialect.close_marker)):
+        close_prefix = dialect.close_marker[:prefix_length]
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+        parser.feed(dialect.open_marker + truncated_payload + close_prefix)
+
+        with pytest.raises(IncompleteToolCallError) as excinfo:
+            parser.finish()
+
+        captured = truncated_payload + close_prefix
+        assert excinfo.value.tool_name == fixture.diagnostic_tool_name
+        assert excinfo.value.payload_bytes == len(captured.encode("utf-8"))
+
+
+def test_decoder_recovery_matrix_matches_every_registered_decoder() -> None:
+    assert {fixture.name for fixture in _DECODER_FIXTURES} == {
+        decoder.name for decoder in PAYLOAD_DECODERS
+    }
+
+
+@pytest.mark.parametrize("fixture", _DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+def test_every_decoder_recovers_from_every_partial_native_close_marker(
+    fixture: RecoveryFixture,
+) -> None:
+    for prefix_length in range(len(TOOL_CALL_CLOSE)):
+        variants: list[str] = []
+        parser = ToolCallStreamParser(
+            frozenset({"weather"}),
+            trace_payload=_variant_tracer(variants),
+        )
+        emissions = parser.feed(TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE[:prefix_length])
+        assert emissions == []
+
+        _assert_tool_call(parser.finish(), fixture.expected_arguments)
+        assert variants == [fixture.name]


### PR DESCRIPTION
## Summary

- recover completed tool calls when a stream ends inside the closing marker
- recover GLM output that opens with `<tool_call>` but closes complete JSON with `</arg_value>`
- keep partial closing-marker bytes in genuine truncation diagnostics
- add registry-driven recovery coverage for all 6 marker dialects and all 11 payload decoders
- cover every partial close prefix, every two-chunk boundary, varied chunk sizes, partial opens, trailing output, and truncated diagnostics
- replay the exact sanitized GLM event stream found during live testing
- verify reasoning and tool calls through ASGI stream and non-stream responses and the official OpenAI client

## Root cause

`_close_tail` contains a verified prefix of the active closing marker. Recovery appended that framing suffix to the completed payload, turning valid tool-call JSON into an incomplete call.

Live Droid testing found a second model shape: GLM sometimes emits a complete native JSON payload followed by the exact GLM value-close token `</arg_value>`. The parser now accepts only that known suffix after strict JSON. Other trailing residue still fails closed.

## Validation

- live GLM/Kimi matrix: 45/45 passed across stream, non-stream, tool, hostile-input, and model-switch scenarios
- official OpenAI client soak: 80/80 allowed GLM/Kimi tool calls passed
- `glm-5.2-fast`: 10/10 probes rejected by organization policy, excluded from success ratio
- local Podman image build and health check passed; live model calls used native Droid because macOS Keychain login is unavailable inside the Linux container
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1286 passed, 100% branch coverage
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
