### PR TITLE
fix(telemetry): count tool-call repairs by dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,6 +1258,9 @@ Collected fields:
 - coarse error category by route, without error messages
 - counts for tools, structured output, attachments, reasoning effort, session
   continuity, multiple choices, and warm-session use
+- counts of tool-call payload repairs, keyed by marker dialect and the repair
+  variant that handled the payload, plus counts of payloads no decoder could
+  parse and turns that asked for more calls than the limit allows
 - aggregate warm-pool, model-discovery, quarantine, and forced-kill counters
 
 Telemetry never includes prompts, responses, full model names, tool names, tool

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1371,6 +1371,16 @@ def create_app(
                 metrics.record_features(("warm_session",))
                 run_request = replace(run_request, warm_session=warm_session)
 
+        def record_repair(
+            event: str,
+            *,
+            dialect: str,
+            variant: str | None = None,
+        ) -> None:
+            metrics.record_features(
+                (_tool_call_repair_feature(event, dialect=dialect, variant=variant),)
+            )
+
         def message_parser() -> ToolCallStreamParser:
             return ToolCallStreamParser(
                 plan.allowed_tool_names,
@@ -1381,6 +1391,7 @@ def create_app(
                 repair_lost_prefix=resolved_settings.repair_lost_prefix,
                 parse_message_json=structured is None,
                 trace_payload=payload_tracer.trace,
+                record_repair=record_repair,
             )
 
         if payload.stream:
@@ -2718,6 +2729,28 @@ def _request_telemetry_features(
         )
         features.append(f"request_error:{route}:{error_category}")
     return tuple(features)
+
+
+_TOOL_CALL_REPAIR_FEATURES = {
+    "tool_call.repaired": "tool_repair",
+    "tool_call.unparsed": "tool_unparsed",
+    "tool_call.over_limit": "tool_over_limit",
+}
+
+
+def _tool_call_repair_feature(
+    event: str,
+    *,
+    dialect: str,
+    variant: str | None = None,
+) -> str:
+    """Names one tool-call repair outcome as a telemetry feature.
+
+    Both halves come from marker-dialect and decoder constants, so the label
+    space stays closed and carries no payload text, tool name or model name.
+    """
+    prefix = _TOOL_CALL_REPAIR_FEATURES.get(event, event.replace(".", "_"))
+    return f"{prefix}:{dialect}" if variant is None else f"{prefix}:{dialect}:{variant}"
 
 
 def _observe_ttft(

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -37,6 +37,15 @@ if TYPE_CHECKING:
     class PayloadTrace(Protocol):
         def __call__(self, event: str, payload: str, **fields: Any) -> None: ...
 
+    class RepairReporter(Protocol):
+        def __call__(
+            self,
+            event: str,
+            *,
+            dialect: str,
+            variant: str | None = None,
+        ) -> None: ...
+
 
 _MAX_TOOL_PAYLOAD_BYTES = 1_000_000
 _ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
@@ -320,6 +329,7 @@ class ToolCallStreamParser:
         repair_lost_prefix: bool = False,
         parse_message_json: bool = True,
         trace_payload: PayloadTrace | None = None,
+        record_repair: RepairReporter | None = None,
     ) -> None:
         self._allowed_tool_names = allowed_tool_names
         self._require_tool_call = require_tool_call
@@ -328,6 +338,7 @@ class ToolCallStreamParser:
         if repair_lost_prefix:
             self._payload_decoders = (*PAYLOAD_DECODERS, LOST_PREFIX_DECODER)
         self._trace_payload: PayloadTrace = trace_payload or NULL_PAYLOAD_TRACER.trace
+        self._record_repair = record_repair
         self._parse_message_json = parse_message_json
         self._text_tail = ""
         self._payload_chunks: list[str] = []
@@ -724,11 +735,21 @@ class ToolCallStreamParser:
             payload_bytes=payload_bytes,
         )
         self._trace_payload("tool_call.over_limit", payload)
+        self._report_repair("tool_call.over_limit")
         return MalformedToolCallError(
             "more tool calls than the configured maximum",
             tool_name=tool_name,
             payload_bytes=payload_bytes,
         )
+
+    def _report_repair(self, event: str, variant: str | None = None) -> None:
+        """Reports one repair outcome to the caller's aggregate counters.
+
+        Only the dialect and the repair variant travel, never payload text or
+        the tool name, so the caller can count shapes without holding content.
+        """
+        if self._record_repair is not None:
+            self._record_repair(event, dialect=self._dialect.name, variant=variant)
 
     def _append_payload(self, value: str) -> None:
         if not value:
@@ -768,6 +789,7 @@ class ToolCallStreamParser:
                     payload_bytes=len(body.encode("utf-8")),
                 )
                 self._trace_payload("tool_call.unparsed", body)
