### PR TITLE
fix(protocol): recover packed python-call tool calls

### DIFF
--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -630,37 +630,77 @@ def _coerce_arg_value(raw: str) -> Any:
     return parsed
 
 
-_PYTHON_CALL_PATTERN = re.compile(r"^([A-Za-z_][\w.-]*)\(\s*(\{.*\})\s*\)$", re.DOTALL)
+_PYTHON_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\s*\(\s*(?=\{)")
+# Closing punctuation a template repeats around a call. It carries no argument
+# data, so skipping it between and after calls cannot change what the client
+# executes, while prose still fails to parse as the next segment.
+_CALL_RESIDUE = ")}]"
 
 
 def _decode_python_call(
     body: str,
     allowed_tool_names: frozenset[str],
 ) -> list[dict[str, Any]] | None:
-    """Rebuilds python-call syntax: ``name({"key":"value"})``.
+    """Rebuilds one or more python-call segments: ``name({"key":"value"})``.
 
     Observed on GLM-family turns: the model answers with the function call it
-    would write in code instead of the requested JSON object. The name must
-    match an allowed tool exactly, so prose containing parentheses stays
-    rejected.
+    would write in code instead of the requested JSON object, packs several of
+    them into one marker pair, and repeats the closing ``})`` after the last
+    one. Every segment must name an allowed tool and carry one strict JSON
+    object, so prose containing parentheses stays rejected.
     """
-    match = _PYTHON_CALL_PATTERN.match(body.strip())
+    stripped = body.strip()
+    calls: list[dict[str, Any]] = []
+    index = 0
+    while len(calls) < _MAX_PACKED_CALLS:
+        parsed = _decode_python_call_segment(stripped, index, allowed_tool_names)
+        if parsed is None:
+            return None
+        call, index = parsed
+        calls.append(call)
+        index = _skip_call_residue(stripped, index)
+        if index == len(stripped):
+            return calls
+        if stripped.startswith(TOOL_CALL_OPEN, index):
+            index = _skip_call_residue(stripped, index + len(TOOL_CALL_OPEN))
+            if index == len(stripped):
+                return None
+    return None
+
+
+def _decode_python_call_segment(
+    segment: str,
+    index: int,
+    allowed_tool_names: frozenset[str],
+) -> tuple[dict[str, Any], int] | None:
+    match = _PYTHON_CALL_PATTERN.match(segment, index)
     if match is None:
         return None
     name = match.group(1)
     if name not in allowed_tool_names:
         return None
-    arguments = _decode_json_object(match.group(2))
-    if arguments is None:
+    try:
+        arguments, end = raw_decode_strict(segment, match.end())
+    except (json.JSONDecodeError, ValueError):
         return None
-    return [{"name": name, "arguments": arguments}]
+    end = _skip_whitespace(segment, end)
+    if not segment.startswith(")", end):
+        return None
+    return {"name": name, "arguments": arguments}, end + 1
+
+
+def _skip_call_residue(value: str, index: int) -> int:
+    index = _skip_whitespace(value, index)
+    while index < len(value) and value[index] in _CALL_RESIDUE:
+        index = _skip_whitespace(value, index + 1)
+    return index
 
 
 _BARE_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\s*(?=\{)")
 # Past this many segments the payload is malformed beyond any tool-call limit
 # an operator can configure, and the parser's byte cap alone would let a
 # pathological turn cost far more work than it can ever be worth.
-_MAX_PACKED_BARE_CALLS = 64
+_MAX_PACKED_CALLS = 64
 
 
 def _decode_bare_call(
@@ -678,7 +718,7 @@ def _decode_bare_call(
     stripped = body.strip()
     calls: list[dict[str, Any]] = []
     index = 0
-    while len(calls) < _MAX_PACKED_BARE_CALLS:
+    while len(calls) < _MAX_PACKED_CALLS:
         parsed = _decode_bare_call_segment(stripped, index, allowed_tool_names)
         if parsed is None:
             return None

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -630,11 +630,11 @@ def _coerce_arg_value(raw: str) -> Any:
     return parsed
 
 
-_PYTHON_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\s*\(\s*(?=\{)")
+_PYTHON_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\(\s*(?=\{)")
 # Closing punctuation a template repeats around a call. It carries no argument
 # data, so skipping it between and after calls cannot change what the client
 # executes, while prose still fails to parse as the next segment.
-_CALL_RESIDUE = ")}]"
+_CALL_RESIDUE = ")}"
 
 
 def _decode_python_call(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -8,7 +8,7 @@ import pytest
 
 from factory_droid_openai import logs, protocol
 from factory_droid_openai.dialects import (
-    _MAX_PACKED_BARE_CALLS,
+    _MAX_PACKED_CALLS,
     MARKER_DIALECTS,
     MarkerDialect,
 )
@@ -1305,6 +1305,19 @@ def test_stream_parser_repairs_python_call_payload() -> None:
     assert json.loads(emissions[0].arguments) == {"name": "apple-notes"}
 
 
+def test_stream_parser_repairs_python_call_with_repeated_close_residue() -> None:
+    parser = ToolCallStreamParser(frozenset({"skill_view"}))
+
+    emissions = parser.feed(
+        TOOL_CALL_OPEN + 'skill_view({"name":"apple-notes"})})' + TOOL_CALL_CLOSE
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "skill_view"
+    assert json.loads(emissions[0].arguments) == {"name": "apple-notes"}
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -1314,6 +1327,11 @@ def test_stream_parser_repairs_python_call_payload() -> None:
         'skill_view(["apple-notes"])',
         "skill_view()",
         'print("hello")',
+        'skill_view({"name":"apple-notes"}) and then I read it',
+        'skill_view({"name":"apple-notes"}',
+        'skill_view({"name":"apple-notes"})skill_view({"name":',
+        '})skill_view({"name":"apple-notes"})',
+        f'skill_view({{"name":"apple-notes"}}){TOOL_CALL_OPEN}',
     ],
 )
 def test_stream_parser_rejects_unrepairable_python_call_payloads(payload: str) -> None:
@@ -2684,14 +2702,56 @@ def test_stream_parser_rejects_invalid_packed_bare_calls(payload: str) -> None:
 
 
 def test_stream_parser_rejects_packed_bare_calls_beyond_the_repair_cap() -> None:
-    segments = [
-        f'read_file{{"filePath":"f{index}"}}' for index in range(_MAX_PACKED_BARE_CALLS + 1)
-    ]
+    segments = [f'read_file{{"filePath":"f{index}"}}' for index in range(_MAX_PACKED_CALLS + 1)]
     parser = ToolCallStreamParser(
         frozenset({"read_file"}),
-        max_tool_calls=_MAX_PACKED_BARE_CALLS + 1,
+        max_tool_calls=_MAX_PACKED_CALLS + 1,
     )
     parser.feed(TOOL_CALL_OPEN + TOOL_CALL_OPEN.join(segments))
+
+    with pytest.raises(IncompleteToolCallError):
+        parser.finish()
+
+
+def test_stream_parser_recovers_packed_glm_python_read_file_calls() -> None:
+    base = "/home/user/.config/Code/User/workspaceStorage/9f1c8d/tasks/1786532954597/"
+    paths = [base + "content.txt", base + "api_conversation_history.json"]
+    calls = [
+        "read_file("
+        + json.dumps(
+            {"filePath": path, "startLine": 1, "endLine": 300},
+            separators=(",", ":"),
+        )
+        + ")"
+        for path in paths
+    ]
+    # Observed on a GLM turn: packed python calls, the last call's closing
+    # punctuation repeated, and the turn dying two bytes into the close marker.
+    stream = TOOL_CALL_OPEN + "".join(calls) + "})" + TOOL_CALL_CLOSE[:2]
+
+    for chunk_size in (1, 17, len(stream)):
+        parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=2)
+        emissions: list[object] = []
+        for index in range(0, len(stream), chunk_size):
+            emissions.extend(parser.feed(stream[index : index + chunk_size]))
+        emissions.extend(parser.finish())
+
+        parsed_calls = [
+            emission for emission in emissions if isinstance(emission, ToolCallEmission)
+        ]
+        assert [call.name for call in parsed_calls] == ["read_file"] * 2
+        assert [json.loads(call.arguments) for call in parsed_calls] == [
+            {"filePath": path, "startLine": 1, "endLine": 300} for path in paths
+        ]
+
+
+def test_stream_parser_rejects_packed_python_calls_beyond_the_repair_cap() -> None:
+    segments = [f'read_file({{"filePath":"f{index}"}})' for index in range(_MAX_PACKED_CALLS + 1)]
+    parser = ToolCallStreamParser(
+        frozenset({"read_file"}),
+        max_tool_calls=_MAX_PACKED_CALLS + 1,
+    )
+    parser.feed(TOOL_CALL_OPEN + "".join(segments))
 
     with pytest.raises(IncompleteToolCallError):
         parser.finish()

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -169,6 +169,11 @@ _PACKED_DECODER_FIXTURES = (
         f'weather{{"city":"Gdansk"}}{TOOL_CALL_OPEN}weather{{"city":"Sopot"}}',
         _PACKED_ARGUMENTS,
     ),
+    PackedRecoveryFixture(
+        "python_call",
+        f'weather({{"city":"Gdansk"}}){TOOL_CALL_OPEN}weather({{"city":"Sopot"}})',
+        _PACKED_ARGUMENTS,
+    ),
 )
 # These shapes carry exactly one call per marker pair, so packing them is not a
 # form the wire can produce. A new decoder has to land in one list or the other.
@@ -176,7 +181,6 @@ _SINGLE_CALL_DECODERS = frozenset(
     {
         "harmony_commentary",
         "arg_key_value",
-        "python_call",
         "bare_name",
     }
 )


### PR DESCRIPTION
## Summary

A GLM turn packed several python-call segments into one `<tool_call>` marker
pair and repeated the last call's closing `})`:

```
<tool_call>read_file({"filePath":"<path-a>","startLine":1,"endLine":300})read_file({"filePath":"<path-b>","startLine":1,"endLine":300})})</
```

`_decode_python_call` matched with a single-shot `^name({...})$` regex, so the
payload stayed unparsed. The turn then ended two bytes into the close marker,
`finish()` could not recover, and the client received `finish_reason="length"`
with zero tool calls (`event=chat.truncated`, `outcome=truncated`) instead of
the calls the model asked for.

Intended behavior: the same repair the bare-call form already gets. The payload
is walked by offset - every segment must name an allowed tool and carry one
strict JSON object, segments may follow each other directly or across a
repeated open marker, and only structural residue (`)`, `}`, `]`, whitespace)
is skipped between and after them.

Fails closed as before on prose after a call, a truncated trailing segment, a
dangling open marker, leading residue, an argument list that is not a JSON
object, and duplicate keys. The repair cap is now shared by both packed forms
(`_MAX_PACKED_BARE_CALLS` renamed to `_MAX_PACKED_CALLS`).

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1374 passed, 100.00% coverage
- [x] `uv build`
- [ ] `prs validate && prs diff --all --no-color && prs check` - not run, no PromptScript source touched

`scripts/generate_openapi.py` produces no semantic change; the regenerated file
only reorders response keys, so `openapi.json` is left untouched.

Tests added:

- python-call payload with a repeated `})` close
- packed GLM `read_file` python calls recovered with the turn dying two bytes
  into the close marker, at three chunk sizes
- packed python calls beyond the repair cap
- five new rejection cases (trailing prose, missing close paren, truncated
  second segment, leading residue, dangling open marker)
- `python_call` moved into the packed-decoder matrix, which covers every
  partial close marker, every two-chunk boundary, and the tool-call limit

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [ ] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.
      The turn was observed in bridge logs without payload tracing enabled, so
      only the head and tail of the payload were recorded; the parser-level
      regression test reproduces both verbatim instead.
