### PR TITLE
fix(protocol): recover packed GLM bare calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,8 @@ jobs:
         run: uv run openapi-spec-validator openapi.json
 
       # Release Please rewrites JSON while updating info.version, so compare
-      # parsed documents instead of serializer-specific formatting.
+      # re-serialized documents instead of the committed formatting. Dumping
+      # keeps the check type-sensitive, where a parsed 0 would equal 0.0.
       - name: Verify OpenAPI contract is regenerated
         run: |
           export COMMITTED_OPENAPI="$RUNNER_TEMP/openapi-committed.json"
@@ -89,7 +90,7 @@ jobs:
               Path(os.environ["COMMITTED_OPENAPI"]).read_text(encoding="utf-8")
           )
           generated = json.loads(Path("openapi.json").read_text(encoding="utf-8"))
-          if committed != generated:
+          if json.dumps(committed, sort_keys=True) != json.dumps(generated, sort_keys=True):
               raise SystemExit("Committed OpenAPI document differs from generated schema.")
           PY
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ text. Every accepted form lives in one table in
 Translation never widens validation. An unknown tool name, a duplicate
 argument key, or prose after a call still fails the turn. A payload truncated
 before its close marker ends with `finish_reason="length"`. A closed malformed
-call or a mangled OpenAI `tool_calls` fragment ends with `finish_reason="stop"`
+call, a mangled OpenAI `tool_calls` fragment, or a turn packing more calls than
+`FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` allows ends with `finish_reason="stop"`
 and a plain-text bridge notice. The malformed JSON and the call are dropped,
 never executed or returned to the client. The notice names no tool-call
 format, because anything it named would itself be tool-call-shaped text in