+                self._report_repair("tool_call.unparsed")
                 raise MalformedToolCallError(
                     f"invalid tool-call JSON: {exc}",
                     tool_name=tool_name,
@@ -785,6 +807,7 @@ class ToolCallStreamParser:
                     raise ProtocolError("tool-call payload must be a JSON object")
                 log_debug("tool_call.repaired", variant="json_array")
                 self._trace_payload("tool_call.repaired", body, variant="json_array")
+                self._report_repair("tool_call.repaired", "json_array")
                 objects.extend(value)
                 continue
             if not isinstance(value, dict):
@@ -793,6 +816,7 @@ class ToolCallStreamParser:
         if len(objects) > 1:
             log_debug("tool_call.repaired", variant="packed_objects")
             self._trace_payload("tool_call.repaired", body, variant="packed_objects")
+            self._report_repair("tool_call.repaired", "packed_objects")
         return objects
 
     def _decode_payload(self, body: str) -> list[Any] | None:
@@ -801,6 +825,7 @@ class ToolCallStreamParser:
             if decoded is not None:
                 log_debug("tool_call.repaired", variant=decoder.name)
                 self._trace_payload("tool_call.repaired", body, variant=decoder.name)
+                self._report_repair("tool_call.repaired", decoder.name)
                 return list(decoded)
         return None
 

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -368,12 +368,7 @@ class ToolCallStreamParser:
         if self._done:
             if self._ignore_transcript_tail:
                 return []
-            self._text_tail += chunk
-            if self._residual(self._text_tail).strip():
-                raise self._trailing_output_error()
-            # Everything left is verified noise except a control token the next
-            # chunk still has to complete.
-            self._text_tail = self._trailing_partial(self._text_tail)
+            self._consume_post_limit_trailing(chunk)
             return []
         if self._capturing:
             return self._consume_tool_payload(chunk)
@@ -473,9 +468,7 @@ class ToolCallStreamParser:
             )
             return emissions
 
-        held = max(
-            _partial_marker_suffix_length(value, dialect.open_marker) for dialect in MARKER_DIALECTS
-        )
+        held = _partial_open_marker_suffix_length(value)
         if detect_message_json:
             held = max(held, _partial_message_json_prefix_length(value))
         if detect_mangled:
@@ -681,13 +674,31 @@ class ToolCallStreamParser:
         )
         if self._tool_call_count >= self._max_tool_calls:
             self._done = True
-            if self._residual(trailing).strip():
-                raise self._trailing_output_error()
-            self._text_tail = self._trailing_partial(trailing)
+            self._consume_post_limit_trailing(trailing)
             return emissions
         if trailing:
             emissions.extend(self._consume_text(trailing))
         return emissions
+
+    def _consume_post_limit_trailing(self, chunk: str) -> None:
+        value = self._text_tail + chunk
+        self._text_tail = ""
+        found = find_open_marker(value)
+        if found is not None:
+            marker_index, dialect = found
+            if not self._residual(value[:marker_index]).strip():
+                self._dialect = dialect
+                self._report_repair("tool_call.over_limit")
+            raise self._trailing_output_error()
+
+        held = max(
+            _partial_open_marker_suffix_length(value),
+            len(self._trailing_partial(value)),
+        )
+        residual = value[:-held] if held else value
+        if self._residual(residual).strip():
+            raise self._trailing_output_error()
+        self._text_tail = value[-held:] if held else ""
 
     def _recover_unclosed_tool_call(self) -> list[dict[str, Any]] | None:
         """Repairs a tool call whose closing marker never arrived."""
@@ -949,6 +960,12 @@ def _partial_marker_suffix_length(value: str, marker: str) -> int:
         if value.endswith(marker[:length]):
             return length
     return 0
+
+
+def _partial_open_marker_suffix_length(value: str) -> int:
+    return max(
+        _partial_marker_suffix_length(value, dialect.open_marker) for dialect in MARKER_DIALECTS
+    )
 
 
 def _partial_message_json_prefix_length(value: str) -> int:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1972,6 +1972,58 @@ async def test_non_streaming_malformed_tool_call_stops_with_note(tmp_path: Path)
 
 
 @pytest.mark.asyncio
