### PR TITLE
fix: close usage, logging, and tool-call gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1440,6 +1440,24 @@ tasks such as title generation.
 Log lines carry no prompt or completion text: sizes, counts, timings, model
 IDs, and session IDs only.
 
+The bridge writes one formatted record per event to stderr. For container
+diagnostics, capture the runtime output directly before sending it to a log
+collector or viewer:
+
+```bash
+# Docker:
+docker logs --timestamps droid-bridge > bridge-docker.log
+
+# Docker Compose:
+docker compose logs --no-color --no-log-prefix --timestamps droid-bridge > bridge-compose.log
+```
+
+These direct command outputs are the source of truth. If one contains one event
+and one copy of each field but a downstream export contains repeated fields,
+the duplication is in the collector or viewer, not the bridge. Do not feed
+already formatted lines back through a formatter that treats their fields as
+new record attributes.
+
 ### Payload tracing
 
 Prompts and malformed tool-call payloads stay out of the log stream. When a

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ factory-droid-openai
 | Parallel tool calls | ✅ | Several sequential tool calls per turn, bounded by a configured cap |
 | Stop sequences | ✅ | `stop` truncates the reply and interrupts the Droid turn |
 | Reasoning output | ✅ | Emitted as `reasoning` and `reasoning_content` |
-| Token usage | ✅ | Includes cache read and write token details |
+| Token usage | ⚠️ | Cache read and write details included; counts are Droid's session counters, not per-request accounting |
 | Model selection | ✅ | `/v1/models` discovers the authenticated account's current catalog |
 | Multimodal content | ⚠️ | Inline image and file data URIs use SDK attachments; remote URLs are rejected |
 | Structured outputs | ✅ | `json_schema` and `json_object` are enforced by Droid and validated by the bridge |
@@ -1561,6 +1561,7 @@ This is a compatibility bridge, not a native OpenAI inference implementation.
 | No native SDK tool-result continuation | Each request runs a fresh Droid session; warm sessions remove its startup cost, not its empty state |
 | Python SDK protocol drift | A small isolated compatibility shim supplies structured output, tool controls, and session RPCs |
 | Session-per-request execution | Prompt caching differs from a native inference endpoint |