--- a/openapi.json
+++ b/openapi.json
@@ -1141,6 +1141,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1170,16 +1180,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1256,6 +1256,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1285,16 +1295,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1379,6 +1379,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1408,16 +1418,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1504,6 +1504,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1533,16 +1543,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1619,6 +1619,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1648,16 +1658,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1734,6 +1734,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1763,16 +1773,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1836,6 +1836,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1865,16 +1875,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1959,6 +1959,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1988,16 +1998,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -2,19 +2,37 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 
-def main() -> None:
+def normalize_numbers(value: Any) -> Any:
+    """Rewrites whole floats as ints so the document is serializer-independent.
+
+    Pydantic renders a numeric constraint as ``0`` or ``0.0`` depending on the
+    release, and both parse to the same JSON number, so a parsed comparison
+    never notices while every regeneration rewrites the committed file.
+    """
+    if isinstance(value, dict):
+        return {key: normalize_numbers(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [normalize_numbers(item) for item in value]
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def render(root: Path) -> str:
+    """Returns the committed contract's exact text for ``root``."""
     from factory_droid_openai.app import create_app
     from factory_droid_openai.config import Settings
 
+    schema = normalize_numbers(create_app(Settings(workdir=root)).openapi())
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> None:
     root = Path(__file__).resolve().parents[1]
-    schema = create_app(Settings(workdir=root)).openapi()
-    output = root / "openapi.json"
-    output.write_text(
-        json.dumps(schema, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    (root / "openapi.json").write_text(render(root), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -663,22 +663,48 @@ def _decode_bare_call(
     body: str,
     allowed_tool_names: frozenset[str],
 ) -> list[dict[str, Any]] | None:
-    """Rebuilds ``name{"key":"value"}`` - the tool name glued to its arguments.
+    """Rebuilds one or more ``name{"key":"value"}`` calls.
 
-    Unlike :func:`_decode_bare_name`, no newline separates the name from the
-    JSON object. The name must match an allowed tool exactly.
+    GLM may pack calls by repeating the opening marker without emitting the
+    matching closes. Every segment must name an allowed tool and carry one
+    strict JSON object, so residue and partial calls remain rejected.
     """
-    stripped = body.strip()
-    match = _BARE_CALL_PATTERN.match(stripped)
+    remaining = body.strip()
+    calls: list[dict[str, Any]] = []
+    while True:
+        parsed = _decode_bare_call_segment(remaining, allowed_tool_names)
+        if parsed is None:
+            return None
+        call, end = parsed
+        calls.append(call)
+        trailing = remaining[end:].lstrip()
+        if not trailing:
+            return calls
+        if not trailing.startswith(TOOL_CALL_OPEN):
+            return None
+        remaining = trailing[len(TOOL_CALL_OPEN) :].lstrip()
+        if not remaining:
+            return None
+
+
+def _decode_bare_call_segment(
+    segment: str,
+    allowed_tool_names: frozenset[str],
+) -> tuple[dict[str, Any], int] | None:
+    match = _BARE_CALL_PATTERN.match(segment)
     if match is None:
         return None
     name = match.group(1)
     if name not in allowed_tool_names:
         return None
-    arguments = _decode_json_object(stripped[match.end() :])
+    try:
+        _, end = json.JSONDecoder().raw_decode(segment, match.end())
+    except json.JSONDecodeError:
+        return None
+    arguments = _decode_json_object(segment[match.end() : end])
     if arguments is None:
         return None
-    return [{"name": name, "arguments": arguments}]
+    return {"name": name, "arguments": arguments}, end
 
 
 _ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE, "<tool_call>")

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -24,7 +24,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from factory_droid_openai.strictjson import parse_strict_json
+from factory_droid_openai.strictjson import parse_strict_json, raw_decode_strict
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -656,7 +656,11 @@ def _decode_python_call(
     return [{"name": name, "arguments": arguments}]
 
 
-_BARE_CALL_PATTERN = re.compile(r"^([A-Za-z_][\w.-]*)\s*(?=\{)")
+_BARE_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\s*(?=\{)")
+# Past this many segments the payload is malformed beyond any tool-call limit
+# an operator can configure, and the parser's byte cap alone would let a
+# pathological turn cost far more work than it can ever be worth.
+_MAX_PACKED_BARE_CALLS = 64
 
 
 def _decode_bare_call(
@@ -667,44 +671,52 @@ def _decode_bare_call(
 
     GLM may pack calls by repeating the opening marker without emitting the
     matching closes. Every segment must name an allowed tool and carry one
-    strict JSON object, so residue and partial calls remain rejected.
+    strict JSON object, so residue and partial calls remain rejected. Segments
+    are walked by offset instead of re-sliced, keeping a payload at the byte
+    cap linear work.
     """
-    remaining = body.strip()
+    stripped = body.strip()
     calls: list[dict[str, Any]] = []
-    while True:
-        parsed = _decode_bare_call_segment(remaining, allowed_tool_names)
+    index = 0
+    while len(calls) < _MAX_PACKED_BARE_CALLS:
+        parsed = _decode_bare_call_segment(stripped, index, allowed_tool_names)
         if parsed is None:
             return None
-        call, end = parsed
+        call, index = parsed
         calls.append(call)
-        trailing = remaining[end:].lstrip()
-        if not trailing:
+        index = _skip_whitespace(stripped, index)
+        if index == len(stripped):
             return calls
-        if not trailing.startswith(TOOL_CALL_OPEN):
+        if not stripped.startswith(TOOL_CALL_OPEN, index):
             return None
-        remaining = trailing[len(TOOL_CALL_OPEN) :].lstrip()
-        if not remaining:
+        index = _skip_whitespace(stripped, index + len(TOOL_CALL_OPEN))
+        if index == len(stripped):
             return None
+    return None
 
 
 def _decode_bare_call_segment(
     segment: str,
+    index: int,
     allowed_tool_names: frozenset[str],
 ) -> tuple[dict[str, Any], int] | None:
-    match = _BARE_CALL_PATTERN.match(segment)
+    match = _BARE_CALL_PATTERN.match(segment, index)
     if match is None:
         return None
     name = match.group(1)
     if name not in allowed_tool_names:
         return None
     try:
-        _, end = json.JSONDecoder().raw_decode(segment, match.end())
-    except json.JSONDecodeError:
-        return None
-    arguments = _decode_json_object(segment[match.end() : end])
-    if arguments is None:
+        arguments, end = raw_decode_strict(segment, match.end())
+    except (json.JSONDecodeError, ValueError):
         return None
     return {"name": name, "arguments": arguments}, end
+
+
+def _skip_whitespace(value: str, index: int) -> int:
+    while index < len(value) and value[index].isspace():
+        index += 1
+    return index
 
 
 _ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE, "<tool_call>")

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -378,14 +378,15 @@ class ToolCallStreamParser:
             self._pending_transcript_error = None
             raise error
         if self._capturing:
+            # Snapshot before recovering: a successful repair clears the chunks.
+            payload = "".join(self._payload_chunks) + self._close_tail
             recovered = self._recover_unclosed_tool_call()
             if recovered is None:
-                payload = "".join(self._payload_chunks) + self._close_tail
                 raise IncompleteToolCallError(
                     tool_name=_guess_tool_name(payload, self._allowed_tool_names),
                     payload_bytes=len(payload.encode("utf-8")),
                 )
-            emissions.extend(self._emit_tool_calls(recovered))
+            emissions.extend(self._emit_tool_calls(recovered, payload))
         if self._capturing_message_json:
             payload = "".join(self._message_json_chunks)
             self._reset_message_json()
@@ -581,6 +582,7 @@ class ToolCallStreamParser:
             emissions.extend(
                 self._emit_tool_calls(
                     [{"name": name, "arguments": arguments}],
+                    raw,
                 )
             )
         return emissions
@@ -663,7 +665,9 @@ class ToolCallStreamParser:
         self._close_tail = ""
         self._capturing = False
 
-        emissions: list[ProtocolEmission] = list(self._emit_tool_calls(payload_objects))
+        emissions: list[ProtocolEmission] = list(
+            self._emit_tool_calls(payload_objects, complete_payload)
+        )
         if self._tool_call_count >= self._max_tool_calls:
             self._done = True
             if self._residual(trailing).strip():
@@ -688,15 +692,43 @@ class ToolCallStreamParser:
         self._capturing = False
         return objects
 
-    def _emit_tool_calls(self, payload_objects: list[dict[str, Any]]) -> list[ToolCallEmission]:
+    def _emit_tool_calls(
+        self,
+        payload_objects: list[dict[str, Any]],
+        payload: str,
+    ) -> list[ToolCallEmission]:
         emissions: list[ToolCallEmission] = []
         for value in payload_objects:
             if self._tool_call_count >= self._max_tool_calls:
-                raise ProtocolError("more tool calls than the configured maximum")
+                raise self._tool_call_limit_error(payload, len(payload_objects))
             emissions.append(self._tool_call_from_object(value))
             self._saw_tool_call = True
             self._tool_call_count += 1
         return emissions
+
+    def _tool_call_limit_error(self, payload: str, requested: int) -> MalformedToolCallError:
+        """Drops a turn that asked for more calls than the limit allows.
+
+        Reported like any other dropped payload, so the client receives the
+        malformed-call note instead of a bridge error and the log still names
+        the tool the model was reaching for.
+        """
+        tool_name = _guess_tool_name(payload, self._allowed_tool_names)
+        payload_bytes = len(payload.encode("utf-8"))
+        log_trace(
+            "tool_call.over_limit",
+            tool_name=tool_name,
+            requested=requested,
+            maximum=self._max_tool_calls,
+            dialect=self._dialect.name,
+            payload_bytes=payload_bytes,
+        )
+        self._trace_payload("tool_call.over_limit", payload)
+        return MalformedToolCallError(
+            "more tool calls than the configured maximum",
+            tool_name=tool_name,
+            payload_bytes=payload_bytes,
+        )
 
     def _append_payload(self, value: str) -> None:
         if not value:

--- a/src/factory_droid_openai/strictjson.py
+++ b/src/factory_droid_openai/strictjson.py
@@ -9,6 +9,7 @@ __all__ = [
     "check_no_duplicate_keys",
     "decode_json_values",
     "parse_strict_json",
+    "raw_decode_strict",
 ]
 
 
@@ -47,11 +48,6 @@ def decode_json_values(text: str) -> list[Any]:
     A model that packs several tool calls into one marker pair produces
     ``{...}{...}``, which ``json.loads`` rejects as trailing data.
     """
-    decoder = json.JSONDecoder(
-        object_pairs_hook=_reject_duplicate_keys,
-        parse_constant=_reject_non_json_constant,
-        parse_float=_parse_finite_float,
-    )
     values: list[Any] = []
     index = 0
     while True:
@@ -59,8 +55,18 @@ def decode_json_values(text: str) -> list[Any]:
             index += 1
         if index >= len(text):
             return values
-        value, index = decoder.raw_decode(text, index)
+        value, index = raw_decode_strict(text, index)
         values.append(value)
+
+
+def raw_decode_strict(text: str, index: int) -> tuple[Any, int]:
+    """Decodes the strict JSON value at ``index`` and reports where it ends.
+
+    The end offset is what separates a packed payload's calls from the residue
+    that follows them, so the boundary is taken from the same strict decoder
+    that validates the value instead of a permissive second pass.
+    """
+    return _STRICT_DECODER.raw_decode(text, index)
 
 
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -81,3 +87,10 @@ def _parse_finite_float(value: str) -> float:
     if not math.isfinite(parsed):
         raise ValueError(f"non-finite number '{value}'")
     return parsed
+
+
+_STRICT_DECODER = json.JSONDecoder(
+    object_pairs_hook=_reject_duplicate_keys,
+    parse_constant=_reject_non_json_constant,
+    parse_float=_parse_finite_float,
+)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1972,6 +1972,37 @@ async def test_non_streaming_malformed_tool_call_stops_with_note(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_turn_over_the_tool_call_limit_stops_with_note(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(
+                f"{TOOL_CALL_OPEN}"
+                '{"name":"weather","arguments":{}}{"name":"weather","arguments":{}}'
+                f"{TOOL_CALL_CLOSE}"
+            ),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        parallel_tool_calls=False,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert 'for tool "weather"' in choice["message"]["content"]
+    assert "tool_calls" not in choice["message"]
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_incomplete_message_json_stops_with_note(tmp_path: Path) -> None:
     runner = FakeRunner(
         [

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,22 +1,49 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openapi_spec_validator import validate
 
 from factory_droid_openai.app import create_app
 from factory_droid_openai.config import Settings
 
+if TYPE_CHECKING:
+    from types import ModuleType
 
-def test_committed_openapi_contract_is_valid_and_current(tmp_path: Path) -> None:
-    root = Path(__file__).resolve().parents[1]
-    committed = json.loads((root / "openapi.json").read_text(encoding="utf-8"))
-    generated = create_app(Settings(workdir=tmp_path)).openapi()
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT_PATH = _ROOT / "scripts" / "generate_openapi.py"
+
+
+def _load_generator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_openapi", _SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_committed_openapi_contract_is_valid_and_current() -> None:
+    committed = json.loads((_ROOT / "openapi.json").read_text(encoding="utf-8"))
+    generated = json.loads(_load_generator().render(_ROOT))
 
     validate(committed)
-    assert committed == generated
+    # Dumping both sides makes the comparison type-sensitive: a parsed 0 equals
+    # a parsed 0.0, which is exactly the drift that kept rewriting the file.
+    assert json.dumps(committed, sort_keys=True) == json.dumps(generated, sort_keys=True)
+
+
+def test_openapi_generator_normalizes_whole_floats() -> None:
+    normalized = _load_generator().normalize_numbers(
+        {"minimum": 0.0, "values": [1.0, 1.5, True, "1.0", None], "nested": {"timeout": 2.0}}
+    )
+
+    assert json.dumps(normalized, sort_keys=True) == (
+        '{"minimum": 0, "nested": {"timeout": 2}, "values": [1, 1.5, true, "1.0", null]}'
+    )
 
 
 def test_openapi_contract_documents_compatibility_surface(tmp_path: Path) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from factory_droid_openai import logs, protocol
+from factory_droid_openai.dialects import _MAX_PACKED_BARE_CALLS
 from factory_droid_openai.models import ChatCompletionRequest
 from factory_droid_openai.protocol import (
     _MAX_TOOL_PAYLOAD_BYTES,
@@ -2434,8 +2435,8 @@ def test_stream_parser_recovers_packed_json_with_glm_value_closes(close_marker: 
         ]
 
 
-def test_stream_parser_recovers_reconstructed_568_byte_glm_read_file_payload() -> None:
-    base = "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x_dev/"
+def test_stream_parser_recovers_packed_glm_bare_read_file_calls() -> None:
+    base = "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x/"
     paths = [
         base + "README.md",
         base + "pyproject.toml",
@@ -2451,7 +2452,6 @@ def test_stream_parser_recovers_reconstructed_568_byte_glm_read_file_payload() -
         for path in paths
     ]
     payload = TOOL_CALL_OPEN.join(calls)
-    assert len(payload.encode("utf-8")) == 568
 
     stream = f"{TOOL_CALL_OPEN}{payload}"
     for chunk_size in (1, 17, len(stream)):
@@ -2483,10 +2483,40 @@ def test_stream_parser_recovers_reconstructed_568_byte_glm_read_file_payload() -
 )
 def test_stream_parser_rejects_invalid_packed_bare_calls(payload: str) -> None:
     parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=3)
-    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    # A rejected payload must not have leaked its valid leading segment first.
+    assert [emission for emission in emissions if isinstance(emission, ToolCallEmission)] == []
+    with pytest.raises(IncompleteToolCallError):
+        parser.finish()
+
+
+def test_stream_parser_rejects_packed_bare_calls_beyond_the_repair_cap() -> None:
+    segments = [
+        f'read_file{{"filePath":"f{index}"}}' for index in range(_MAX_PACKED_BARE_CALLS + 1)
+    ]
+    parser = ToolCallStreamParser(
+        frozenset({"read_file"}),
+        max_tool_calls=_MAX_PACKED_BARE_CALLS + 1,
+    )
+    parser.feed(TOOL_CALL_OPEN + TOOL_CALL_OPEN.join(segments))
 
     with pytest.raises(IncompleteToolCallError):
         parser.finish()
+
+
+def test_stream_parser_recovers_packed_bare_calls_separated_by_whitespace() -> None:
+    payload = 'read_file{"filePath":"a"}\n\t<tool_call>\n read_file{"filePath":"b"}'
+    parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=2)
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    calls = parser.finish()
+
+    assert [json.loads(call.arguments) for call in calls if isinstance(call, ToolCallEmission)] == [
+        {"filePath": "a"},
+        {"filePath": "b"},
+    ]
 
 
 def test_stream_parser_keeps_open_marker_inside_packed_bare_call_arguments() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2435,29 +2435,81 @@ def test_stream_parser_recovers_packed_json_with_glm_value_closes(close_marker: 
 
 
 def test_stream_parser_recovers_reconstructed_568_byte_glm_read_file_payload() -> None:
+    base = "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x_dev/"
     paths = [
-        "/workspace/example/monorepo/service/api/service/runtime_x/README.md",
-        "/workspace/example/monorepo/service/api/service/runtime_x/pyproject.toml",
-        "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x/main.py",
-        "/workspace/example/monorepo/service/api/src/ciapi/service/runtime_x/config.py",
+        base + "README.md",
+        base + "pyproject.toml",
+        base + "main.py",
+        base + "config.py",
     ]
     calls = [
-        json.dumps(
-            {"name": "read_file", "arguments": {"file_path": path}},
+        "read_file"
+        + json.dumps(
+            {"filePath": path, "startLine": 1, "endLine": 300},
             separators=(",", ":"),
         )
         for path in paths
     ]
-    payload = "</arg_value><tool_call>".join(calls) + "</arg_value>"
+    payload = TOOL_CALL_OPEN.join(calls)
     assert len(payload.encode("utf-8")) == 568
 
-    parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=4)
-    emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}")
-    emissions.extend(parser.finish())
+    stream = f"{TOOL_CALL_OPEN}{payload}"
+    for chunk_size in (1, 17, len(stream)):
+        parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=4)
+        emissions: list[object] = []
+        for index in range(0, len(stream), chunk_size):
+            emissions.extend(parser.feed(stream[index : index + chunk_size]))
+        emissions.extend(parser.finish())
 
-    parsed_calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
-    assert [call.name for call in parsed_calls] == ["read_file"] * 4
-    assert [json.loads(call.arguments)["file_path"] for call in parsed_calls] == paths
+        parsed_calls = [
+            emission for emission in emissions if isinstance(emission, ToolCallEmission)
+        ]
+        assert [call.name for call in parsed_calls] == ["read_file"] * 4
+        assert [json.loads(call.arguments) for call in parsed_calls] == [
+            {"filePath": path, "startLine": 1, "endLine": 300} for path in paths
+        ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        'read_file{"filePath":"a"}<tool_call>unknown{"filePath":"b"}',
+        'read_file{"filePath":"a"}<tool_call>read_file{"filePath":"b"',
+        'read_file{"filePath":"a"}junk<tool_call>read_file{"filePath":"b"}',
+        'read_file{"filePath":"a"}<tool_call>read_file{"filePath":"b","filePath":"c"}',
+        'read_file{"filePath":"a"}<tool_call><tool_call>read_file{"filePath":"b"}',
+        'read_file{"filePath":"a"}<tool_call>',
+    ],
+)
+def test_stream_parser_rejects_invalid_packed_bare_calls(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=3)
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    with pytest.raises(IncompleteToolCallError):
+        parser.finish()
+
+
+def test_stream_parser_keeps_open_marker_inside_packed_bare_call_arguments() -> None:
+    payload = (
+        'write_file{"content":"literal <tool_call> marker"}'
+        '<tool_call>read_file{"filePath":"README.md"}'
+    )
+    parser = ToolCallStreamParser(
+        frozenset({"write_file", "read_file"}),
+        max_tool_calls=2,
+    )
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    calls = parser.finish()
+
+    assert [call.name for call in calls if isinstance(call, ToolCallEmission)] == [
+        "write_file",
+        "read_file",
+    ]
+    assert [json.loads(call.arguments) for call in calls if isinstance(call, ToolCallEmission)] == [
+        {"content": "literal <tool_call> marker"},
+        {"filePath": "README.md"},
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1479,14 +1479,39 @@ def test_stream_parser_accepts_objects_packed_in_one_marker_pair() -> None:
 
 def test_stream_parser_rejects_packed_objects_past_the_cap() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+    payload = '{"name":"weather","arguments":{}}{"name":"weather","arguments":{}}'
 
-    with pytest.raises(ProtocolError, match="more tool calls than the configured maximum"):
-        parser.feed(
-            f"{TOOL_CALL_OPEN}"
-            '{"name":"weather","arguments":{}}'
-            '{"name":"weather","arguments":{}}'
-            f"{TOOL_CALL_CLOSE}"
-        )
+    with pytest.raises(MalformedToolCallError) as excinfo:
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+    assert str(excinfo.value) == "more tool calls than the configured maximum"
+    assert excinfo.value.tool_name == "weather"
+    assert excinfo.value.payload_bytes == len(payload.encode("utf-8"))
+
+
+def test_stream_parser_keeps_diagnostics_when_an_unclosed_payload_packs_too_many_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+    payload = f'weather{{"city":"Gdansk"}}{TOOL_CALL_OPEN}weather{{"city":"Sopot"}}'
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+
+    with pytest.raises(MalformedToolCallError) as excinfo:
+        parser.finish()
+
+    assert excinfo.value.tool_name == "weather"
+    assert excinfo.value.payload_bytes == len(payload.encode("utf-8"))
+
+
+def test_stream_parser_keeps_diagnostics_when_a_transcript_echo_packs_too_many_calls() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+    calls = [
+        {"id": "call_1", "type": "function", "function": {"name": "weather", "arguments": "{}"}},
+        {"id": "call_2", "type": "function", "function": {"name": "weather", "arguments": "{}"}},
+    ]
+
+    with pytest.raises(MalformedToolCallError) as excinfo:
+        parser.feed(json.dumps({"role": "assistant", "tool_calls": calls}))
+
+    assert str(excinfo.value) == "more tool calls than the configured maximum"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -26,21 +26,40 @@ _DEEPSEEK_CALL_OPEN = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}begin{_DS_BAR}>"
 _DEEPSEEK_CALL_CLOSE = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}end{_DS_BAR}>"
 _DEEPSEEK_SEP = f"<{_DS_BAR}tool{_DS_BLOCK}sep{_DS_BAR}>"
 
-_PIPE_TAG_CALL = (
-    '<|open|>call tool="weather" index="1"<|sep|>'
-    '<|open|>argument key="city" type="string"<|sep|>Gdansk<|close|>argument<|sep|>'
-    "<|close|>call<|sep|>"
-)
-_KIMI_CALL = (
-    '<|tool_call_begin|>functions.weather:0<|tool_call_argument_begin|>{"city":"Gdansk"}'
-    "<|tool_call_end|>"
-)
+
+def _pipe_tag_call(city: str, index: int) -> str:
+    return (
+        f'<|open|>call tool="weather" index="{index}"<|sep|>'
+        f'<|open|>argument key="city" type="string"<|sep|>{city}<|close|>argument<|sep|>'
+        "<|close|>call<|sep|>"
+    )
+
+
+def _kimi_call(city: str, index: int) -> str:
+    return (
+        f"<|tool_call_begin|>functions.weather:{index}"
+        f'<|tool_call_argument_begin|>{{"city":"{city}"}}<|tool_call_end|>'
+    )
+
+
+def _deepseek_call(city: str) -> str:
+    return f'{_DEEPSEEK_CALL_OPEN}weather{_DEEPSEEK_SEP}{{"city":"{city}"}}{_DEEPSEEK_CALL_CLOSE}'
+
+
+def _qwen_call(city: str) -> str:
+    return f"<function=weather><parameter=city>{city}</parameter></function>"
+
+
+def _native_call(city: str) -> str:
+    return f'{{"name":"weather","arguments":{{"city":"{city}"}}}}'
+
+
+_PIPE_TAG_CALL = _pipe_tag_call("Gdansk", 1)
+_KIMI_CALL = _kimi_call("Gdansk", 0)
 _HARMONY_CALL = 'functions.weather <|constrain|>json<|message|>{"city":"Gdansk"}'
-_DEEPSEEK_CALL = (
-    f'{_DEEPSEEK_CALL_OPEN}weather{_DEEPSEEK_SEP}{{"city":"Gdansk"}}{_DEEPSEEK_CALL_CLOSE}'
-)
+_DEEPSEEK_CALL = _deepseek_call("Gdansk")
 _INTERNLM_CALL = '{"name":"weather","parameters":{"city":"Gdansk"}}'
-_NATIVE_CALL = '{"name":"weather","arguments":{"city":"Gdansk"}}'
+_NATIVE_CALL = _native_call("Gdansk")
 _CHUNK_SIZES = (1, 2, 5, 13, 64)
 
 
@@ -50,6 +69,15 @@ class RecoveryFixture:
     payload: str
     expected_arguments: dict[str, Any]
     diagnostic_tool_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PackedRecoveryFixture:
+    """One payload holding several calls the decoder must return together."""
+
+    name: str
+    payload: str
+    expected_arguments: tuple[dict[str, Any], ...]
 
 
 _MARKER_FIXTURES = {
@@ -104,6 +132,55 @@ _DECODER_FIXTURES = (
     RecoveryFixture("bare_call", 'weather{"city":"Gdansk"}', {"city": "Gdansk"}),
 )
 
+_PACKED_ARGUMENTS = ({"city": "Gdansk"}, {"city": "Sopot"})
+_PACKED_DECODER_FIXTURES = (
+    PackedRecoveryFixture(
+        "pipe_tag_tokens",
+        _pipe_tag_call("Gdansk", 1) + _pipe_tag_call("Sopot", 2),
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "kimi_sections",
+        _kimi_call("Gdansk", 0) + _kimi_call("Sopot", 1),
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "deepseek_calls",
+        _deepseek_call("Gdansk") + "\n" + _deepseek_call("Sopot"),
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "function_parameter_tags",
+        _qwen_call("Gdansk") + _qwen_call("Sopot"),
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "json_arg_value_close",
+        f"{_native_call('Gdansk')}</arg_value>{TOOL_CALL_OPEN}{_native_call('Sopot')}</arg_value>",
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "arg_key_value_repair",
+        f'weather<arg_key>city":"Gdansk"}}{TOOL_CALL_OPEN}weather<arg_key>city":"Sopot"}}',
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "bare_call",
+        f'weather{{"city":"Gdansk"}}{TOOL_CALL_OPEN}weather{{"city":"Sopot"}}',
+        _PACKED_ARGUMENTS,
+    ),
+)
+# These shapes carry exactly one call per marker pair, so packing them is not a
+# form the wire can produce. A new decoder has to land in one list or the other.
+_SINGLE_CALL_DECODERS = frozenset(
+    {
+        "harmony_commentary",
+        "arg_key_value",
+        "python_call",
+        "bare_name",
+    }
+)
+
 
 def _assert_tool_call(
     emissions: Sequence[object],
@@ -114,6 +191,16 @@ def _assert_tool_call(
     assert isinstance(emission, ToolCallEmission)
     assert emission.name == "weather"
     assert json.loads(emission.arguments) == expected_arguments
+
+
+def _assert_tool_calls(
+    emissions: Sequence[object],
+    expected_arguments: tuple[dict[str, Any], ...],
+) -> None:
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert len(calls) == len(emissions)
+    assert [call.name for call in calls] == ["weather"] * len(expected_arguments)
+    assert [json.loads(call.arguments) for call in calls] == list(expected_arguments)
 
 
 def _variant_tracer(variants: list[str]) -> Callable[..., None]:
@@ -240,3 +327,60 @@ def test_every_decoder_recovers_from_every_partial_native_close_marker(
 
             _assert_tool_call(parser.finish(), fixture.expected_arguments)
             assert variants == [fixture.name]
+
+
+def test_packed_decoder_matrix_accounts_for_every_registered_decoder() -> None:
+    packed = {fixture.name for fixture in _PACKED_DECODER_FIXTURES}
+    assert not packed & _SINGLE_CALL_DECODERS
+    assert packed | _SINGLE_CALL_DECODERS == {decoder.name for decoder in PAYLOAD_DECODERS}
+
+
+@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+def test_every_packing_decoder_recovers_every_call_from_every_partial_close_marker(
+    fixture: PackedRecoveryFixture,
+) -> None:
+    for prefix_length in range(len(TOOL_CALL_CLOSE)):
+        stream = TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE[:prefix_length]
+        for chunk_size in _CHUNK_SIZES:
+            variants: list[str] = []
+            parser = ToolCallStreamParser(
+                frozenset({"weather"}),
+                max_tool_calls=len(fixture.expected_arguments),
+                trace_payload=_variant_tracer(variants),
+            )
+            assert _feed_in_chunks(parser, stream, chunk_size) == []
+
+            _assert_tool_calls(parser.finish(), fixture.expected_arguments)
+            # The decoder repair is traced first, the packing it returned second.
+            assert variants == [fixture.name, "packed_objects"]
+
+
+@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+def test_every_packing_decoder_handles_every_two_chunk_boundary(
+    fixture: PackedRecoveryFixture,
+) -> None:
+    stream = TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE
+
+    for boundary in range(len(stream) + 1):
+        parser = ToolCallStreamParser(
+            frozenset({"weather"}),
+            max_tool_calls=len(fixture.expected_arguments),
+        )
+        emissions = parser.feed(stream[:boundary])
+        emissions.extend(parser.feed(stream[boundary:]))
+        emissions.extend(parser.finish())
+
+        _assert_tool_calls(emissions, fixture.expected_arguments)
+
+
+@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+def test_every_packing_decoder_rejects_more_calls_than_the_turn_allows(
+    fixture: PackedRecoveryFixture,
+) -> None:
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=len(fixture.expected_arguments) - 1,
+    )
+
+    with pytest.raises(ProtocolError, match="more tool calls than the configured maximum"):
+        parser.feed(TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE)


### PR DESCRIPTION
## Summary

Packed GLM bare tool calls, plus the follow-ups the review turned up.

- Recover GLM bare tool calls packed with repeated `<tool_call>` open markers and no close markers, preserving marker text inside string arguments.
- Reject unknown tools, malformed JSON, duplicate keys, empty segments, and trailing residue.
- Walk packed segments by offset instead of re-slicing, and cap the repair at 64 segments, so a 1 MB packed payload costs 0.01s instead of 0.55s.
- Take the segment boundary from the strict decoder (`raw_decode_strict`), so each segment is parsed once instead of twice.
- Report a turn that packs more calls than `max_tool_calls` as a malformed tool call carrying the guessed tool name and payload size.
- Extend the recovery matrix: every decoder that can return several calls now runs the partial-close-marker, chunk-size and two-chunk-boundary loops with two packed calls, behind a registry gate that splits packing from single-call decoders.
- Stop the OpenAPI regeneration churn by normalizing whole floats to ints and committing the contract with sorted keys.

## Behavior change

A turn over the tool-call limit used to surface as a bridge error. It now ends
with `finish_reason="stop"` and the plain-text bridge notice, like any other
dropped malformed call, and the log carries `tool_call.over_limit` with the
guessed tool name. No call is executed either way.

## Notes

- The OpenAPI contract kept being rewritten for two reasons: pydantic renders a numeric constraint as `0` or `0.0` depending on the release, and the committed document was not key-sorted. Neither was visible to a parsed comparison, where `0 == 0.0` and dict order does not count, so the contract test and the CI check now compare re-serialized documents.
- Bare calls glued to a stray `</arg_value>` stay rejected. Widening that without a captured payload would relax fail-closed validation, so the request for wire evidence is tracked in #65.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1346 passed, 100% coverage
- `uv run python scripts/generate_openapi.py` - no diff
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
