### PR TITLE
fix(runtime): harden tool calls and sessions

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -123,7 +123,7 @@
           "max_completion_tokens": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "integer"
               },
               {
@@ -135,7 +135,7 @@
           "max_tokens": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "integer"
               },
               {
@@ -157,7 +157,7 @@
           },
           "n": {
             "default": 1,
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "N",
             "type": "integer"
           },
@@ -237,7 +237,7 @@
           "timeout": {
             "anyOf": [
               {
-                "exclusiveMinimum": 0,
+                "exclusiveMinimum": 0.0,
                 "type": "number"
               },
               {
@@ -1103,6 +1103,16 @@
             },
             "description": "The requested Factory Droid session is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "413": {
             "content": {
               "application/json": {
@@ -1130,6 +1140,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1160,16 +1180,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1218,6 +1228,16 @@
             },
             "description": "The requested Factory Droid session is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1235,6 +1255,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1265,16 +1295,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1331,6 +1351,16 @@
             },
             "description": "The requested Factory Droid session is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1348,6 +1378,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1378,16 +1418,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1446,6 +1476,16 @@
             },
             "description": "The requested Factory Droid session is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1463,6 +1503,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1493,16 +1543,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1551,6 +1591,16 @@
             },
             "description": "The requested Factory Droid session is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1568,6 +1618,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1598,16 +1658,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1656,6 +1706,16 @@
             },
             "description": "The requested Factory Droid session is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1673,6 +1733,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1703,16 +1773,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1748,6 +1808,16 @@
               }
             }
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1765,6 +1835,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1795,16 +1875,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1861,6 +1931,16 @@
             },
             "description": "The requested model is unknown to this bridge."
           },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "The requested Factory Droid session is already in use."