+| Droid-reported token usage | `usage` mirrors the newest Droid session counter, so it can undercount a prompt and, on a continued session, include earlier turns |
 | Strict tool marker protocol | Invalid generated tool payloads fail closed; unparseable or truncated payloads end the turn with `finish_reason="length"` |
 | Sequential tool calls only | Calls arrive one after another, never concurrently |
 

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -711,9 +711,10 @@ def _decode_bare_call(
 
     GLM may pack calls by repeating the opening marker without emitting the
     matching closes. Every segment must name an allowed tool and carry one
-    strict JSON object, so residue and partial calls remain rejected. Segments
-    are walked by offset instead of re-sliced, keeping a payload at the byte
-    cap linear work.
+    strict JSON object. A single GLM value-close residue may separate segments
+    or terminate the payload; other residue and partial calls remain rejected.
+    Segments are walked by offset instead of re-sliced, keeping a payload at
+    the byte cap linear work.
     """
     stripped = body.strip()
     calls: list[dict[str, Any]] = []
@@ -725,6 +726,8 @@ def _decode_bare_call(
         call, index = parsed
         calls.append(call)
         index = _skip_whitespace(stripped, index)
+        if stripped.startswith(_ARG_VALUE_CLOSE, index):
+            index = _skip_whitespace(stripped, index + len(_ARG_VALUE_CLOSE))
         if index == len(stripped):
             return calls
         if not stripped.startswith(TOOL_CALL_OPEN, index):

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -537,6 +537,10 @@ class DroidRunner:
                     elif isinstance(event, WorkingStateChanged):
                         yield StatusUpdate(_state_value(event.state))
                     elif isinstance(event, TokenUsageUpdate):
+                        # The SDK forwards session-cumulative counters, and its
+                        # own TurnComplete carries the newest update as the turn
+                        # total. Summing them would count the same tokens once
+                        # per event.
                         usage = _map_usage(event)
                         yield UsageUpdate(usage)
                     elif isinstance(event, TurnComplete):

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -104,6 +104,7 @@ def test_configure_logging_replaces_previous_handler() -> None:
     logs.info("probe")
 
     assert first.getvalue() == ""
+    assert len(_lines(second)) == 1
     assert "event=probe" in second.getvalue()
 
 
@@ -130,6 +131,19 @@ def test_text_format_renders_fields_and_request_id(log_stream: io.StringIO) -> N
     assert fields["zero"] == "0.0"
     assert "dropped" not in fields
     assert "elapsed_ms" in fields
+
+
+def test_text_format_emits_each_record_and_field_once(log_stream: io.StringIO) -> None:
+    logs.bind_request("chatcmpl-once")
+    logs.info("chat.completed", model="gpt-5.4", status=200)
+
+    lines = _lines(log_stream)
+
+    assert len(lines) == 1
+    assert lines[0].count("event=chat.completed") == 1
+    assert lines[0].count("request_id=chatcmpl-once") == 1
+    assert lines[0].count("model=gpt-5.4") == 1
+    assert lines[0].count("status=200") == 1
 
 
 def test_elapsed_is_omitted_when_phase_timings_are_present(log_stream: io.StringIO) -> None:
@@ -180,6 +194,26 @@ def test_json_format_emits_one_object_per_line() -> None:
     assert payload["level"] == "WARNING"
     assert payload["request_id"] == "chatcmpl-json"
     assert payload["status"] == 429
+
+
+def test_json_format_emits_each_record_and_key_once() -> None:
+    stream = io.StringIO()
+    logs.configure_logging(level="info", log_format="json", stream=stream)
+    logs.bind_request("chatcmpl-json-once")
+
+    logs.info("chat.completed", model="gpt-5.4", status=200)
+
+    lines = _lines(stream)
+    assert len(lines) == 1
+    assert lines[0].count('"event"') == 1
+    assert lines[0].count('"request_id"') == 1
+    assert lines[0].count('"model"') == 1
+    assert lines[0].count('"status"') == 1
+    payload = json.loads(lines[0])
+    assert payload["event"] == "chat.completed"
+    assert payload["request_id"] == "chatcmpl-json-once"
+    assert payload["model"] == "gpt-5.4"
+    assert payload["status"] == 200
 
 
 def test_json_format_includes_exception_text() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2679,6 +2679,24 @@ def test_stream_parser_recovers_packed_glm_bare_read_file_calls() -> None:
         ]
 
 
+def test_stream_parser_recovers_packed_bare_calls_with_glm_value_closes() -> None:
+    payload = (
+        'read_file{"filePath":"a"}</arg_value>'
+        f"{TOOL_CALL_OPEN}"
+        'read_file{"filePath":"b"}</arg_value>'
+    )
+    parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=2)
+
+    parser.feed(f"{TOOL_CALL_OPEN}{payload}")
+    emissions = parser.finish()
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments) for call in calls] == [
+        {"filePath": "a"},
+        {"filePath": "b"},
+    ]
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -2688,6 +2706,7 @@ def test_stream_parser_recovers_packed_glm_bare_read_file_calls() -> None:
         'read_file{"filePath":"a"}<tool_call>read_file{"filePath":"b","filePath":"c"}',
         'read_file{"filePath":"a"}<tool_call><tool_call>read_file{"filePath":"b"}',
         'read_file{"filePath":"a"}<tool_call>',
+        'read_file{"filePath":"a"}</arg_value></arg_value><tool_call>read_file{"filePath":"b"}',
     ],
 )
 def test_stream_parser_rejects_invalid_packed_bare_calls(payload: str) -> None:

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -170,6 +170,12 @@ _PACKED_DECODER_FIXTURES = (
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "bare_call",
+        f'weather{{"city":"Gdansk"}}</arg_value>{TOOL_CALL_OPEN}'
+        'weather{"city":"Sopot"}</arg_value>',
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
         "python_call",
         f'weather({{"city":"Gdansk"}}){TOOL_CALL_OPEN}weather({{"city":"Sopot"}})',
         _PACKED_ARGUMENTS,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -224,6 +224,44 @@ async def test_runner_maps_sdk_stream_and_usage(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_runner_reports_newest_usage_snapshot_without_summing(tmp_path: Path) -> None:
+    """Mirrors the SDK: counters are cumulative and TurnComplete repeats the last one."""
+    first = TokenUsageUpdate(
+        input_tokens=2000,
+        output_tokens=10,
+        cache_read_tokens=6,
+        cache_write_tokens=8,
+    )
+    latest = TokenUsageUpdate(
+        input_tokens=2000,
+        output_tokens=25,
+        cache_read_tokens=6,
+        cache_write_tokens=8,
+    )
+    client = FakeClient(
+        [
+            AssistantTextDelta("hello"),
+            first,
+            latest,
+            TurnComplete(latest),
+        ]
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request())]
+
+    assert [event.usage for event in events if isinstance(event, UsageUpdate)] == [
+        Usage(2000, 10, 6, 8),
+        Usage(2000, 25, 6, 8),
+    ]
+    assert events[-1] == RunComplete(Usage(2000, 25, 6, 8))
+
+
+@pytest.mark.asyncio
 async def test_runner_passes_explicit_model_id(tmp_path: Path) -> None:
     client = FakeClient([TurnComplete()])
     runner = DroidRunner(


### PR DESCRIPTION
## Summary

- #70: `usage` now reports Droid's newest session counter instead of a summed
  total. The SDK forwards session-cumulative counters and repeats the newest one
  in `TurnComplete`, so accumulating them counted the same tokens once per
  event, and turns ending on a client tool call (no `TurnComplete`) shipped that
  inflated running total to the client. The absolute counts Droid reports are
  still unexplained, so the issue stays open pending a recorded event stream
  with `FACTORY_DROID_OPENAI_PAYLOAD_TRACE`.
- #65: accept one exact GLM `</arg_value>` residue in bare calls; extra residue
  and partial calls stay rejected. The accepted shape is still synthetic, so the
  issue stays open until a captured payload from a real turn pins it.
- #69: formatter regression coverage for text and json (one record per event,
  one copy of each field, handler replaced on reconfigure) plus direct
  Docker/Compose log-capture guidance.
- README: token usage marked ⚠️ with the session-counter caveat, and an
  architecture-limits row for undercounted prompts and continued-session
  carryover.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1382 passed, 100% coverage
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`

Closes #69
Refs #65
Refs #70