+async def test_repaired_tool_call_counts_a_bounded_telemetry_feature(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(f'{TOOL_CALL_OPEN}weather{{"city":"Gdansk"}}{TOOL_CALL_CLOSE}'),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    app = _app(tmp_path, runner)
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    features = dict(app.state.metrics.telemetry_snapshot().features)
+    assert features["tool_repair:native:bare_call"] == 1
+    # The label must carry no tool name, model name or payload text.
+    assert not any("weather" in feature or "Gdansk" in feature for feature in features)
+
+
+@pytest.mark.asyncio
+async def test_unparsed_tool_call_counts_a_bounded_telemetry_feature(tmp_path: Path) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}"),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    app = _app(tmp_path, runner)
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    features = dict(app.state.metrics.telemetry_snapshot().features)
+    assert features["tool_unparsed:native"] == 1
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_turn_over_the_tool_call_limit_stops_with_note(tmp_path: Path) -> None:
     runner = FakeRunner(
         [

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,7 +7,11 @@ from typing import Any
 import pytest
 
 from factory_droid_openai import logs, protocol
-from factory_droid_openai.dialects import _MAX_PACKED_BARE_CALLS
+from factory_droid_openai.dialects import (
+    _MAX_PACKED_BARE_CALLS,
+    MARKER_DIALECTS,
+    MarkerDialect,
+)
 from factory_droid_openai.models import ChatCompletionRequest
 from factory_droid_openai.protocol import (
     _MAX_TOOL_PAYLOAD_BYTES,
@@ -1498,6 +1502,11 @@ def _repair_recorder() -> tuple[list[tuple[str, str, str | None]], Any]:
     return reported, record
 
 
+def _feed_parts(parser: ToolCallStreamParser, *parts: str) -> None:
+    for part in parts:
+        parser.feed(part)
+
+
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
@@ -1557,6 +1566,93 @@ def test_stream_parser_reports_the_repair_before_the_call_limit() -> None:
         ("tool_call.repaired", "native", "packed_objects"),
         ("tool_call.over_limit", "native", None),
     ]
+
+
+def test_stream_parser_reports_a_same_feed_trailing_call_over_limit() -> None:
+    reported, record = _repair_recorder()
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=1,
+        record_repair=record,
+    )
+
+    with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+        parser.feed(_tool_call("weather", "{}") + _tool_call("weather", "{}"))
+
+    assert reported == [("tool_call.over_limit", "native", None)]
+
+
+@pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
+def test_stream_parser_reports_the_trailing_call_dialect_over_limit(
+    dialect: MarkerDialect,
+) -> None:
+    reported, record = _repair_recorder()
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=1,
+        record_repair=record,
+    )
+    parser.feed(_tool_call("weather", "{}"))
+
+    with pytest.raises(
+        ProtocolError,
+        match=rf"unexpected text after tool call \({dialect.name} dialect\)",
+    ):
+        parser.feed(dialect.open_marker)
+
+    assert reported == [("tool_call.over_limit", dialect.name, None)]
+
+
+def test_stream_parser_reports_a_split_trailing_call_over_limit() -> None:
+    second = _tool_call("weather", "{}")
+
+    for split in range(1, len(second)):
+        reported, record = _repair_recorder()
+        parser = ToolCallStreamParser(
+            frozenset({"weather"}),
+            max_tool_calls=1,
+            record_repair=record,
+        )
+        parser.feed(_tool_call("weather", "{}"))
+
+        with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+            _feed_parts(parser, second[:split], second[split:])
+
+        assert reported == [("tool_call.over_limit", "native", None)]
+
+
+def test_stream_parser_rejects_an_incomplete_trailing_marker_after_limit() -> None:
+    reported, record = _repair_recorder()
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=1,
+        record_repair=record,
+    )
+    parser.feed(_tool_call("weather", "{}"))
+    parser.feed(_tool_call("weather", "{}")[: len(TOOL_CALL_OPEN) - 1])
+
+    with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+        parser.finish()
+
+    assert reported == []
+
+
+def test_stream_parser_does_not_report_prose_before_a_trailing_call() -> None:
+    second = _tool_call("weather", "{}")
+
+    for trailing in (f"prose {second}", f"prose {second[: len(TOOL_CALL_OPEN) - 1]}"):
+        reported, record = _repair_recorder()
+        parser = ToolCallStreamParser(
+            frozenset({"weather"}),
+            max_tool_calls=1,
+            record_repair=record,
+        )
+        parser.feed(_tool_call("weather", "{}"))
+
+        with pytest.raises(ProtocolError, match="unexpected text after tool call"):
+            parser.feed(trailing)
+
+        assert reported == []
 
 
 def test_stream_parser_keeps_diagnostics_when_an_unclosed_payload_packs_too_many_calls() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1489,6 +1489,76 @@ def test_stream_parser_rejects_packed_objects_past_the_cap() -> None:
     assert excinfo.value.payload_bytes == len(payload.encode("utf-8"))
 
 