+          },
           "429": {
             "content": {
               "application/json": {
@@ -1878,6 +1958,16 @@
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
           },
           "502": {
             "content": {
@@ -1908,16 +1998,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -145,6 +145,10 @@ CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
         "model": ErrorResponse,
         "description": "The requested Factory Droid session is unknown to this bridge.",
     },
+    409: {
+        "model": ErrorResponse,
+        "description": "The requested Factory Droid session is already in use.",
+    },
     502: {
         "model": ErrorResponse,
         "description": "Droid SDK, process, or bridge protocol failure.",
@@ -168,6 +172,7 @@ FACTORY_OPERATION_RESPONSES: dict[int | str, dict[str, Any]] = {
         "model": ErrorResponse,
         "description": "The requested Factory Droid session is unknown to this bridge.",
     },
+    409: CHAT_COMPLETION_RESPONSES[409],
     429: CHAT_COMPLETION_RESPONSES[429],
     502: CHAT_COMPLETION_RESPONSES[502],
     503: CHAT_COMPLETION_RESPONSES[503],
@@ -302,12 +307,26 @@ class SessionRegistry:
     def __init__(self, max_entries: int) -> None:
         self._max_entries = max_entries
         self._sessions: OrderedDict[str, SessionKey] = OrderedDict()
+        self._in_use: set[str] = set()
 
     def remember(self, session_id: str, key: SessionKey) -> None:
         self._sessions.pop(session_id, None)
         self._sessions[session_id] = key
+        self._evict_excess(protected=session_id)
+
+    def _evict_excess(self, *, protected: str | None = None) -> None:
         while len(self._sessions) > self._max_entries:
-            self._sessions.popitem(last=False)
+            candidate = next(
+                (
+                    existing_id
+                    for existing_id in self._sessions
+                    if existing_id not in self._in_use and existing_id != protected
+                ),
+                None,
+            )
+            if candidate is None:
+                return
+            self._sessions.pop(candidate)
 
     def key(self, session_id: str) -> SessionKey | None:
         key = self._sessions.get(session_id)
@@ -318,6 +337,42 @@ class SessionRegistry:
 
     def forget(self, session_id: str) -> None:
         self._sessions.pop(session_id, None)
+
+    def acquire(self, session_id: str) -> SessionUseLease | None:
+        if session_id in self._in_use:
+            return None
+        self._in_use.add(session_id)
+        return SessionUseLease(self, session_id)
+
+    def release(self, session_id: str) -> None:
+        self._in_use.discard(session_id)
+        self._evict_excess()
+
+
+class SessionUseLease:
+    """Keeps one bridge-created Droid session on one operation at a time."""
+
+    def __init__(self, registry: SessionRegistry, session_id: str) -> None:
+        self._registry = registry
+        self._session_id = session_id
+        self._released = False
+
+    async def __aenter__(self) -> SessionUseLease:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        self.release()
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._registry.release(self._session_id)
+        self._released = True
 
 
 class AdmissionLease:
@@ -884,6 +939,17 @@ def create_app(
             )
         return key
 
+    def acquire_session_use(session_id: str) -> SessionUseLease:
+        lease = sessions.acquire(session_id)
+        if lease is None:
+            log_warning("session.rejected", status=409, phase="session_busy")
+            raise BridgeHTTPError(
+                "Factory Droid session is already serving another request.",
+                status_code=409,
+                error_type="invalid_request_error",
+            )
+        return lease
+
     @application.get(
         "/health",
         response_model=HealthResponse,
@@ -981,12 +1047,13 @@ def create_app(
     )
     async def session_context(session_id: str) -> SessionContextResponse:
         require_known_session(session_id)
-        stats, breakdown = await run_factory_operation(
-            lambda runner, remaining: runner.get_context(
-                session_id,
-                timeout_seconds=remaining,
+        async with acquire_session_use(session_id):
+            stats, breakdown = await run_factory_operation(
+                lambda runner, remaining: runner.get_context(
+                    session_id,
+                    timeout_seconds=remaining,
+                )
             )
-        )
         return SessionContextResponse(
             session_id=session_id,
             stats=ContextStatsResponse(
@@ -1026,13 +1093,14 @@ def create_app(
         payload: CompactSessionRequest,
     ) -> CompactSessionResponse:
         key = require_known_session(session_id)
-        result = await run_factory_operation(
-            lambda runner, remaining: runner.compact_session(
-                session_id,
-                custom_instructions=payload.custom_instructions,
-                timeout_seconds=remaining,
+        async with acquire_session_use(session_id):
+            result = await run_factory_operation(
+                lambda runner, remaining: runner.compact_session(
+                    session_id,
+                    custom_instructions=payload.custom_instructions,
+                    timeout_seconds=remaining,
+                )
             )
-        )
         sessions.remember(result.new_session_id, key)
         return CompactSessionResponse(
             session_id=result.new_session_id,
@@ -1049,12 +1117,13 @@ def create_app(
     )
     async def fork_session(session_id: str) -> ForkSessionResponse:
         key = require_known_session(session_id)
-        new_session_id = await run_factory_operation(
-            lambda runner, remaining: runner.fork_session(
-                session_id,
-                timeout_seconds=remaining,
+        async with acquire_session_use(session_id):
+            new_session_id = await run_factory_operation(
+                lambda runner, remaining: runner.fork_session(
+                    session_id,
+                    timeout_seconds=remaining,
+                )
             )
-        )
         sessions.remember(new_session_id, key)
         return ForkSessionResponse(session_id=new_session_id)
 
@@ -1071,13 +1140,14 @@ def create_app(
         payload: RenameSessionRequest,
     ) -> SessionOperationResponse:
         require_known_session(session_id)
-        await run_factory_operation(
-            lambda runner, remaining: runner.rename_session(
-                session_id,
-                title=payload.title,
-                timeout_seconds=remaining,
+        async with acquire_session_use(session_id):
+            await run_factory_operation(
+                lambda runner, remaining: runner.rename_session(
+                    session_id,
+                    title=payload.title,
+                    timeout_seconds=remaining,
+                )
             )
-        )
         return SessionOperationResponse(session_id=session_id, status="renamed")
 
     @application.delete(
@@ -1090,12 +1160,13 @@ def create_app(
     )
     async def close_session(session_id: str) -> SessionOperationResponse:
         require_known_session(session_id)
-        await run_factory_operation(
-            lambda runner, remaining: runner.close_session(
-                session_id,
-                timeout_seconds=remaining,
+        async with acquire_session_use(session_id):
+            await run_factory_operation(
+                lambda runner, remaining: runner.close_session(
+                    session_id,
+                    timeout_seconds=remaining,
+                )
             )
-        )
         sessions.forget(session_id)
         return SessionOperationResponse(session_id=session_id, status="closed")
 
@@ -1246,10 +1317,13 @@ def create_app(
             session_id=session_id,
             output_format=structured.payload if structured is not None else None,
         )
+        session_use = acquire_session_use(session_id) if session_id is not None else None
 
         try:
             lease = await admission.acquire(deadline)
         except AdmissionRejectedError:
+            if session_use is not None:
+                session_use.release()
             metrics.increment_overload_rejections()
             request.state.telemetry_error_type = "rate_limit_error"
             log_warning("chat.rejected", status=429, phase="queue")
@@ -1260,6 +1334,8 @@ def create_app(
                 headers={"Retry-After": str(resolved_settings.retry_after_seconds)},
             )
         except TimeoutError:
+            if session_use is not None:
+                session_use.release()
             request.state.telemetry_error_type = "factory_droid_timeout"
             log_warning(
                 "chat.rejected",
@@ -1272,13 +1348,21 @@ def create_app(
                 504,
                 "factory_droid_timeout",
             )
+        except BaseException:
+            if session_use is not None:
+                session_use.release()
+            raise
 
         log_debug("chat.admitted", queue_ms=timeline.mark("queue_ms"))
 
         try:
             runner = resolved_runner_factory()
         except BaseException:
-            await lease.release()
+            try:
+                await lease.release()
+            finally:
+                if session_use is not None:
+                    session_use.release()
             raise
 
         if session_id is None:
@@ -1301,6 +1385,21 @@ def create_app(
 
         if payload.stream:
             request.state.stream_outcome = "pending"
+            started_stream_session: str | None = None
+
+            def record_started_session(started_id: str) -> None:
+                nonlocal started_stream_session
+                started_stream_session = started_id
+
+            def record_stream_outcome(outcome: str) -> None:
+                request.state.stream_outcome = outcome
+                if started_stream_session is not None and outcome in {
+                    "success",
+                    "truncated",
+                    "malformed",
+                }:
+                    sessions.remember(started_stream_session, requested_key)
+
             event_stream = _stream_completion(
                 request_id=request_id,
                 created=created,
@@ -1311,18 +1410,11 @@ def create_app(
                 lease=lease,
                 metrics=metrics,
                 request_started_at=request_started_at,
-                outcome_callback=lambda outcome: setattr(
-                    request.state,
-                    "stream_outcome",
-                    outcome,
-                ),
+                outcome_callback=record_stream_outcome,
                 include_usage=bool(payload.stream_options and payload.stream_options.include_usage),
                 stop_sequences=payload.stop_sequences,
                 emit_status=payload.factory_droid_status,
-                session_callback=lambda started_id: sessions.remember(
-                    started_id,
-                    requested_key,
-                ),
+                session_callback=record_started_session,
                 expose_session=resolved_settings.session_continuity,
                 structured=structured,
                 failure_callback=note_runner_failure,
@@ -1339,6 +1431,7 @@ def create_app(
                     warm_session=run_request.warm_session,
                     reaper=reaper,
                     runner_factory=resolved_runner_factory,
+                    session_use=session_use,
                 ),
                 headers={
                     "Cache-Control": "no-cache",
@@ -1404,6 +1497,9 @@ def create_app(
             log_warning("chat.failed", status=exc.status_code, error_type=exc.error_type)
             note_runner_failure(payload.model, exc)
             return _error_response(str(exc), exc.status_code, exc.error_type)
+        finally:
+            if session_use is not None:
+                session_use.release()
 
         log_info(
             "chat.completed",
@@ -2031,6 +2127,7 @@ async def _finalize_stream(
     warm_session: WarmSession | None = None,
     reaper: BackgroundReaper | None = None,
     runner_factory: RunnerFactory | None = None,
+    session_use: SessionUseLease | None = None,
 ) -> None:
     close = getattr(stream, "aclose", None)
     try:
@@ -2048,7 +2145,11 @@ async def _finalize_stream(
             # The stream was discarded before the run started, so nothing else
             # will tear this session down.
             reaper.submit(runner_factory().discard(warm_session))
-        await lease.release()
+        try:
+            await lease.release()
+        finally:
+            if session_use is not None:
+                session_use.release()
 
 
 def _apply_emissions(

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -527,22 +527,41 @@ def _decode_json_object(raw: str) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-def _decode_json_arg_value_close(
-    body: str,
+def _parse_allowed_json_call(
+    raw: str,
     allowed_tool_names: frozenset[str],
-) -> list[dict[str, Any]] | None:
-    """Repairs strict JSON followed by GLM's mismatched value-close token."""
-    stripped = body.strip()
-    if not stripped.endswith(_ARG_VALUE_CLOSE):
-        return None
-    candidate = stripped[: -len(_ARG_VALUE_CLOSE)].rstrip()
+) -> dict[str, Any] | None:
     try:
-        parsed = parse_strict_json(candidate)
+        parsed = parse_strict_json(raw)
     except (json.JSONDecodeError, ValueError):
         return None
     if not isinstance(parsed, dict) or parsed.get("name") not in allowed_tool_names:
         return None
-    return [parsed]
+    return parsed
+
+
+def _decode_json_arg_value_close(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> list[dict[str, Any]] | None:
+    """Repairs strict JSON calls followed by GLM's mismatched value-close token."""
+    stripped = body.strip()
+    if not stripped.endswith(_ARG_VALUE_CLOSE):
+        return None
+    candidate = stripped[: -len(_ARG_VALUE_CLOSE)].rstrip()
+    parsed = _parse_allowed_json_call(candidate, allowed_tool_names)
+    if parsed is not None:
+        return [parsed]
+    separator = f"{_ARG_VALUE_CLOSE}{TOOL_CALL_OPEN}"
+    if separator not in candidate:
+        return None
+    calls: list[dict[str, Any]] = []
+    for segment in candidate.split(separator):
+        parsed = _parse_allowed_json_call(segment.strip(), allowed_tool_names)
+        if parsed is None:
+            return None
+        calls.append(parsed)
+    return calls if len(calls) > 1 else None
 
 
 def _decode_arg_key_value(
@@ -565,13 +584,20 @@ def _decode_arg_key_value(
         value_start = body.find(_ARG_VALUE_OPEN, key_end)
         if not key or key in arguments or value_start < 0:
             return None
+        key_trailing = body[key_end + len(_ARG_KEY_CLOSE) : value_start]
+        if key_trailing.strip():
+            return None
         value_end = body.find(_ARG_VALUE_CLOSE, value_start)
         if value_end < 0:
             # A truncated value would silently drop data, so fail closed.
             return None
         raw = body[value_start + len(_ARG_VALUE_OPEN) : value_end].strip()
         arguments[key] = _coerce_arg_value(raw)
+        value_end += len(_ARG_VALUE_CLOSE)
         index = body.find(_ARG_KEY_OPEN, value_end)
+        trailing_end = index if index >= 0 else len(body)
+        if body[value_end:trailing_end].strip():
+            return None
     return [{"name": name, "arguments": arguments}]
 
 

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -433,6 +433,8 @@ class DroidRunner:
         initialized = warm is not None
         completed = False
         ignored_native_tool = False
+        saw_assistant_text = False
+        unmapped_event_kind: str | None = None
         usage = Usage()
 
         try:
@@ -528,6 +530,7 @@ class DroidRunner:
                     if log_enabled(_TRACE_LEVEL):
                         log_trace("droid.event", kind=type(event).__name__)
                     if isinstance(event, AssistantTextDelta):
+                        saw_assistant_text = saw_assistant_text or bool(event.text)
                         yield TextDelta(event.text)
                     elif isinstance(event, ThinkingTextDelta):
                         yield ReasoningDelta(event.text)
@@ -537,6 +540,18 @@ class DroidRunner:
                         usage = _map_usage(event)
                         yield UsageUpdate(usage)
                     elif isinstance(event, TurnComplete):
+                        if not saw_assistant_text and (
+                            ignored_native_tool or unmapped_event_kind is not None
+                        ):
+                            reason = (
+                                "a disabled Droid meta-tool attempt"
+                                if ignored_native_tool
+                                else f"unmapped SDK event {unmapped_event_kind!r}"
+                            )
+                            raise RunnerError(
+                                f"Factory Droid completed without assistant output after {reason}.",
+                                error_type="factory_incomplete_response",
+                            )
                         if event.token_usage is not None:
                             usage = _map_usage(event.token_usage)
                         completed = True
@@ -577,6 +592,9 @@ class DroidRunner:
                             event,
                             model=_resolve_model_id(request.model, request.model_alias),
                         )
+                    else:
+                        unmapped_event_kind = type(event).__name__
+                        log_debug("droid.event_unmapped", kind=unmapped_event_kind)
         except (TimeoutError, DroidTimeoutError) as exc:
             raise RunnerError(
                 f"Factory Droid timed out after {loop.time() - started:.1f} seconds.",

--- a/tests/fixtures/events/tool-parallel--glm-5-2-stream.jsonl
+++ b/tests/fixtures/events/tool-parallel--glm-5-2-stream.jsonl
@@ -1,0 +1,6 @@
+{"kind": "meta", "scenario": "tool_parallel", "stream": true, "recorded_model": "glm-5.2", "expect_verdict": "pass", "provenance": "reconstructed"}
+{"kind": "session_started"}
+{"kind": "status", "state": "streaming_assistant_message"}
+{"kind": "text_delta", "text": "<tool_call>{\"name\":\"weather\",\"arguments\":{\"city\":\"Gdansk\"}}</arg_value><tool_call>{\"name\":\"clock\",\"arguments\":{\"city\":\"Gdansk\"}}</arg_value>"}
+{"kind": "status", "state": "idle"}
+{"kind": "run_complete", "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -976,6 +976,60 @@ async def test_tool_call_drain_keeps_usage_reported_by_the_sdk(tmp_path: Path) -
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("stream", [False, True])
+async def test_tool_call_drain_keeps_delayed_parallel_calls(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    class DelayedParallelRunner(FakeRunner):
+        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+            self.requests.append(request)
+            try:
+                for city in ("Gdansk", "Sopot"):
+                    call = json.dumps(
+                        {"name": "weather", "arguments": {"city": city}},
+                        separators=(",", ":"),
+                    )
+                    yield TextDelta(f"{TOOL_CALL_OPEN}{call}{TOOL_CALL_CLOSE}")
+                    await asyncio.sleep(0.01)
+                await asyncio.Event().wait()
+            finally:
+                self.closed = True
+
+    runner = DelayedParallelRunner([])
+    app = _feature_app(tmp_path, runner, tool_call_drain_seconds=0.05)
+    payload = _payload(
+        stream=stream,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        calls = [
+            call
+            for line in response.text.splitlines()
+            if line.startswith("data: {")
+            for choice in json.loads(line.removeprefix("data: "))["choices"]
+            for call in choice["delta"].get("tool_calls", [])
+        ]
+    else:
+        calls = response.json()["choices"][0]["message"]["tool_calls"]
+    assert [json.loads(call["function"]["arguments"])["city"] for call in calls] == [
+        "Gdansk",
+        "Sopot",
+    ]
+    assert runner.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
 async def test_backend_timeout_after_tool_call_returns_the_call(
     tmp_path: Path,
     stream: bool,
@@ -1332,9 +1386,11 @@ async def test_bounded_queue_rejects_overload_before_stream_headers(
             max_concurrency=1,
             max_queue_size=1,
             retry_after_seconds=2,
+            session_continuity=True,
         ),
         runner_factory=cast("RunnerFactory", lambda: runner),
     )
+    app.state.sessions.remember("session-rejected", SessionKey(None, None))
     async with _client(app) as client:
         active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
         await runner.started.wait()
@@ -1345,7 +1401,10 @@ async def test_bounded_queue_rejects_overload_before_stream_headers(
 
         rejected = await client.post(
             "/v1/chat/completions",
-            json=_payload(stream=True),
+            json=_payload(
+                stream=True,
+                factory_droid_session_id="session-rejected",
+            ),
         )
 
         assert rejected.status_code == 429
@@ -1354,10 +1413,20 @@ async def test_bounded_queue_rejects_overload_before_stream_headers(
         runner.release.set()
         assert (await active).status_code == 200
         assert (await queued).status_code == 200
+        retried = await client.post(
+            "/v1/chat/completions",
+            json=_payload(factory_droid_session_id="session-rejected"),
+        )
+
+    assert retried.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_queue_wait_consumes_end_to_end_timeout(tmp_path: Path) -> None:
+@pytest.mark.parametrize("use_session", [False, True])
+async def test_queue_wait_consumes_end_to_end_timeout(
+    tmp_path: Path,
+    use_session: bool,
+) -> None:
     runner = GateRunner()
     app = create_app(
         Settings(
@@ -1365,16 +1434,24 @@ async def test_queue_wait_consumes_end_to_end_timeout(tmp_path: Path) -> None:
             timeout_seconds=30,
             max_concurrency=1,
             max_queue_size=1,
+            session_continuity=True,
         ),
         runner_factory=cast("RunnerFactory", lambda: runner),
     )
+    timed_payload = _payload(timeout=0.02)
+    if use_session:
+        app.state.sessions.remember("session-timeout", SessionKey(None, None))
+        timed_payload = _payload(
+            timeout=0.02,
+            factory_droid_session_id="session-timeout",
+        )
     async with _client(app) as client:
         active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
         await runner.started.wait()
 
         timed_out = await client.post(
             "/v1/chat/completions",
-            json=_payload(timeout=0.02),
+            json=timed_payload,
         )
 
         assert timed_out.status_code == 504
@@ -1382,6 +1459,12 @@ async def test_queue_wait_consumes_end_to_end_timeout(tmp_path: Path) -> None:
         assert len(runner.requests) == 1
         runner.release.set()
         assert (await active).status_code == 200
+        retried = await client.post(
+            "/v1/chat/completions",
+            json=timed_payload,
+        )
+
+    assert retried.status_code == 200
 
 
 @pytest.mark.asyncio
@@ -2887,6 +2970,92 @@ async def test_session_id_round_trips_and_drives_a_continuation(
 
 
 @pytest.mark.asyncio
+async def test_concurrent_session_uses_return_conflict_and_release_the_lease(
+    tmp_path: Path,
+) -> None:
+    runner = GateRunner()
+    app = _feature_app(
+        tmp_path,
+        runner,
+        session_continuity=True,
+        max_concurrency=3,
+        max_queue_size=0,
+    )
+    app.state.sessions.remember("session-77", SessionKey(None, None))
+    continuation = _payload(factory_droid_session_id="session-77")
+
+    async with _client(app) as client:
+        active = asyncio.create_task(client.post("/v1/chat/completions", json=continuation))
+        await runner.started.wait()
+
+        duplicate = await client.post("/v1/chat/completions", json=continuation)
+        context = await client.get("/v1/factory/sessions/session-77/context")
+
+        runner.release.set()
+        completed = await active
+        retried = await client.post("/v1/chat/completions", json=continuation)
+
+    assert duplicate.status_code == 409
+    assert context.status_code == 409
+    assert duplicate.json()["error"]["type"] == "invalid_request_error"
+    assert context.json()["error"]["type"] == "invalid_request_error"
+    assert completed.status_code == 200
+    assert retried.status_code == 200
+    assert len(runner.requests) == 2
+    assert runner.session_operations == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_session", [False, True])
+async def test_cancelled_admission_wait_releases_the_session_lease(
+    tmp_path: Path,
+    use_session: bool,
+) -> None:
+    runner = GateRunner()
+    app = _feature_app(
+        tmp_path,
+        runner,
+        session_continuity=True,
+        max_concurrency=1,
+        max_queue_size=1,
+    )
+    app.state.sessions.remember("session-active", SessionKey(None, None))
+    queued_payload = _payload()
+    if use_session:
+        app.state.sessions.remember("session-queued", SessionKey(None, None))
+        queued_payload = _payload(factory_droid_session_id="session-queued")
+
+    async with _client(app) as client:
+        active = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=_payload(factory_droid_session_id="session-active"),
+            )
+        )
+        await runner.started.wait()
+        queued = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=queued_payload,
+            )
+        )
+        await _wait_for_metric(app, "factory_droid_openai_queued_requests 1")
+
+        queued.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await queued
+
+        runner.release.set()
+        assert (await active).status_code == 200
+        retried = await client.post(
+            "/v1/chat/completions",
+            json=queued_payload,
+        )
+
+    assert retried.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_session_continuation_rejects_settings_switches(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
@@ -2987,6 +3156,24 @@ async def test_streaming_session_id_is_announced_when_continuity_is_enabled(
         )
 
     assert '"factory_droid_session_id":"session-5"' in response.text
+    assert app.state.sessions.key("session-5") == SessionKey(None, None)
+
+
+@pytest.mark.asyncio
+async def test_failed_stream_does_not_register_its_started_session(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([SessionStarted("session-failed"), TextDelta("partial")])
+    app = _feature_app(tmp_path, runner, session_continuity=True)
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(stream=True),
+        )
+
+    assert '"type":"factory_incomplete_response"' in response.text
+    assert app.state.sessions.key("session-failed") is None
 
 
 @pytest.mark.asyncio
@@ -3558,6 +3745,65 @@ def test_session_registry_ignores_duplicate_entries() -> None:
     assert registry.key("missing") is None
 
 
+def test_session_registry_does_not_evict_a_session_in_use() -> None:
+    registry = SessionRegistry(2)
+    key_a = SessionKey("model-a", None)
+    key_b = SessionKey("model-b", None)
+    key_c = SessionKey("model-c", None)
+    registry.remember("a", key_a)
+    registry.remember("b", key_b)
+    lease = registry.acquire("a")
+    assert lease is not None
+
+    registry.remember("c", key_c)
+
+    assert registry.key("a") == key_a
+    assert registry.key("b") is None
+    assert registry.key("c") == key_c
+    lease.release()
+
+
+def test_session_registry_defers_eviction_until_a_busy_session_releases() -> None:
+    registry = SessionRegistry(2)
+    keys = {session_id: SessionKey(f"model-{session_id}", None) for session_id in ("a", "b", "c")}
+    registry.remember("a", keys["a"])
+    registry.remember("b", keys["b"])
+    first = registry.acquire("a")
+    second = registry.acquire("b")
+    assert first is not None
+    assert second is not None
+
+    registry.remember("c", keys["c"])
+    assert registry.key("a") == keys["a"]
+    assert registry.key("b") == keys["b"]
+    assert registry.key("c") == keys["c"]
+
+    first.release()
+    assert registry.key("a") is None
+    assert registry.key("b") == keys["b"]
+    assert registry.key("c") == keys["c"]
+    second.release()
+
+
+@pytest.mark.asyncio
+async def test_session_registry_lease_is_exclusive_and_idempotent() -> None:
+    registry = SessionRegistry(2)
+    registry.remember("a", SessionKey("model-a", None))
+
+    first = registry.acquire("a")
+    assert first is not None
+    assert registry.acquire("a") is None
+
+    first.release()
+    first.release()
+    second = registry.acquire("a")
+    assert second is not None
+    async with second:
+        assert registry.acquire("a") is None
+
+    assert registry.acquire("a") is not None
+
+
 @pytest.mark.asyncio
 async def test_request_limit_middleware_passes_non_http_scopes_through() -> None:
     seen: list[str] = []
@@ -4064,6 +4310,35 @@ async def test_runner_factory_failure_releases_the_admission_slot(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_runner_factory_failure_releases_the_session_lease(tmp_path: Path) -> None:
+    attempts = 0
+
+    def factory() -> Any:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("no droid runner")
+
+    app = create_app(
+        Settings(
+            workdir=tmp_path,
+            session_continuity=True,
+            max_concurrency=1,
+            max_queue_size=0,
+        ),
+        runner_factory=cast("RunnerFactory", factory),
+    )
+    app.state.sessions.remember("session-1", SessionKey(None, None))
+    payload = _payload(factory_droid_session_id="session-1")
+
+    async with _client(app) as client:
+        for _ in range(2):
+            with pytest.raises(RuntimeError, match="no droid runner"):
+                await client.post("/v1/chat/completions", json=payload)
+
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_request_answers_499_when_the_client_disconnects(
     tmp_path: Path,
 ) -> None:
@@ -4247,16 +4522,23 @@ async def test_stream_finalizer_accepts_a_stream_without_aclose() -> None:
     metrics = BridgeMetrics()
     admission = AdmissionController(max_concurrency=1, max_queue_size=1, metrics=metrics)
     lease = await admission.acquire(asyncio.get_running_loop().time() + 30)
+    registry = SessionRegistry(1)
+    registry.remember("session-1", SessionKey(None, None))
+    session_use = registry.acquire("session-1")
+    assert session_use is not None
+    assert registry.acquire("session-1") is None
     request = SimpleNamespace(state=SimpleNamespace(stream_outcome="pending"))
 
     await _finalize_stream(
         cast("Any", SimpleNamespace(aclose=None)),
         lease,
         cast("Any", request),
+        session_use=session_use,
     )
 
     assert request.state.stream_outcome == "cancelled"
     assert "factory_droid_openai_active_sessions 0" in metrics.render()
+    assert registry.acquire("session-1") is not None
 
 
 def test_request_outcome_falls_back_to_the_status_code() -> None:

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 import pytest
-from openai import APIStatusError, AsyncOpenAI
+from openai import APIError, APIStatusError, AsyncOpenAI
 
 from factory_droid_openai.app import create_app
 from factory_droid_openai.config import Settings
@@ -15,6 +15,7 @@ from factory_droid_openai.runner import (
     ReasoningDelta,
     RunComplete,
     RunEvent,
+    RunnerError,
     RunRequest,
     TextDelta,
     Usage,
@@ -158,6 +159,34 @@ async def test_official_openai_client_parses_stream(
     assert chunks[-1].choices == []
     assert chunks[-1].usage is not None
     assert chunks[-1].usage.total_tokens == 6
+
+
+@pytest.mark.asyncio
+async def test_official_openai_client_raises_for_an_sse_error(
+    tmp_path: Path,
+) -> None:
+    class FailingStreamRunner(ScriptedRunner):
+        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+            self.requests.append(request)
+            yield TextDelta("partial")
+            raise RunnerError(
+                "Droid failed",
+                error_type="factory_droid_sdk_error",
+            )
+
+    runner = FailingStreamRunner([])
+    client, http_client = _sdk_client(tmp_path, runner)
+    async with http_client:
+        stream = await client.chat.completions.create(
+            model="factory-droid",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+        )
+        with pytest.raises(APIError, match="Droid failed") as error:
+            _ = [chunk async for chunk in stream]
+
+    assert isinstance(error.value.body, dict)
+    assert error.value.body["type"] == "factory_droid_sdk_error"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -45,6 +45,7 @@ def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> Non
         "200",
         "4XX",
         "404",
+        "409",
         "413",
         "429",
         "502",

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -634,6 +634,48 @@ def test_stream_parser_repairs_arg_key_value_payload() -> None:
     assert json.loads(emissions[0].arguments) == {"city": "Gdańsk", "days": 3}
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "weather<arg_key>city</arg_key><arg_value>Gdansk</arg_value>unexpected",
+        "weather<arg_key>city</arg_key>unexpected<arg_value>Gdansk</arg_value>",
+        (
+            "weather<arg_key>city</arg_key><arg_value>Gdansk</arg_value>"
+            "unexpected<arg_key>days</arg_key><arg_value>2</arg_value>"
+        ),
+    ],
+)
+def test_stream_parser_rejects_residue_inside_arg_key_value_payload(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(MalformedToolCallError):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_keeps_separate_tagged_arg_key_calls() -> None:
+    parser = ToolCallStreamParser(
+        frozenset({"weather", "calendar"}),
+        max_tool_calls=2,
+    )
+    payload = (
+        "weather<arg_key>city</arg_key><arg_value>Gdansk</arg_value>"
+        "<tool_call>"
+        "calendar<arg_key>day</arg_key><arg_value>2</arg_value>"
+    )
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+    assert [emission.name for emission in emissions if isinstance(emission, ToolCallEmission)] == [
+        "weather",
+        "calendar",
+    ]
+    assert [
+        json.loads(emission.arguments)
+        for emission in emissions
+        if isinstance(emission, ToolCallEmission)
+    ] == [{"city": "Gdansk"}, {"day": 2}]
+
+
 def test_stream_parser_uses_injected_payload_tracer() -> None:
     traces: list[tuple[str, str, dict[str, Any]]] = []
 
@@ -2365,6 +2407,87 @@ def test_stream_parser_recovers_json_with_glm_value_close(close_marker: str) -> 
     assert len(emissions) == 1
     assert isinstance(emissions[0], ToolCallEmission)
     assert json.loads(emissions[0].arguments) == {"city": "Gdansk"}
+
+
+@pytest.mark.parametrize("close_marker", ["", TOOL_CALL_CLOSE])
+def test_stream_parser_recovers_packed_json_with_glm_value_closes(close_marker: str) -> None:
+    payload = (
+        '{"name":"weather","arguments":{"city":"Gdansk"}}</arg_value>'
+        '<tool_call>{"name":"clock","arguments":{"city":"Gdansk"}}</arg_value>'
+    )
+    stream = f"{TOOL_CALL_OPEN}{payload}{close_marker}"
+
+    for boundary in range(len(stream) + 1):
+        parser = ToolCallStreamParser(
+            frozenset({"weather", "clock"}),
+            max_tool_calls=2,
+        )
+        emissions = parser.feed(stream[:boundary])
+        emissions.extend(parser.feed(stream[boundary:]))
+        emissions.extend(parser.finish())
+
+        calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+        assert [call.name for call in calls] == ["weather", "clock"]
+        assert [json.loads(call.arguments) for call in calls] == [
+            {"city": "Gdansk"},
+            {"city": "Gdansk"},
+        ]
+
+
+def test_stream_parser_recovers_reconstructed_568_byte_glm_read_file_payload() -> None:
+    paths = [
+        "/workspace/example/monorepo/service/api/service/runtime_x/README.md",
+        "/workspace/example/monorepo/service/api/service/runtime_x/pyproject.toml",
+        "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x/main.py",
+        "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x/config.py",
+    ]
+    calls = [
+        json.dumps(
+            {"name": "read_file", "arguments": {"file_path": path}},
+            separators=(",", ":"),
+        )
+        for path in paths
+    ]
+    payload = "</arg_value><tool_call>".join(calls) + "</arg_value>"
+    assert len(payload.encode("utf-8")) == 568
+
+    parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=4)
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+    emissions.extend(parser.finish())
+
+    parsed_calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [call.name for call in parsed_calls] == ["read_file"] * 4
+    assert [json.loads(call.arguments)["file_path"] for call in parsed_calls] == paths
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        (
+            '{"name":"weather","arguments":{"city":"Gdansk"}}</arg_value>'
+            '<tool_call>{"name":"unknown","arguments":{"city":"Gdansk"}}</arg_value>'
+        ),
+        (
+            '{"name":"weather","arguments":{"city":"Gdansk"}}</arg_value>junk'
+            '<tool_call>{"name":"clock","arguments":{"city":"Gdansk"}}</arg_value>'
+        ),
+        (
+            '{"name":"weather","arguments":{"city":"Gdansk"}}</arg_value>'
+            '<tool_call>{"name":"clock","name":"clock","arguments":{}}</arg_value>'
+        ),
+    ],
+)
+def test_stream_parser_rejects_invalid_packed_json_with_glm_value_closes(
+    payload: str,
+) -> None:
+    parser = ToolCallStreamParser(
+        frozenset({"weather", "clock"}),
+        max_tool_calls=2,
+    )
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    with pytest.raises(IncompleteToolCallError):
+        parser.finish()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -294,6 +294,32 @@ async def test_runner_lets_droid_meta_tools_pass(tmp_path: Path, tool_name: str)
 
 
 @pytest.mark.asyncio
+async def test_runner_rejects_a_meta_tool_only_completion(tmp_path: Path) -> None:
+    client = FakeClient(
+        [
+            ToolUse(
+                tool_name="ToolSearch",
+                tool_input={"query": "select:weather"},
+                tool_use_id="meta-call",
+            ),
+            ToolResult(tool_name="", content="tool disabled", is_error=True),
+            TurnComplete(token_usage=None),
+        ]
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="without assistant output") as error:
+        _ = [event async for event in runner.run(_request())]
+
+    assert error.value.error_type == "factory_incomplete_response"
+    assert client.interrupted is True
+
+
+@pytest.mark.asyncio
 async def test_runner_blocks_an_unattributed_tool_result(tmp_path: Path) -> None:
     client = FakeClient([ToolResult(tool_name="", content="", is_error=False)])
     runner = DroidRunner(
@@ -1634,7 +1660,13 @@ async def test_runner_maps_events_without_trace_logging(
 
 @pytest.mark.asyncio
 async def test_runner_ignores_sdk_events_it_does_not_map(tmp_path: Path) -> None:
-    client = FakeClient([SimpleNamespace(kind="unknown"), TurnComplete()])
+    client = FakeClient(
+        [
+            SimpleNamespace(kind="unknown"),
+            AssistantTextDelta("done"),
+            TurnComplete(),
+        ]
+    )
     runner = DroidRunner(
         droid_path="droid",
         workdir=tmp_path,
@@ -1643,7 +1675,27 @@ async def test_runner_ignores_sdk_events_it_does_not_map(tmp_path: Path) -> None
 
     events = await _collect(runner, _request())
 
-    assert events == [SessionStarted("session-1"), RunComplete(usage=Usage())]
+    assert events == [
+        SessionStarted("session-1"),
+        TextDelta("done"),
+        RunComplete(usage=Usage()),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_an_unmapped_event_only_completion(tmp_path: Path) -> None:
+    client = FakeClient([SimpleNamespace(kind="unknown"), TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="unmapped SDK event") as error:
+        await _collect(runner, _request())
+
+    assert error.value.error_type == "factory_incomplete_response"
+    assert client.interrupted is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- recover packed GLM calls separated by `</arg_value><tool_call>` only when every segment is strict JSON for an allowed tool
- reject interstitial and trailing residue in GLM argument-tag dialects
- fail Droid turns completed after only disabled meta-tools or unmapped SDK events
- serialize continuation and management operations per bridge-created session with `409` conflicts
- release session leases across queue rejection, timeout, cancellation, runner construction failure, and stream finalization
- register streamed sessions only after settled outcomes
- cover delayed parallel-call draining and official OpenAI client SSE errors

## Evidence

The supplied Droid log starts after the reported failure and has payload tracing disabled, so it does not contain the original 568-byte response. Controlled live GLM 5.2 single and parallel calls normally completed. A reconstructed 568-byte packed `read_file` payload reproduced the parser failure and now passes. Exact production-payload equivalence remains unconfirmed.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1311 passed, 100% coverage
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