+def _repair_recorder() -> tuple[list[tuple[str, str, str | None]], Any]:
+    reported: list[tuple[str, str, str | None]] = []
+
+    def record(event: str, *, dialect: str, variant: str | None = None) -> None:
+        reported.append((event, dialect, variant))
+
+    return reported, record
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ('weather{"city":"Gdansk"}', [("tool_call.repaired", "native", "bare_call")]),
+        (
+            '{"name":"weather","arguments":{}}{"name":"weather","arguments":{}}',
+            [("tool_call.repaired", "native", "packed_objects")],
+        ),
+        (
+            '[{"name":"weather","arguments":{}}]',
+            [("tool_call.repaired", "native", "json_array")],
+        ),
+    ],
+)
+def test_stream_parser_reports_the_repair_variant_it_used(
+    payload: str,
+    expected: list[tuple[str, str, str | None]],
+) -> None:
+    reported, record = _repair_recorder()
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=2,
+        record_repair=record,
+    )
+
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+    assert reported == expected
+
+
+def test_stream_parser_reports_an_unparsed_payload() -> None:
+    reported, record = _repair_recorder()
+    parser = ToolCallStreamParser(frozenset({"weather"}), record_repair=record)
+
+    with pytest.raises(MalformedToolCallError):
+        parser.feed(f"{TOOL_CALL_OPEN}not json{TOOL_CALL_CLOSE}")
+
+    assert reported == [("tool_call.unparsed", "native", None)]
+
+
+def test_stream_parser_reports_the_repair_before_the_call_limit() -> None:
+    reported, record = _repair_recorder()
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=1,
+        record_repair=record,
+    )
+
+    with pytest.raises(MalformedToolCallError):
+        parser.feed(
+            f"{TOOL_CALL_OPEN}"
+            '{"name":"weather","arguments":{}}{"name":"weather","arguments":{}}'
+            f"{TOOL_CALL_CLOSE}"
+        )
+
+    assert reported == [
+        ("tool_call.repaired", "native", "packed_objects"),
+        ("tool_call.over_limit", "native", None),
+    ]
+
+
 def test_stream_parser_keeps_diagnostics_when_an_unclosed_payload_packs_too_many_calls() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
     payload = f'weather{{"city":"Gdansk"}}{TOOL_CALL_OPEN}weather{{"city":"Sopot"}}'


### PR DESCRIPTION
## Why

Tool-call repair outcomes only reached the local logs (`log_debug`,
`log_trace`). The aggregate could show that protocol errors rose, because
`malformed` and `truncated` both collapse into `request_error:<route>:protocol`,
but never which payload shape caused it, and never which of the 11 decoders
carry production traffic.

## What

- The stream parser takes an optional `record_repair` reporter and calls it for the repair variant it used, for a payload no decoder could parse, and for a turn over the call limit.
- The bridge counts those as telemetry features: `tool_repair:<dialect>:<variant>`, `tool_unparsed:<dialect>`, `tool_over_limit:<dialect>`.
- Both halves of every label come from marker-dialect and decoder constants, so the label space is closed at about 90 values and no payload text, tool name or model name travels.

## Notes

- Marker dialect is the framing (`native`, `pipe_tag`, `kimi_k2`, `harmony`, `deepseek`, `internlm2`), not the model family. GLM output arrives under `native`, so the repair variant is what identifies its shapes.
- `/metrics` output is unchanged: features feed the telemetry snapshot only. A Prometheus counter for operators watching their own bridge would be a separate change.
- Telemetry stays opt-out through `FACTORY_DROID_OPENAI_TELEMETRY=false` or `DO_NOT_TRACK`, and the README collected-fields list gained the new counters.
- One test asserts no feature label contains the tool name or argument text from the turn that produced it.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1353 passed, 100% coverage
- `uv run python scripts/generate_openapi.py` - no diff
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
