### PR TITLE
fix(protocol): harden tool-call recovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,10 @@ Each fixture in `tests/fixtures/events/` holds one recorded Droid event stream
 plus the contract it satisfied, and `tests/test_replay.py` replays all of them
 through the ASGI app on every test run. Live runs stay in `traces/`, which is
 gitignored: rows and traces carry model output and account-specific denials.
+Every recovery path justified by live output should include its sanitized
+full-trace fixture. Use `seed` as the recorded model for hand-seeded fixtures;
+a seed can extend negative coverage but does not replace a production capture.
+Keep one fixture per scenario, model, and stream mode so replay IDs stay unique.
 
 Reasoning deltas are dropped from fixtures, because models quote the operator's
 instructions back inside them; `--keep-reasoning` overrides that for local

--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ format, because anything it named would itself be tool-call-shaped text in
 assistant content: recovery is the client's retry, not the model's next turn.
 When an earlier call in the same turn did complete, the turn keeps
 `finish_reason="tool_calls"` so the client runs the call it already received.
+Close markers inside JSON strings are argument data, not framing. Ambiguous
+repairs fail closed, including multiple argument aliases, trailing data after
+a code fence, missing Qwen parameter close tags, and pipe-tag values that do
+not match their declared type. Model-generated JSON uses the same configured
+nesting limit as request JSON.
 Qwen3's XML form declares no argument types, so a scalar value stays the
 string the model wrote unless it wrote a JSON object or array.
 
@@ -1196,12 +1201,12 @@ error types.
 | `FACTORY_DROID_OPENAI_MAX_TRANSCRIPT_BYTES` | `4194304` | Serialized transcript size limit |
 | `FACTORY_DROID_OPENAI_MAX_TOOL_SCHEMA_BYTES` | `1048576` | Serialized tool schema size limit |
 | `FACTORY_DROID_OPENAI_MAX_STRUCTURED_OUTPUT_BYTES` | `1048576` | Buffered structured output size limit |
-| `FACTORY_DROID_OPENAI_MAX_JSON_DEPTH` | `32` | Request JSON nesting limit |
+| `FACTORY_DROID_OPENAI_MAX_JSON_DEPTH` | `32` | Request and model-generated JSON nesting limit |
 | `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS` | `5` | Wait before killing a Droid process |
 | `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` | `10` | Total budget for session cleanup |
 | `FACTORY_DROID_OPENAI_UVICORN_LIMIT_CONCURRENCY` | `64` | Uvicorn connection limit |
 | `FACTORY_DROID_OPENAI_UVICORN_BACKLOG` | `128` | Uvicorn listen backlog |
-| `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `8` | Tool calls accepted per Droid turn |
+| `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `8` | Tool calls accepted per Droid turn, from 1 through 64 |
 | `FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS` | `0.5` | Wait for further events after a complete tool call |
 | `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX` | `false` | Repair tool-call payloads missing their opening `{"name":"` bytes |
 | `FACTORY_DROID_OPENAI_MAX_ATTACHMENTS` | `16` | Inline attachments per request |

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -82,6 +82,7 @@ from factory_droid_openai.runner import (
 from factory_droid_openai.strictjson import (
     DuplicateKeyError,
     check_no_duplicate_keys,
+    json_depth_exceeds,
 )
 from factory_droid_openai.telemetry import DEFAULT_TELEMETRY_ENDPOINT, TelemetryReporter
 
@@ -230,6 +231,7 @@ class StructuredOutput:
     payload: dict[str, Any]
     validator: Validator
     max_bytes: int
+    max_depth: int = 32
 
 
 class StructuredOutputBuffer:
@@ -1247,6 +1249,7 @@ def create_app(
                 payload,
                 max_schema_bytes=resolved_settings.max_tool_schema_bytes,
                 max_output_bytes=resolved_settings.max_structured_output_bytes,
+                max_json_depth=resolved_settings.max_json_depth,
             )
             plan = build_prompt(
                 payload,
@@ -1388,6 +1391,7 @@ def create_app(
                 max_tool_calls=(
                     resolved_settings.max_tool_calls if payload.parallel_tool_calls else 1
                 ),
+                max_json_depth=resolved_settings.max_json_depth,
                 repair_lost_prefix=resolved_settings.repair_lost_prefix,
                 parse_message_json=structured is None,
                 trace_payload=payload_tracer.trace,
@@ -2354,6 +2358,7 @@ def _prepare_output_format(
     *,
     max_schema_bytes: int,
     max_output_bytes: int,
+    max_json_depth: int,
 ) -> StructuredOutput | None:
     response_format = payload.response_format
     if response_format is None:
@@ -2389,6 +2394,7 @@ def _prepare_output_format(
         payload={"type": "json_schema", "schema": schema},
         validator=validator_class(schema),
         max_bytes=max_output_bytes,
+        max_depth=max_json_depth,
     )
 
 
@@ -2401,6 +2407,10 @@ def _validate_structured_output(text: str, structured: StructuredOutput) -> None
         value = parse_strict_json(text)
     except (TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ProtocolError("Factory Droid returned invalid structured JSON output") from exc
+    if json_depth_exceeds(value, structured.max_depth):
+        raise ProtocolError(
+            f"Factory Droid structured output exceeds maximum JSON depth of {structured.max_depth}"
+        )
     try:
         structured.validator.validate(value)
     except JsonSchemaValidationError as exc:

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from droid_sdk.schemas.enums import ReasoningEffort
 
+from factory_droid_openai.dialects import MAX_PACKED_CALLS
 from factory_droid_openai.logs import LOG_FORMATS, LOG_LEVELS
 from factory_droid_openai.payloadlog import PAYLOAD_TRACE_MODES
 
@@ -75,6 +76,8 @@ class Settings:
     trace_payload_file: Path | None = None
 
     def __post_init__(self) -> None:
+        if self.max_tool_calls > MAX_PACKED_CALLS:
+            raise ValueError(f"max_tool_calls must be at most {MAX_PACKED_CALLS}")
         # The warm pool keys sessions by this value, so it has to match the
         # normalized effort the request path sends to Droid, and a bad value
         # has to fail at construction instead of on every request.

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -24,7 +24,11 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from factory_droid_openai.strictjson import parse_strict_json, raw_decode_strict
+from factory_droid_openai.strictjson import (
+    JsonNestingError,
+    parse_strict_json,
+    raw_decode_strict,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -36,6 +40,7 @@ _ARG_KEY_OPEN = "<arg_key>"
 _ARG_KEY_CLOSE = "</arg_key>"
 _ARG_VALUE_OPEN = "<arg_value>"
 _ARG_VALUE_CLOSE = "</arg_value>"
+_ARG_CONTROL_PREFIXES = ("<arg_", "</arg_", "<tool_call", "</tool_call")
 
 _PIPE_TAG_TOOLS_OPEN = "<|open|>tools<|sep|>"
 _PIPE_TAG_TOOLS_CLOSE = "<|close|>tools"
@@ -98,7 +103,7 @@ _QWEN_FUNCTION_OPEN = "<function="
 _QWEN_FUNCTION_CLOSE = "</function>"
 _QWEN_PARAMETER_OPEN = "<parameter="
 _QWEN_PARAMETER_CLOSE = "</parameter>"
-_QWEN_PARAMETER_TOKEN = re.compile(r"</parameter>|<parameter=")
+_QWEN_PARAMETER_TOKEN = re.compile(r"</parameter>")
 
 _HARMONY_COMMENTARY_OPEN = "<|channel|>commentary to="
 _HARMONY_CALL_CLOSE = "<|call|>"
@@ -117,6 +122,7 @@ _FUNCTIONS_PREFIX = "functions."
 __all__ = [
     "LOST_PREFIX_DECODER",
     "MARKER_DIALECTS",
+    "MAX_PACKED_CALLS",
     "PAYLOAD_DECODERS",
     "TOOL_CALL_CLOSE",
     "TOOL_CALL_OPEN",
@@ -135,6 +141,7 @@ class MarkerDialect:
     open_marker: str
     close_marker: str
     control_tokens: tuple[str, ...] = ()
+    json_quoted_close: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,7 +152,27 @@ class PayloadDecoder:
     decode: Callable[[str, frozenset[str]], list[dict[str, Any]] | None]
 
 
-NATIVE_DIALECT = MarkerDialect("native", TOOL_CALL_OPEN, TOOL_CALL_CLOSE)
+# Past this many segments a malformed payload can only exceed every supported
+# operator limit, so every packing decoder stops before doing unbounded work.
+MAX_PACKED_CALLS = 64
+
+
+def _append_packed_call(
+    calls: list[dict[str, Any]],
+    call: dict[str, Any],
+) -> bool:
+    if len(calls) >= MAX_PACKED_CALLS:
+        return False
+    calls.append(call)
+    return True
+
+
+NATIVE_DIALECT = MarkerDialect(
+    "native",
+    TOOL_CALL_OPEN,
+    TOOL_CALL_CLOSE,
+    json_quoted_close=True,
+)
 # Observed on Kimi K3 turns served through Droid. Named after the token shape
 # rather than the model, because the same scaffolding shows up whenever a model
 # answers in its own template.
@@ -160,18 +187,21 @@ KIMI_K2_DIALECT = MarkerDialect(
     _KIMI_SECTION_OPEN,
     _KIMI_SECTION_CLOSE,
     _KIMI_CONTROL_TOKENS,
+    json_quoted_close=True,
 )
 HARMONY_DIALECT = MarkerDialect(
     "harmony",
     _HARMONY_COMMENTARY_OPEN,
     _HARMONY_CALL_CLOSE,
     _HARMONY_CONTROL_TOKENS,
+    json_quoted_close=True,
 )
 DEEPSEEK_DIALECT = MarkerDialect(
     "deepseek",
     _DEEPSEEK_SECTION_OPEN,
     _DEEPSEEK_SECTION_CLOSE,
     _DEEPSEEK_CONTROL_TOKENS,
+    json_quoted_close=True,
 )
 # The InternLM2 template selects a target right after the opening token, so the
 # tool form is the two-token sequence rather than <|action_start|> alone; the
@@ -181,6 +211,7 @@ INTERNLM2_DIALECT = MarkerDialect(
     _INTERNLM_ACTION_OPEN,
     _INTERNLM_ACTION_CLOSE,
     _INTERNLM_CONTROL_TOKENS,
+    json_quoted_close=True,
 )
 MARKER_DIALECTS: tuple[MarkerDialect, ...] = (
     NATIVE_DIALECT,
@@ -210,7 +241,11 @@ def strip_code_fence(payload: str) -> str:
         return payload
     body = payload[newline + 1 :]
     closing = body.rfind("```")
-    return body[:closing].strip() if closing >= 0 else body.strip()
+    if closing < 0:
+        return body.strip()
+    if body[closing + 3 :].strip():
+        return payload
+    return body[:closing].strip()
 
 
 def _decode_pipe_tag_tokens(
@@ -248,7 +283,8 @@ def _decode_pipe_tag_tokens(
         trailing = body[call_end + len(_PIPE_TAG_CALL_CLOSE) : block_end]
         if arguments is None or not _pipe_tag_noise_only(trailing):
             return None
-        calls.append({"name": name, "arguments": arguments})
+        if not _append_packed_call(calls, {"name": name, "arguments": arguments}):
+            return None
         index = next_index
     return calls
 
@@ -274,7 +310,10 @@ def _pipe_tag_arguments(block: str) -> dict[str, Any] | None:
             # A truncated value would silently drop data, so fail closed.
             return None
         raw = block[header_end + len(_PIPE_TAG_SEP) : value_end]
-        arguments[key] = _coerce_pipe_tag_value(raw, attributes.get("type"))
+        valid, decoded = _decode_pipe_tag_value(raw, attributes.get("type"))
+        if not valid:
+            return None
+        arguments[key] = decoded
         next_index = block.find(_PIPE_TAG_ARG_OPEN, value_end + len(_PIPE_TAG_ARG_CLOSE))
         trailing_end = next_index if next_index >= 0 else len(block)
         if not _pipe_tag_noise_only(block[value_end + len(_PIPE_TAG_ARG_CLOSE) : trailing_end]):
@@ -305,12 +344,29 @@ def _pipe_tag_attributes(
     return attributes if not header[cursor:].strip() else None
 
 
-def _coerce_pipe_tag_value(raw: str, kind: str | None) -> Any:
+def _decode_pipe_tag_value(raw: str, kind: str | None) -> tuple[bool, Any]:
     # A declared string type is authoritative: coercing "1" to a number there
     # would change the argument the client receives.
     if kind == "string":
-        return raw
-    return _coerce_arg_value(raw.strip())
+        return True, raw
+    candidate = raw.strip()
+    try:
+        parsed = parse_strict_json(candidate)
+    except JsonNestingError:
+        raise
+    except (json.JSONDecodeError, ValueError):
+        return (True, candidate) if kind is None else (False, None)
+    if kind is None:
+        return True, parsed
+    matches = {
+        "array": isinstance(parsed, list),
+        "boolean": isinstance(parsed, bool),
+        "integer": isinstance(parsed, int) and not isinstance(parsed, bool),
+        "null": parsed is None,
+        "number": isinstance(parsed, (int, float)) and not isinstance(parsed, bool),
+        "object": isinstance(parsed, dict),
+    }
+    return matches.get(kind, False), parsed
 
 
 def _decode_kimi_sections(
@@ -341,7 +397,8 @@ def _decode_kimi_sections(
         arguments = _decode_json_object(raw)
         if arguments is None:
             return None
-        calls.append({"name": name, "arguments": arguments})
+        if not _append_packed_call(calls, {"name": name, "arguments": arguments}):
+            return None
         call_end += len(_KIMI_CALL_CLOSE)
         next_index = body.find(_KIMI_CALL_OPEN, call_end)
         trailing_end = next_index if next_index >= 0 else len(body)
@@ -408,7 +465,8 @@ def _decode_deepseek_calls(
         arguments = _decode_json_object(raw) if name else None
         if name is None or arguments is None:
             return None
-        calls.append({"name": name, "arguments": arguments})
+        if not _append_packed_call(calls, {"name": name, "arguments": arguments}):
+            return None
         call_end += len(_DEEPSEEK_CALL_CLOSE)
         next_index = body.find(_DEEPSEEK_CALL_OPEN, call_end)
         trailing_end = next_index if next_index >= 0 else len(body)
@@ -461,7 +519,8 @@ def _decode_function_parameter_tags(
             return None
         if body[close + len(_QWEN_FUNCTION_CLOSE) : trailing_end].strip():
             return None
-        calls.append({"name": name, "arguments": arguments})
+        if not _append_packed_call(calls, {"name": name, "arguments": arguments}):
+            return None
         index = next_index
     return calls
 
@@ -483,12 +542,11 @@ def _qwen_call(body: str, name_end: int) -> tuple[int, dict[str, Any]] | None:
         parameter_token = _QWEN_PARAMETER_TOKEN.search(body, key_end + 1)
         if parameter_token is None or not key or key in arguments:
             return None
-        arguments[key] = _qwen_value(body[key_end + 1 : parameter_token.start()])
-        cursor = (
-            parameter_token.end()
-            if parameter_token.group() == _QWEN_PARAMETER_CLOSE
-            else parameter_token.start()
-        )
+        raw_value = body[key_end + 1 : parameter_token.start()]
+        if _QWEN_PARAMETER_OPEN in raw_value:
+            return None
+        arguments[key] = _qwen_value(raw_value)
+        cursor = parameter_token.end()
 
 
 def _qwen_value(raw: str) -> Any:
@@ -501,6 +559,8 @@ def _qwen_value(raw: str) -> Any:
         # wrote instead of being guessed into another type.
         try:
             return parse_strict_json(candidate)
+        except JsonNestingError:
+            raise
         except (json.JSONDecodeError, ValueError):
             return value
     return value
@@ -555,7 +615,8 @@ def _decode_json_arg_value_close(
             or parsed["name"] not in allowed_tool_names
         ):
             return None
-        calls.append(parsed)
+        if not _append_packed_call(calls, parsed):
+            return None
         index = _skip_whitespace(stripped, end)
         if stripped.startswith(_ARG_VALUE_CLOSE, index):
             index = _skip_whitespace(stripped, index + len(_ARG_VALUE_CLOSE))
@@ -586,7 +647,7 @@ def _decode_arg_key_value(
             return None
         key = body[index + len(_ARG_KEY_OPEN) : key_end].strip()
         value_start = body.find(_ARG_VALUE_OPEN, key_end)
-        if not key or key in arguments or value_start < 0:
+        if not key or _has_arg_control_markup(key) or key in arguments or value_start < 0:
             return None
         key_trailing = body[key_end + len(_ARG_KEY_CLOSE) : value_start]
         if key_trailing.strip():
@@ -629,9 +690,15 @@ def _decode_bare_name(
 def _coerce_arg_value(raw: str) -> Any:
     try:
         parsed = parse_strict_json(raw)
+    except JsonNestingError:
+        raise
     except (json.JSONDecodeError, ValueError):
         return raw
     return parsed
+
+
+def _has_arg_control_markup(value: str) -> bool:
+    return any(prefix in value for prefix in _ARG_CONTROL_PREFIXES)
 
 
 _PYTHON_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\(\s*(?=\{)")
@@ -656,7 +723,7 @@ def _decode_python_call(
     stripped = body.strip()
     calls: list[dict[str, Any]] = []
     index = 0
-    while len(calls) < _MAX_PACKED_CALLS:
+    while len(calls) < MAX_PACKED_CALLS:
         parsed = _decode_python_call_segment(stripped, index, allowed_tool_names)
         if parsed is None:
             return None
@@ -701,10 +768,6 @@ def _skip_call_residue(value: str, index: int) -> int:
 
 
 _BARE_CALL_PATTERN = re.compile(r"([A-Za-z_][\w.-]*)\s*(?=\{)")
-# Past this many segments the payload is malformed beyond any tool-call limit
-# an operator can configure, and the parser's byte cap alone would let a
-# pathological turn cost far more work than it can ever be worth.
-_MAX_PACKED_CALLS = 64
 
 
 def _decode_bare_call(
@@ -723,7 +786,7 @@ def _decode_bare_call(
     stripped = body.strip()
     calls: list[dict[str, Any]] = []
     index = 0
-    while len(calls) < _MAX_PACKED_CALLS:
+    while len(calls) < MAX_PACKED_CALLS:
         parsed = _decode_bare_call_segment(stripped, index, allowed_tool_names)
         if parsed is None:
             return None
@@ -766,7 +829,7 @@ def _skip_whitespace(value: str, index: int) -> int:
     return index
 
 
-_ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE, "<tool_call>")
+_ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE)
 
 
 def _decode_arg_key_value_repair(
@@ -785,14 +848,11 @@ def _decode_arg_key_value_repair(
     """
     if _ARG_KEY_OPEN not in body:
         return None
-    segments = [
-        segment.strip()
-        for segment in body.replace(TOOL_CALL_CLOSE, TOOL_CALL_OPEN).split(TOOL_CALL_OPEN)
-    ]
+    segments = _arg_key_repair_segments(body)
+    if segments is None:
+        return None
     calls: list[dict[str, Any]] = []
     for segment in segments:
-        if not segment:
-            continue
         parsed = _arg_key_repair_segment(segment, allowed_tool_names)
         if parsed is None:
             return None
@@ -800,11 +860,71 @@ def _decode_arg_key_value_repair(
     return calls or None
 
 
+def _arg_key_repair_segments(body: str) -> list[str] | None:
+    value = body.replace(TOOL_CALL_CLOSE, TOOL_CALL_OPEN).strip()
+    start = 0
+    if value.startswith(TOOL_CALL_OPEN):
+        start = _skip_whitespace(value, len(TOOL_CALL_OPEN))
+    if start >= len(value) or value.startswith(TOOL_CALL_OPEN, start):
+        return None
+    segments: list[str] = []
+    while True:
+        marker = _find_arg_key_separator(value, start)
+        if marker < 0:
+            segment = value[start:].strip()
+            if not segment or len(segments) >= MAX_PACKED_CALLS:
+                return None
+            segments.append(segment)
+            return segments
+        segment = value[start:marker].strip()
+        valid_end = (
+            segment.endswith(_ARG_VALUE_CLOSE)
+            if _ARG_VALUE_OPEN in segment
+            else segment.endswith("}")
+        )
+        if not segment or not valid_end or len(segments) >= MAX_PACKED_CALLS:
+            return None
+        segments.append(segment)
+        start = _skip_whitespace(value, marker + len(TOOL_CALL_OPEN))
+        if start >= len(value) or value.startswith(TOOL_CALL_OPEN, start):
+            return None
+
+
+def _find_arg_key_separator(value: str, start: int) -> int:
+    in_string = False
+    escaped = False
+    previous_significant: str | None = None
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if index >= start and value.startswith(TOOL_CALL_OPEN, index):
+            return index
+        if char == '"' and previous_significant in {None, "{", "[", ":", ","}:
+            in_string = True
+        if not char.isspace():
+            previous_significant = char
+        index += 1
+    return -1
+
+
 def _arg_key_repair_segment(
     segment: str,
     allowed_tool_names: frozenset[str],
 ) -> dict[str, Any] | None:
+    if TOOL_CALL_OPEN in segment or TOOL_CALL_CLOSE in segment:
+        return None
     index = segment.find(_ARG_KEY_OPEN)
+    if index < 0:
+        return None
     name = segment[:index].strip()
     if not name or name not in allowed_tool_names:
         return None
@@ -826,9 +946,6 @@ def _arg_key_repair_segment(
     return {"name": name, "arguments": arguments}
 
 
-_ARG_KEY_NAME_PATTERN = re.compile(r"^[A-Za-z_][\w.-]*$")
-
-
 def _arg_key_repair_entry(rest: str) -> tuple[str, Any, str] | None:
     key_close = rest.find(_ARG_KEY_CLOSE)
     json_sep = rest.find('":"')
@@ -848,7 +965,7 @@ def _arg_key_repair_entry(rest: str) -> tuple[str, Any, str] | None:
         value, remainder = _arg_key_repair_value(rest[json_sep + 3 :], quoted=True)
     else:
         return None
-    if not _ARG_KEY_NAME_PATTERN.match(key):
+    if not key or _has_arg_control_markup(key):
         return None
     return key, value, remainder
 

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -1016,13 +1016,15 @@ def _decode_lost_prefix(
             except (json.JSONDecodeError, ValueError):
                 return None
             arguments: Any = parsed
-            if len(parsed) == 1:
-                for key in _WRAPPER_KEYS:
-                    if key in parsed and isinstance(parsed[key], dict):
-                        # The wrapped form survived as ``"arguments":{...}``;
-                        # a single-key mapping unwraps back to the arguments.
-                        arguments = parsed[key]
-                        break
+            wrapper_keys = [key for key in _WRAPPER_KEYS if key in parsed]
+            if len(wrapper_keys) > 1:
+                # Two argument aliases in one payload is ambiguous, so the
+                # repair fails closed like the strict path does.
+                return None
+            if len(parsed) == 1 and wrapper_keys and isinstance(parsed[wrapper_keys[0]], dict):
+                # The wrapped form survived as ``"arguments":{...}``;
+                # a single-key mapping unwraps back to the arguments.
+                arguments = parsed[wrapper_keys[0]]
             return [{"name": name, "arguments": arguments}]
     return None
 

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -10,6 +10,7 @@ from factory_droid_openai.attachments import AttachmentSet, extract_attachments
 from factory_droid_openai.dialects import (
     LOST_PREFIX_DECODER,
     MARKER_DIALECTS,
+    MAX_PACKED_CALLS,
     NATIVE_DIALECT,
     PAYLOAD_DECODERS,
     TOOL_CALL_CLOSE,
@@ -27,7 +28,12 @@ from factory_droid_openai.errors import (
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import trace as log_trace
 from factory_droid_openai.payloadlog import NULL_PAYLOAD_TRACER
-from factory_droid_openai.strictjson import decode_json_values, parse_strict_json
+from factory_droid_openai.strictjson import (
+    JsonNestingError,
+    decode_json_values,
+    json_depth_exceeds,
+    parse_strict_json,
+)
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -49,6 +55,8 @@ if TYPE_CHECKING:
 
 _MAX_TOOL_PAYLOAD_BYTES = 1_000_000
 _ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
+_ARG_KEY_REPAIR_MARKER = "<arg_key>"
+_ARG_VALUE_REPAIR_CLOSE = "</arg_value>"
 _UNPARSED_HEAD_CHARS = 64
 _MESSAGE_JSON_PATTERN = re.compile(r'\{\s*"(?:role|content|tool_calls|id|type)"\s*:')
 _MESSAGE_JSON_KEYS = ("role", "content", "tool_calls", "id", "type")
@@ -130,7 +138,7 @@ def build_prompt(
     tool_schema_bytes = 0
     for tool in selected_tools:
         payload = tool.model_dump(mode="json")
-        if _json_depth_exceeds(payload, max_json_depth):
+        if json_depth_exceeds(payload, max_json_depth):
             raise RequestTooLargeError(
                 f"tool schema exceeds maximum JSON depth of {max_json_depth}"
             )
@@ -157,7 +165,7 @@ def build_prompt(
             max_attachments=max_attachments,
             max_attachment_bytes=max_attachment_bytes,
         )
-        if _json_depth_exceeds(payload, max_json_depth):
+        if json_depth_exceeds(payload, max_json_depth):
             raise RequestTooLargeError(f"message exceeds maximum JSON depth of {max_json_depth}")
         serialized, serialized_bytes = _serialize_json(payload)
         message_bytes += serialized_bytes
@@ -326,6 +334,7 @@ class ToolCallStreamParser:
         *,
         require_tool_call: bool = False,
         max_tool_calls: int = 1,
+        max_json_depth: int = 32,
         repair_lost_prefix: bool = False,
         parse_message_json: bool = True,
         trace_payload: PayloadTrace | None = None,
@@ -334,6 +343,7 @@ class ToolCallStreamParser:
         self._allowed_tool_names = allowed_tool_names
         self._require_tool_call = require_tool_call
         self._max_tool_calls = max(1, max_tool_calls)
+        self._max_json_depth = max(1, max_json_depth)
         self._payload_decoders: tuple[PayloadDecoder, ...] = PAYLOAD_DECODERS
         if repair_lost_prefix:
             self._payload_decoders = (*PAYLOAD_DECODERS, LOST_PREFIX_DECODER)
@@ -344,6 +354,11 @@ class ToolCallStreamParser:
         self._payload_chunks: list[str] = []
         self._payload_bytes = 0
         self._close_tail = ""
+        self._payload_in_string = False
+        self._payload_escaped = False
+        self._payload_previous_significant: str | None = None
+        self._payload_quoted_close = False
+        self._payload_arg_key_repair = False
         self._message_json_chunks: list[str] = []
         self._message_json_bytes = 0
         self._message_json_depth = 0
@@ -365,6 +380,10 @@ class ToolCallStreamParser:
             error = self._pending_transcript_error
             self._pending_transcript_error = None
             raise error
+        try:
+            chunk.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise ProtocolError("model output contains invalid Unicode") from exc
         if self._done:
             if self._ignore_transcript_tail:
                 return []
@@ -499,7 +518,7 @@ class ToolCallStreamParser:
             raise self._transcript_error(raw) from exc
 
         role = parsed.get("role")
-        if role in {"tool", "user"}:
+        if isinstance(role, str) and role in {"tool", "user"}:
             raise self._transcript_error(raw)
         if role != "assistant" or not parsed.get("tool_calls"):
             return self._emit_plain_json(raw, trailing)
@@ -523,6 +542,9 @@ class ToolCallStreamParser:
                 self._message_json_in_string = True
             elif char in "{[":
                 self._message_json_depth += 1
+                if self._message_json_depth > self._max_json_depth:
+                    self._reset_message_json()
+                    raise self._transcript_error("")
             elif char in "}]":
                 self._message_json_depth -= 1
                 if self._message_json_depth == 0:
@@ -583,6 +605,8 @@ class ToolCallStreamParser:
                         raise self._transcript_error(raw) from exc
             if not isinstance(arguments, dict):
                 raise self._transcript_error(raw)
+            if json_depth_exceeds(arguments, self._max_json_depth):
+                raise self._transcript_error(raw)
             emissions.extend(
                 self._emit_tool_calls(
                     [{"name": name, "arguments": arguments}],
@@ -640,35 +664,78 @@ class ToolCallStreamParser:
     def _consume_tool_payload(self, chunk: str) -> list[ProtocolEmission]:
         close_marker = self._dialect.close_marker
         value = self._close_tail + chunk
-        close_index = value.find(close_marker)
+        if self._dialect.json_quoted_close:
+            if not self._payload_arg_key_repair and _ARG_KEY_REPAIR_MARKER in value:
+                repair_index, _, _, _, _ = _find_marker_outside_json_string(
+                    value,
+                    _ARG_KEY_REPAIR_MARKER,
+                    in_string=self._payload_in_string,
+                    escaped=self._payload_escaped,
+                    previous_significant=self._payload_previous_significant,
+                )
+                self._payload_arg_key_repair = repair_index >= 0
+            close_index, _, _, _, quoted_close = _find_marker_outside_json_string(
+                value,
+                close_marker,
+                in_string=self._payload_in_string,
+                escaped=self._payload_escaped,
+                previous_significant=self._payload_previous_significant,
+                repair_value_close=self._payload_arg_key_repair,
+            )
+            self._payload_quoted_close = self._payload_quoted_close or quoted_close
+        else:
+            close_index = value.find(close_marker)
         if close_index < 0:
             held = _partial_marker_suffix_length(value, close_marker)
+            if self._dialect.json_quoted_close and not self._payload_arg_key_repair:
+                held = max(
+                    held,
+                    _partial_marker_suffix_length(value, _ARG_KEY_REPAIR_MARKER),
+                )
             committed = value[:-held] if held else value
-            self._append_payload(committed)
+            if self._dialect.json_quoted_close:
+                (
+                    _,
+                    self._payload_in_string,
+                    self._payload_escaped,
+                    self._payload_previous_significant,
+                    quoted_close,
+                ) = _find_marker_outside_json_string(
+                    committed,
+                    close_marker,
+                    in_string=self._payload_in_string,
+                    escaped=self._payload_escaped,
+                    previous_significant=self._payload_previous_significant,
+                    repair_value_close=self._payload_arg_key_repair,
+                )
+                self._payload_quoted_close = self._payload_quoted_close or quoted_close
+            try:
+                self._append_payload(committed)
+            except ProtocolError:
+                self._reset_tool_payload()
+                raise
             self._close_tail = value[-held:] if held else ""
             return []
 
         payload = value[:close_index]
-        self._append_payload(payload)
-        trailing = value[close_index + len(close_marker) :]
-        complete_payload = "".join(self._payload_chunks)
         try:
+            self._append_payload(payload)
+            complete_payload = "".join(self._payload_chunks)
+            if self._payload_arg_key_repair and self._payload_quoted_close:
+                raise MalformedToolCallError(
+                    "ambiguous close marker inside arg_key repair payload",
+                    tool_name=_guess_tool_name(
+                        complete_payload,
+                        self._allowed_tool_names,
+                    ),
+                    payload_bytes=len(complete_payload.encode("utf-8")),
+                )
             payload_objects = self._tool_payload_objects(complete_payload)
-        except MalformedToolCallError:
-            # The payload is garbage but complete: reset the capture state so
-            # finish() does not re-raise it as a truncated call.
-            self._payload_chunks.clear()
-            self._payload_bytes = 0
-            self._close_tail = ""
-            self._capturing = False
+        except ProtocolError:
+            self._reset_tool_payload()
             raise
-        self._payload_chunks.clear()
-        # The size limit is per payload, so the bounded call count is what caps
-        # the total bytes a single turn can buffer.
-        self._payload_bytes = 0
-        self._close_tail = ""
-        self._capturing = False
-
+        trailing = value[close_index + len(close_marker) :]
+        self._reset_tool_payload()
         emissions: list[ProtocolEmission] = list(
             self._emit_tool_calls(payload_objects, complete_payload)
         )
@@ -700,18 +767,31 @@ class ToolCallStreamParser:
             raise self._trailing_output_error()
         self._text_tail = value[-held:] if held else ""
 
-    def _recover_unclosed_tool_call(self) -> list[dict[str, Any]] | None:
-        """Repairs a tool call whose closing marker never arrived."""
-        # A held suffix is a verified close-marker prefix, not payload data.
-        payload = "".join(self._payload_chunks)
-        try:
-            objects = self._tool_payload_objects(payload)
-        except ProtocolError:
-            return None
+    def _reset_tool_payload(self) -> None:
         self._payload_chunks.clear()
         self._payload_bytes = 0
         self._close_tail = ""
+        self._payload_in_string = False
+        self._payload_escaped = False
+        self._payload_previous_significant = None
+        self._payload_quoted_close = False
+        self._payload_arg_key_repair = False
         self._capturing = False
+
+    def _recover_unclosed_tool_call(self) -> list[dict[str, Any]] | None:
+        """Repairs a tool call whose closing marker never arrived."""
+        # Only a close-marker prefix is verified framing; other held prefixes
+        # may be truncated payload data and must fail closed.
+        if self._close_tail and not self._dialect.close_marker.startswith(self._close_tail):
+            return None
+        payload = "".join(self._payload_chunks)
+        if self._payload_arg_key_repair and self._payload_quoted_close:
+            return None
+        try:
+            objects = self._tool_payload_objects(payload, enforce_call_limit=False)
+        except ProtocolError:
+            return None
+        self._reset_tool_payload()
         return objects
 
     def _emit_tool_calls(
@@ -770,7 +850,12 @@ class ToolCallStreamParser:
             raise ProtocolError("tool-call payload is too large")
         self._payload_chunks.append(value)
 
-    def _tool_payload_objects(self, payload: str) -> list[dict[str, Any]]:
+    def _tool_payload_objects(
+        self,
+        payload: str,
+        *,
+        enforce_call_limit: bool = True,
+    ) -> list[dict[str, Any]]:
         """Returns the tool-call objects a marker payload carries.
 
         Strict JSON first, then the decoders in
@@ -783,8 +868,18 @@ class ToolCallStreamParser:
         if not self._allowed_tool_names:
             raise ProtocolError("the model requested a tool when none are available")
         body = strip_code_fence(payload.strip())
+        object_limit = (
+            min(self._max_tool_calls, MAX_PACKED_CALLS) if enforce_call_limit else MAX_PACKED_CALLS
+        )
+        if _top_level_json_array_exceeds(body, MAX_PACKED_CALLS):
+            raise self._tool_call_limit_error(body, MAX_PACKED_CALLS + 1)
         try:
-            values = decode_json_values(body)
+            values = decode_json_values(
+                body,
+                max_values=object_limit,
+            )
+        except JsonNestingError as exc:
+            raise ProtocolError("tool-call JSON nesting exceeds the parser limit") from exc
         except (json.JSONDecodeError, ValueError) as exc:
             decoded = self._decode_payload(body)
             if decoded is None:
@@ -819,20 +914,41 @@ class ToolCallStreamParser:
                 log_debug("tool_call.repaired", variant="json_array")
                 self._trace_payload("tool_call.repaired", body, variant="json_array")
                 self._report_repair("tool_call.repaired", "json_array")
+                requested = len(objects) + len(value)
+                if requested > object_limit:
+                    self._report_packed_objects(body)
+                    raise self._tool_call_limit_error(body, requested)
+                if json_depth_exceeds(value, self._max_json_depth):
+                    raise ProtocolError(
+                        f"tool-call payload exceeds maximum JSON depth of {self._max_json_depth}"
+                    )
                 objects.extend(value)
                 continue
             if not isinstance(value, dict):
                 raise ProtocolError("tool-call payload must be a JSON object")
+            if len(objects) >= object_limit:
+                self._report_packed_objects(body)
+                raise self._tool_call_limit_error(body, len(objects) + 1)
+            if json_depth_exceeds(value, self._max_json_depth):
+                raise ProtocolError(
+                    f"tool-call payload exceeds maximum JSON depth of {self._max_json_depth}"
+                )
             objects.append(value)
         if len(objects) > 1:
-            log_debug("tool_call.repaired", variant="packed_objects")
-            self._trace_payload("tool_call.repaired", body, variant="packed_objects")
-            self._report_repair("tool_call.repaired", "packed_objects")
+            self._report_packed_objects(body)
         return objects
+
+    def _report_packed_objects(self, body: str) -> None:
+        log_debug("tool_call.repaired", variant="packed_objects")
+        self._trace_payload("tool_call.repaired", body, variant="packed_objects")
+        self._report_repair("tool_call.repaired", "packed_objects")
 
     def _decode_payload(self, body: str) -> list[Any] | None:
         for decoder in self._payload_decoders:
-            decoded = decoder.decode(body, self._allowed_tool_names)
+            try:
+                decoded = decoder.decode(body, self._allowed_tool_names)
+            except JsonNestingError as exc:
+                raise ProtocolError("tool-call JSON nesting exceeds the parser limit") from exc
             if decoded is not None:
                 log_debug("tool_call.repaired", variant=decoder.name)
                 self._trace_payload("tool_call.repaired", body, variant=decoder.name)
@@ -842,18 +958,24 @@ class ToolCallStreamParser:
 
     def _tool_call_from_object(self, parsed: dict[str, Any]) -> ToolCallEmission:
         name = parsed.get("name")
-        arguments = _tool_arguments(parsed)
+        argument_keys = [key for key in _ARGUMENT_KEYS if key in parsed]
         if not isinstance(name, str) or not name:
             raise ProtocolError("tool-call name must be a non-empty string")
         if name not in self._allowed_tool_names:
             raise ProtocolError(f"tool '{name}' is not available")
+        if not argument_keys:
+            raise ProtocolError("tool-call arguments must be a JSON object")
+        if len(argument_keys) > 1:
+            raise ProtocolError("tool call must contain exactly one arguments field")
+        arguments = parsed[argument_keys[0]]
         if not isinstance(arguments, dict):
             raise ProtocolError("tool-call arguments must be a JSON object")
+        arguments_json, _ = _serialize_json(arguments)
 
         return ToolCallEmission(
             id=f"call_{uuid.uuid4().hex[:24]}",
             name=name,
-            arguments=json.dumps(arguments, ensure_ascii=False, separators=(",", ":")),
+            arguments=arguments_json,
         )
 
 
@@ -907,28 +1029,37 @@ class StopSequenceBuffer:
         return held
 
 
-def _tool_arguments(parsed: dict[str, Any]) -> Any:
-    for key in _ARGUMENT_KEYS:
-        if key in parsed:
-            return parsed[key]
-    return None
-
-
 def _serialize_json(value: Any) -> tuple[str, int]:
     serialized = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
     return serialized, len(serialized.encode("utf-8"))
 
 
-def _json_depth_exceeds(value: Any, max_depth: int) -> bool:
-    stack: list[tuple[Any, int]] = [(value, 1)]
-    while stack:
-        current, depth = stack.pop()
-        if not isinstance(current, (dict, list)):
+def _top_level_json_array_exceeds(value: str, max_items: int) -> bool:
+    if not value.startswith("["):
+        return False
+    depth = 0
+    in_string = False
+    escaped = False
+    separators = 0
+    for char in value:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
             continue
-        if depth > max_depth:
-            return True
-        children = current.values() if isinstance(current, dict) else current
-        stack.extend((child, depth + 1) for child in children)
+        if char == '"':
+            in_string = True
+        elif char in "[{":
+            depth += 1
+        elif char in "]}":
+            depth -= 1
+        elif char == "," and depth == 1:
+            separators += 1
+            if separators >= max_items:
+                return True
     return False
 
 
@@ -952,6 +1083,46 @@ def _guess_tool_name(payload: str, allowed_tool_names: frozenset[str]) -> str | 
     if match and match.group(1) in allowed_tool_names:
         return match.group(1)
     return None
+
+
+def _find_marker_outside_json_string(
+    value: str,
+    marker: str,
+    *,
+    in_string: bool,
+    escaped: bool,
+    previous_significant: str | None,
+    repair_value_close: bool = False,
+) -> tuple[int, bool, bool, str | None, bool]:
+    index = 0
+    quoted_marker = False
+    while index < len(value):
+        char = value[index]
+        if in_string:
+            if repair_value_close and value.startswith(_ARG_VALUE_REPAIR_CLOSE, index):
+                in_string = False
+                escaped = False
+                previous_significant = ">"
+                index += len(_ARG_VALUE_REPAIR_CLOSE)
+                continue
+            if value.startswith(marker, index):
+                quoted_marker = True
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if value.startswith(marker, index):
+            return index, in_string, escaped, previous_significant, quoted_marker
+        if char == '"' and previous_significant in {None, "{", "[", ":", ","}:
+            in_string = True
+        if not char.isspace():
+            previous_significant = char
+        index += 1
+    return -1, in_string, escaped, previous_significant, quoted_marker
 
 
 def _partial_marker_suffix_length(value: str, marker: str) -> int:

--- a/src/factory_droid_openai/strictjson.py
+++ b/src/factory_droid_openai/strictjson.py
@@ -6,8 +6,10 @@ from typing import Any
 
 __all__ = [
     "DuplicateKeyError",
+    "JsonNestingError",
     "check_no_duplicate_keys",
     "decode_json_values",
+    "json_depth_exceeds",
     "parse_strict_json",
     "raw_decode_strict",
 ]
@@ -15,6 +17,10 @@ __all__ = [
 
 class DuplicateKeyError(ValueError):
     """Raised when a JSON object repeats a key the bridge must not accept."""
+
+
+class JsonNestingError(ValueError):
+    """Raised when Python's JSON decoder cannot safely traverse the input."""
 
 
 def check_no_duplicate_keys(text: str) -> None:
@@ -34,19 +40,25 @@ def parse_strict_json(text: str) -> Any:
     a non-finite float are all refused, so a caller never forwards a value a
     strict JSON parser on the client side would reject.
     """
-    return json.loads(
-        text,
-        object_pairs_hook=_reject_duplicate_keys,
-        parse_constant=_reject_non_json_constant,
-        parse_float=_parse_finite_float,
-    )
+    try:
+        parsed = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_non_json_constant,
+            parse_float=_parse_finite_float,
+        )
+    except RecursionError as exc:
+        raise JsonNestingError("JSON nesting exceeds the parser limit") from exc
+    _check_utf8_strings(parsed)
+    return parsed
 
 
-def decode_json_values(text: str) -> list[Any]:
+def decode_json_values(text: str, *, max_values: int | None = None) -> list[Any]:
     """Decodes the JSON values a payload holds, back to back.
 
     A model that packs several tool calls into one marker pair produces
-    ``{...}{...}``, which ``json.loads`` rejects as trailing data.
+    ``{...}{...}``, which ``json.loads`` rejects as trailing data. When a
+    caller supplies a limit, one extra value is enough to prove overflow.
     """
     values: list[Any] = []
     index = 0
@@ -57,6 +69,8 @@ def decode_json_values(text: str) -> list[Any]:
             return values
         value, index = raw_decode_strict(text, index)
         values.append(value)
+        if max_values is not None and len(values) > max_values:
+            return values
 
 
 def raw_decode_strict(text: str, index: int) -> tuple[Any, int]:
@@ -66,7 +80,12 @@ def raw_decode_strict(text: str, index: int) -> tuple[Any, int]:
     that follows them, so the boundary is taken from the same strict decoder
     that validates the value instead of a permissive second pass.
     """
-    return _STRICT_DECODER.raw_decode(text, index)
+    try:
+        parsed, end = _STRICT_DECODER.raw_decode(text, index)
+    except RecursionError as exc:
+        raise JsonNestingError("JSON nesting exceeds the parser limit") from exc
+    _check_utf8_strings(parsed)
+    return parsed, end
 
 
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -87,6 +106,35 @@ def _parse_finite_float(value: str) -> float:
     if not math.isfinite(parsed):
         raise ValueError(f"non-finite number '{value}'")
     return parsed
+
+
+def _check_utf8_strings(value: Any) -> None:
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, str):
+            try:
+                current.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                raise ValueError("JSON string contains an invalid Unicode surrogate") from exc
+        elif isinstance(current, dict):
+            stack.extend(current.keys())
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+
+
+def json_depth_exceeds(value: Any, max_depth: int) -> bool:
+    stack: list[tuple[Any, int]] = [(value, 1)]
+    while stack:
+        current, depth = stack.pop()
+        if not isinstance(current, (dict, list)):
+            continue
+        if depth > max_depth:
+            return True
+        children = current.values() if isinstance(current, dict) else current
+        stack.extend((child, depth + 1) for child in children)
+    return False
 
 
 _STRICT_DECODER = json.JSONDecoder(

--- a/src/factory_droid_openai/strictjson.py
+++ b/src/factory_droid_openai/strictjson.py
@@ -20,7 +20,10 @@ class DuplicateKeyError(ValueError):
 
 
 class JsonNestingError(ValueError):
-    """Raised when Python's JSON decoder cannot safely traverse the input."""
+    """Raised when JSON exceeds the bridge's safe nesting limit."""
+
+
+_MAX_JSON_NESTING = 512
 
 
 def check_no_duplicate_keys(text: str) -> None:
@@ -49,6 +52,8 @@ def parse_strict_json(text: str) -> Any:
         )
     except RecursionError as exc:
         raise JsonNestingError("JSON nesting exceeds the parser limit") from exc
+    if json_depth_exceeds(parsed, _MAX_JSON_NESTING):
+        raise JsonNestingError("JSON nesting exceeds the parser limit")
     _check_utf8_strings(parsed)
     return parsed
 
@@ -84,6 +89,8 @@ def raw_decode_strict(text: str, index: int) -> tuple[Any, int]:
         parsed, end = _STRICT_DECODER.raw_decode(text, index)
     except RecursionError as exc:
         raise JsonNestingError("JSON nesting exceeds the parser limit") from exc
+    if json_depth_exceeds(parsed, _MAX_JSON_NESTING):
+        raise JsonNestingError("JSON nesting exceeds the parser limit")
     _check_utf8_strings(parsed)
     return parsed, end
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1844,6 +1844,80 @@ async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_model_tool_json_over_the_depth_limit_never_returns_500(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    nested = "[" * 8 + "0" + "]" * 8
+    runner = FakeRunner(
+        [
+            TextDelta(
+                f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"value":{nested}}}}}'
+                f"{TOOL_CALL_CLOSE}"
+            ),
+            RunComplete(Usage()),
+        ]
+    )
+    payload = _payload(
+        stream=stream,
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+    async with _client(_feature_app(tmp_path, runner, max_json_depth=8)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code != 500
+    if not stream:
+        assert response.status_code == 502
+        assert response.json()["error"]["type"] == "factory_protocol_error"
+        return
+    events = [
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert json.loads(events[-2])["error"]["type"] == "factory_protocol_error"
+    assert events[-1] == "[DONE]"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_model_lone_surrogate_never_returns_500(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("invalid\ud800text"),
+            RunComplete(Usage()),
+        ]
+    )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(stream=stream),
+        )
+
+    assert response.status_code != 500
+    if not stream:
+        assert response.status_code == 502
+        assert response.json()["error"]["type"] == "factory_protocol_error"
+        return
+    events = [
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert json.loads(events[-2])["error"]["type"] == "factory_protocol_error"
+    assert events[-1] == "[DONE]"
+
+
+@pytest.mark.asyncio
 async def test_streaming_malformed_tool_call_stops_with_note(tmp_path: Path) -> None:
     runner = FakeRunner(
         [
@@ -3751,6 +3825,50 @@ async def test_structured_output_over_the_byte_cap_fails_closed(
     ]
     assert chunks[-1]["error"]["type"] == "factory_protocol_error"
     assert "exceeds maximum" in chunks[-1]["error"]["message"]
+    assert not [
+        choice
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+        if choice["delta"].get("content")
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_structured_output_over_the_depth_limit_fails_closed(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    nested: object = 0
+    for _ in range(8):
+        nested = {"value": nested}
+    runner = FakeRunner(
+        [
+            TextDelta(json.dumps({"result": nested})),
+            RunComplete(Usage()),
+        ]
+    )
+    app = _feature_app(tmp_path, runner, max_json_depth=8)
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                stream=stream,
+                response_format={"type": "json_object"},
+            ),
+        )
+
+    if not stream:
+        assert response.status_code == 502
+        assert "maximum JSON depth" in response.json()["error"]["message"]
+        return
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: {")
+    ]
+    assert chunks[-1]["error"]["type"] == "factory_protocol_error"
+    assert "maximum JSON depth" in chunks[-1]["error"]["message"]
     assert not [
         choice
         for chunk in chunks

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from factory_droid_openai.config import Settings
+from factory_droid_openai.dialects import MAX_PACKED_CALLS
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -440,6 +441,27 @@ def test_settings_read_feature_limits_from_environment(
     assert settings.max_tracked_sessions == 5
     assert settings.worktree == "feature-branch"
     assert settings.append_system_prompt_file == prompt_file.resolve()
+
+
+def test_settings_accepts_the_tool_call_repair_cap(tmp_path: Path) -> None:
+    settings = Settings(workdir=tmp_path, max_tool_calls=MAX_PACKED_CALLS)
+
+    assert settings.max_tool_calls == MAX_PACKED_CALLS
+
+
+def test_settings_rejects_tool_call_limit_over_the_repair_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv(
+        "FACTORY_DROID_OPENAI_MAX_TOOL_CALLS",
+        str(MAX_PACKED_CALLS + 1),
+    )
+
+    with pytest.raises(ValueError, match=f"must be at most {MAX_PACKED_CALLS}"):
+        Settings.from_env()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -8,8 +8,8 @@ import pytest
 
 from factory_droid_openai import logs, protocol
 from factory_droid_openai.dialects import (
-    _MAX_PACKED_CALLS,
     MARKER_DIALECTS,
+    MAX_PACKED_CALLS,
     MarkerDialect,
 )
 from factory_droid_openai.models import ChatCompletionRequest
@@ -501,6 +501,25 @@ def test_strict_json_keeps_finite_numbers() -> None:
     assert parse_strict_json('{"amount":1.5,"count":2}') == {"amount": 1.5, "count": 2}
 
 
+def test_strict_json_contains_excessive_nesting() -> None:
+    payload = "[" * 1100 + "0" + "]" * 1100
+
+    with pytest.raises(ValueError, match="nesting exceeds"):
+        parse_strict_json(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"value":"\\ud800"}',
+        '{"\\udfff":"value"}',
+    ],
+)
+def test_strict_json_rejects_lone_unicode_surrogates(payload: str) -> None:
+    with pytest.raises(ValueError, match="invalid Unicode surrogate"):
+        parse_strict_json(payload)
+
+
 def test_check_no_duplicate_keys_rejects_repeated_keys() -> None:
     with pytest.raises(DuplicateKeyError, match="duplicate key 'model'"):
         check_no_duplicate_keys('{"model":"a","model":"b"}')
@@ -529,6 +548,46 @@ def test_stream_parser_rejects_non_finite_tool_arguments() -> None:
         parser.feed(
             f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"lat":1e999}}}}{TOOL_CALL_CLOSE}'
         )
+
+
+def test_stream_parser_rejects_tool_arguments_over_the_json_depth_limit() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_json_depth=4)
+    payload = '{"name":"weather","arguments":{"values":[[[0]]]}}'
+
+    with pytest.raises(ProtocolError, match="maximum JSON depth"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_contains_excessively_nested_tool_json() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    nested = "[" * 1100 + "0" + "]" * 1100
+
+    with pytest.raises(ProtocolError, match="nesting exceeds"):
+        parser.feed(
+            f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"value":{nested}}}}}'
+            f"{TOOL_CALL_CLOSE}"
+        )
+
+
+def test_stream_parser_rejects_lone_surrogate_in_repaired_arguments() -> None:
+    parser = ToolCallStreamParser(frozenset({"write_file"}))
+    payload = (
+        f"{_PIPE_TAG_OPEN}"
+        '<|open|>call tool="write_file"<|sep|>'
+        '<|open|>argument key="content" type="string"<|sep|>'
+        "\ud800<|close|>argument<|sep|><|close|>call<|sep|>"
+        f"{_PIPE_TAG_CLOSE}"
+    )
+
+    with pytest.raises(ProtocolError, match="invalid Unicode"):
+        parser.feed(payload)
+
+
+def test_stream_parser_rejects_lone_surrogate_in_plain_text() -> None:
+    parser = ToolCallStreamParser(frozenset())
+
+    with pytest.raises(ProtocolError, match="invalid Unicode"):
+        parser.feed("plain\udffftext")
 
 
 def test_stream_parser_requires_object_arguments() -> None:
@@ -575,6 +634,10 @@ def test_stream_parser_accepts_whitespace_after_tool_call() -> None:
     ("value", "message"),
     [
         (f"{TOOL_CALL_OPEN}{{", "incomplete tool-call marker"),
+        (
+            f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}<arg_',
+            "incomplete tool-call marker",
+        ),
         (
             f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}{TOOL_CALL_CLOSE}trailing',
             "unexpected text after tool call",
@@ -1191,9 +1254,47 @@ def test_stream_parser_rejects_non_finite_message_values(payload: str) -> None:
         parser.feed(payload)
 
 
+def test_stream_parser_rejects_message_json_over_the_depth_limit() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_json_depth=3)
+    payload = '{"role":"assistant","metadata":{"nested":{"value":{"deep":0}}}}'
+
+    with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+        parser.feed(payload)
+
+
+def test_stream_parser_rejects_string_arguments_over_the_depth_limit() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_json_depth=4)
+    arguments = json.dumps({"values": [[[[0]]]]})
+    payload = json.dumps(
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        },
+        separators=(",", ":"),
+    )
+
+    with pytest.raises(MalformedToolCallError, match="echoed an OpenAI transcript"):
+        parser.feed(payload)
+
+
 def test_stream_parser_preserves_non_message_json() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
     payload = '{"role":1.5}'
+
+    assert parser.feed(payload) == [TextEmission(payload)]
+
+
+@pytest.mark.parametrize("payload", ['{"role":[]}', '{"role":{}}'])
+def test_stream_parser_preserves_json_with_non_string_role(payload: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
 
     assert parser.feed(payload) == [TextEmission(payload)]
 
@@ -1270,6 +1371,7 @@ def test_stream_parser_lost_prefix_stays_fail_closed(body: str) -> None:
         "weather<arg_key></arg_key><arg_value>Gdansk</arg_value>",
         "weather<arg_key>city</arg_key><arg_value>A</arg_value>"
         "<arg_key>city</arg_key><arg_value>B</arg_value>",
+        "weather<arg_key>bad<arg_value>key</arg_key><arg_value>x</arg_value>",
         "<arg_key>city</arg_key><arg_value>Gdansk</arg_value>",
     ],
 )
@@ -1393,6 +1495,17 @@ def test_stream_parser_repairs_arg_key_payload_with_leading_separator() -> None:
     assert json.loads(emissions[0].arguments) == {"name": "apple-notes"}
 
 
+def test_stream_parser_repairs_arg_key_payload_with_space_in_key() -> None:
+    parser = ToolCallStreamParser(frozenset({"skill_view"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}skill_view<arg_key>file path":"notes.txt"}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"file path": "notes.txt"}
+
+
 def test_stream_parser_repairs_arg_key_mangled_two_call_payload() -> None:
     parser = ToolCallStreamParser(
         frozenset({"skill_view", "terminal"}),
@@ -1419,7 +1532,7 @@ def test_stream_parser_repairs_arg_key_mangled_two_call_payload() -> None:
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
-        ('skill_view<arg_key>count":"3}', {"count": 3}),
+        ('skill_view<arg_key>count":"3"}', {"count": 3}),
         ('skill_view<arg_key>name":"abc"', {"name": "abc"}),
     ],
 )
@@ -1436,14 +1549,31 @@ def test_stream_parser_repairs_arg_key_value_endings(
     assert json.loads(emissions[0].arguments) == expected
 
 
+def test_stream_parser_repairs_proper_arg_key_value_with_packed_residue() -> None:
+    parser = ToolCallStreamParser(frozenset({"skill_view"}), max_tool_calls=2)
+    payload = (
+        "skill_view<arg_key>count</arg_key><arg_value>3}</arg_value>"
+        f"{TOOL_CALL_OPEN}"
+        'skill_view<arg_key>name":"abc"}'
+    )
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+    calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
+    assert [json.loads(call.arguments) for call in calls] == [
+        {"count": 3},
+        {"name": "abc"},
+    ]
+
+
 @pytest.mark.parametrize(
     "payload",
     [
         'unknown<arg_key>name":"apple-notes"}',
-        'skill_view<arg_key>na me":"apple-notes"}',
         'skill_view<arg_key>name":"a"}<arg_key>name":"b"}',
         'skill_view<arg_key>name":"a"}</arg_value> junk',
         'skill_view<arg_key>name":"a"}<tool_call>unknown<arg_key>k":"v"}',
+        'skill_view<arg_key>bad<arg_key>key":"x"',
     ],
 )
 def test_stream_parser_rejects_unrepairable_arg_key_repair_payloads(payload: str) -> None:
@@ -1476,6 +1606,17 @@ def test_stream_parser_repairs_unterminated_fence() -> None:
 
     assert len(emissions) == 1
     assert isinstance(emissions[0], ToolCallEmission)
+
+
+def test_stream_parser_rejects_data_after_a_closed_code_fence() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(
+            f"{TOOL_CALL_OPEN}```json\n"
+            '{"name":"weather","arguments":{"city":"Sopot"}}\n'
+            f"```garbage{TOOL_CALL_CLOSE}"
+        )
 
 
 def test_stream_parser_keeps_single_line_fence_unrepaired() -> None:
@@ -1823,9 +1964,14 @@ def test_stream_parser_recovers_pipe_tag_call_without_close_marker() -> None:
     [
         ('key="city" type="string"', "123", "123"),
         ('key="days" type="number"', "3", 3),
+        ('key="days" type="integer"', "3", 3),
         ('key="metric" type="boolean"', "true", True),
         ('key="filter" type="object"', '{"unit":"c"}', {"unit": "c"}),
+        ('key="cities" type="array"', '["Gdansk","Sopot"]', ["Gdansk", "Sopot"]),
+        ('key="value" type="null"', "null", None),
         ('key="days"', "7", 7),
+        ('key="city"', "Gdansk", "Gdansk"),
+        ('key="city"', "  Gdansk  ", "Gdansk"),
     ],
 )
 def test_stream_parser_coerces_pipe_tag_argument_values(
@@ -1845,6 +1991,64 @@ def test_stream_parser_coerces_pipe_tag_argument_values(
 
     assert isinstance(emissions[0], ToolCallEmission)
     assert list(json.loads(emissions[0].arguments).values()) == [expected]
+
+
+@pytest.mark.parametrize(
+    ("declared_type", "raw"),
+    [
+        ("number", "true"),
+        ("integer", "1.5"),
+        ("boolean", "yes"),
+        ("object", "[]"),
+        ("array", "{}"),
+        ("null", "false"),
+        ("unknown", '"value"'),
+        ("number", "many"),
+    ],
+)
+def test_stream_parser_rejects_mismatched_pipe_tag_argument_types(
+    declared_type: str,
+    raw: str,
+) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(
+            f"{_PIPE_TAG_OPEN}"
+            '<|open|>call tool="weather"<|sep|>'
+            f'<|open|>argument key="value" type="{declared_type}"<|sep|>'
+            f"{raw}<|close|>argument<|sep|><|close|>call<|sep|>"
+            f"{_PIPE_TAG_CLOSE}"
+        )
+
+
+@pytest.mark.parametrize("decoder", ["pipe-tag", "qwen", "arg-key"])
+def test_recovery_decoders_do_not_downgrade_excessive_json_nesting(
+    decoder: str,
+) -> None:
+    nested = "[" * 1100 + "0" + "]" * 1100
+    if decoder == "pipe-tag":
+        stream = (
+            f"{_PIPE_TAG_OPEN}"
+            '<|open|>call tool="weather"<|sep|>'
+            '<|open|>argument key="value" type="array"<|sep|>'
+            f"{nested}<|close|>argument<|sep|><|close|>call<|sep|>"
+            f"{_PIPE_TAG_CLOSE}"
+        )
+    elif decoder == "qwen":
+        stream = (
+            f"{TOOL_CALL_OPEN}<function=weather><parameter=value>{nested}"
+            f"</parameter></function>{TOOL_CALL_CLOSE}"
+        )
+    else:
+        stream = (
+            f"{TOOL_CALL_OPEN}weather<arg_key>value</arg_key>"
+            f"<arg_value>{nested}</arg_value>{TOOL_CALL_CLOSE}"
+        )
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    with pytest.raises(ProtocolError, match="nesting exceeds"):
+        parser.feed(stream)
 
 
 def test_stream_parser_preserves_pipe_tag_string_whitespace() -> None:
@@ -2423,18 +2627,15 @@ def test_stream_parser_preserves_qwen_function_tags_inside_values() -> None:
     }
 
 
-def test_stream_parser_recovers_a_qwen_parameter_without_its_close_tag() -> None:
-    # The next parameter tag still delimits the value, so the call survives.
+def test_stream_parser_rejects_qwen_parameter_without_its_close_tag() -> None:
     parser = ToolCallStreamParser(frozenset({"get_current_weather"}))
 
-    emissions = parser.feed(
-        f"{TOOL_CALL_OPEN}\n<function=get_current_weather>\n"
-        "<parameter=city>\nDallas\n<parameter=state>\nTX\n</parameter>\n"
-        f"</function>\n{TOOL_CALL_CLOSE}"
-    )
-
-    assert isinstance(emissions[0], ToolCallEmission)
-    assert json.loads(emissions[0].arguments) == {"city": "Dallas", "state": "TX"}
+    with pytest.raises(ProtocolError, match="invalid tool-call JSON"):
+        parser.feed(
+            f"{TOOL_CALL_OPEN}\n<function=get_current_weather>\n"
+            "<parameter=city>\nDallas\n<parameter=state>\nTX\n</parameter>\n"
+            f"</function>\n{TOOL_CALL_CLOSE}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -2541,6 +2742,46 @@ def test_stream_parser_accepts_a_json_array_of_calls() -> None:
     assert [json.loads(call.arguments)["city"] for call in calls] == ["Gdansk", "Sopot"]
 
 
+def test_stream_parser_rejects_json_array_over_the_configured_call_limit() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=1)
+    payload = (
+        '[{"name":"weather","arguments":{"city":"Gdansk"}},'
+        '{"name":"weather","arguments":{"city":"Sopot"}}]'
+    )
+
+    with pytest.raises(ProtocolError, match="configured maximum"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_rejects_nested_json_array_over_the_depth_limit() -> None:
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=1,
+        max_json_depth=3,
+    )
+    payload = '[{"name":"weather","arguments":{"values":[0]}}]'
+
+    with pytest.raises(ProtocolError, match="maximum JSON depth"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_rejects_json_array_over_the_global_repair_cap() -> None:
+    calls = [
+        {
+            "name": "weather",
+            "arguments": ({"text": 'slash\\"quote'} if index == 0 else {"index": index}),
+        }
+        for index in range(MAX_PACKED_CALLS + 1)
+    ]
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=MAX_PACKED_CALLS + 1,
+    )
+
+    with pytest.raises(ProtocolError, match="configured maximum"):
+        parser.feed(f"{TOOL_CALL_OPEN}{json.dumps(calls, separators=(',', ':'))}{TOOL_CALL_CLOSE}")
+
+
 @pytest.mark.parametrize("payload", ["[]", '[{"name":"weather","arguments":{}},7]'])
 def test_stream_parser_rejects_invalid_json_arrays(payload: str) -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
@@ -2565,6 +2806,22 @@ def test_stream_parser_reads_argument_key_aliases() -> None:
 
     assert isinstance(emissions[0], ToolCallEmission)
     assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+@pytest.mark.parametrize("alias", ["parameters", "args", "input"])
+def test_stream_parser_rejects_multiple_argument_aliases(alias: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+    payload = json.dumps(
+        {
+            "name": "weather",
+            "arguments": {"city": "Gdansk"},
+            alias: {"city": "Sopot"},
+        },
+        separators=(",", ":"),
+    )
+
+    with pytest.raises(ProtocolError, match="exactly one arguments field"):
+        parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
 
 
 def test_stream_parser_requires_an_arguments_key() -> None:
@@ -2791,15 +3048,28 @@ def test_stream_parser_rejects_invalid_packed_bare_calls(payload: str) -> None:
 
 
 def test_stream_parser_rejects_packed_bare_calls_beyond_the_repair_cap() -> None:
-    segments = [f'read_file{{"filePath":"f{index}"}}' for index in range(_MAX_PACKED_CALLS + 1)]
+    segments = [f'read_file{{"filePath":"f{index}"}}' for index in range(MAX_PACKED_CALLS + 1)]
     parser = ToolCallStreamParser(
         frozenset({"read_file"}),
-        max_tool_calls=_MAX_PACKED_CALLS + 1,
+        max_tool_calls=MAX_PACKED_CALLS + 1,
     )
     parser.feed(TOOL_CALL_OPEN + TOOL_CALL_OPEN.join(segments))
 
     with pytest.raises(IncompleteToolCallError):
         parser.finish()
+
+
+def test_stream_parser_accepts_packed_bare_calls_at_the_repair_cap() -> None:
+    segments = [f'read_file{{"filePath":"f{index}"}}' for index in range(MAX_PACKED_CALLS)]
+    parser = ToolCallStreamParser(
+        frozenset({"read_file"}),
+        max_tool_calls=MAX_PACKED_CALLS,
+    )
+    parser.feed(TOOL_CALL_OPEN + TOOL_CALL_OPEN.join(segments))
+
+    emissions = parser.finish()
+
+    assert len(emissions) == MAX_PACKED_CALLS
 
 
 def test_stream_parser_recovers_packed_glm_python_read_file_calls() -> None:
@@ -2835,10 +3105,10 @@ def test_stream_parser_recovers_packed_glm_python_read_file_calls() -> None:
 
 
 def test_stream_parser_rejects_packed_python_calls_beyond_the_repair_cap() -> None:
-    segments = [f'read_file({{"filePath":"f{index}"}})' for index in range(_MAX_PACKED_CALLS + 1)]
+    segments = [f'read_file({{"filePath":"f{index}"}})' for index in range(MAX_PACKED_CALLS + 1)]
     parser = ToolCallStreamParser(
         frozenset({"read_file"}),
-        max_tool_calls=_MAX_PACKED_CALLS + 1,
+        max_tool_calls=MAX_PACKED_CALLS + 1,
     )
     parser.feed(TOOL_CALL_OPEN + "".join(segments))
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1356,6 +1356,7 @@ def test_stream_parser_lost_prefix_keeps_scalar_wrapper_key() -> None:
         'unknown","city":"Gdansk"}',
         'weather","city":"Gdansk"',
         'weather","city":"A","city":"B"}',
+        'weather","arguments":{"city":"A"},"parameters":{"city":"B"}}',
     ],
 )
 def test_stream_parser_lost_prefix_stays_fail_closed(body: str) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -501,8 +501,9 @@ def test_strict_json_keeps_finite_numbers() -> None:
     assert parse_strict_json('{"amount":1.5,"count":2}') == {"amount": 1.5, "count": 2}
 
 
-def test_strict_json_contains_excessive_nesting() -> None:
-    payload = "[" * 1100 + "0" + "]" * 1100
+@pytest.mark.parametrize("depth", [600, 1100])
+def test_strict_json_contains_excessive_nesting(depth: int) -> None:
+    payload = "[" * depth + "0" + "]" * depth
 
     with pytest.raises(ValueError, match="nesting exceeds"):
         parse_strict_json(payload)
@@ -558,9 +559,10 @@ def test_stream_parser_rejects_tool_arguments_over_the_json_depth_limit() -> Non
         parser.feed(f"{TOOL_CALL_OPEN}{payload}{TOOL_CALL_CLOSE}")
 
 
-def test_stream_parser_contains_excessively_nested_tool_json() -> None:
+@pytest.mark.parametrize("depth", [600, 1100])
+def test_stream_parser_contains_excessively_nested_tool_json(depth: int) -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
-    nested = "[" * 1100 + "0" + "]" * 1100
+    nested = "[" * depth + "0" + "]" * depth
 
     with pytest.raises(ProtocolError, match="nesting exceeds"):
         parser.feed(

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from factory_droid_openai.dialects import MARKER_DIALECTS, PAYLOAD_DECODERS, MarkerDialect
+from factory_droid_openai.dialects import (
+    MARKER_DIALECTS,
+    MAX_PACKED_CALLS,
+    PAYLOAD_DECODERS,
+    PIPE_TAG_DIALECT,
+    MarkerDialect,
+)
 from factory_droid_openai.protocol import (
     TOOL_CALL_CLOSE,
     TOOL_CALL_OPEN,
@@ -27,31 +33,53 @@ _DEEPSEEK_CALL_CLOSE = f"<{_DS_BAR}tool{_DS_BLOCK}call{_DS_BLOCK}end{_DS_BAR}>"
 _DEEPSEEK_SEP = f"<{_DS_BAR}tool{_DS_BLOCK}sep{_DS_BAR}>"
 
 
-def _pipe_tag_call(city: str, index: int) -> str:
+def _pipe_tag_call(city: str, index: int, name: str = "weather") -> str:
     return (
-        f'<|open|>call tool="weather" index="{index}"<|sep|>'
+        f'<|open|>call tool="{name}" index="{index}"<|sep|>'
         f'<|open|>argument key="city" type="string"<|sep|>{city}<|close|>argument<|sep|>'
         "<|close|>call<|sep|>"
     )
 
 
-def _kimi_call(city: str, index: int) -> str:
+def _kimi_call(city: str, index: int, name: str = "weather") -> str:
     return (
-        f"<|tool_call_begin|>functions.weather:{index}"
+        f"<|tool_call_begin|>functions.{name}:{index}"
         f'<|tool_call_argument_begin|>{{"city":"{city}"}}<|tool_call_end|>'
     )
 
 
-def _deepseek_call(city: str) -> str:
-    return f'{_DEEPSEEK_CALL_OPEN}weather{_DEEPSEEK_SEP}{{"city":"{city}"}}{_DEEPSEEK_CALL_CLOSE}'
+def _deepseek_call(city: str, name: str = "weather") -> str:
+    return f'{_DEEPSEEK_CALL_OPEN}{name}{_DEEPSEEK_SEP}{{"city":"{city}"}}{_DEEPSEEK_CALL_CLOSE}'
 
 
-def _qwen_call(city: str) -> str:
-    return f"<function=weather><parameter=city>{city}</parameter></function>"
+def _qwen_call(city: str, name: str = "weather") -> str:
+    return f"<function={name}><parameter=city>{city}</parameter></function>"
 
 
-def _native_call(city: str) -> str:
-    return f'{{"name":"weather","arguments":{{"city":"{city}"}}}}'
+def _native_call(city: str, name: str = "weather") -> str:
+    return f'{{"name":"{name}","arguments":{{"city":"{city}"}}}}'
+
+
+def _close_collision_payload(dialect: MarkerDialect) -> str:
+    arguments = json.dumps(
+        {"text": f'quoted " {dialect.close_marker}'},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if dialect.name == "native":
+        return f'{{"name":"weather","arguments":{arguments}}}'
+    if dialect.name == "kimi_k2":
+        return (
+            "<|tool_call_begin|>functions.weather:0"
+            f"<|tool_call_argument_begin|>{arguments}<|tool_call_end|>"
+        )
+    if dialect.name == "harmony":
+        return f"functions.weather <|constrain|>json<|message|>{arguments}"
+    if dialect.name == "deepseek":
+        return f"{_DEEPSEEK_CALL_OPEN}weather{_DEEPSEEK_SEP}{arguments}{_DEEPSEEK_CALL_CLOSE}"
+    if dialect.name == "internlm2":
+        return f'{{"name":"weather","parameters":{arguments}}}'
+    raise AssertionError(f"dialect is not JSON framed: {dialect.name}")
 
 
 _PIPE_TAG_CALL = _pipe_tag_call("Gdansk", 1)
@@ -75,9 +103,19 @@ class RecoveryFixture:
 class PackedRecoveryFixture:
     """One payload holding several calls the decoder must return together."""
 
+    case_id: str
     name: str
     payload: str
+    expected_names: tuple[str, ...]
     expected_arguments: tuple[dict[str, Any], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RejectionFixture:
+    case_id: str
+    stream: str
+    allowed_tool_names: frozenset[str]
+    max_tool_calls: int = 1
 
 
 _MARKER_FIXTURES = {
@@ -133,56 +171,78 @@ _DECODER_FIXTURES = (
 )
 
 _PACKED_ARGUMENTS = ({"city": "Gdansk"}, {"city": "Sopot"})
+_PACKED_NAMES = ("weather", "forecast")
 _PACKED_DECODER_FIXTURES = (
     PackedRecoveryFixture(
+        "pipe-tag-mixed",
         "pipe_tag_tokens",
-        _pipe_tag_call("Gdansk", 1) + _pipe_tag_call("Sopot", 2),
+        _pipe_tag_call("Gdansk", 1) + _pipe_tag_call("Sopot", 2, "forecast"),
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "kimi-mixed",
         "kimi_sections",
-        _kimi_call("Gdansk", 0) + _kimi_call("Sopot", 1),
+        _kimi_call("Gdansk", 0) + _kimi_call("Sopot", 1, "forecast"),
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "deepseek-mixed",
         "deepseek_calls",
-        _deepseek_call("Gdansk") + "\n" + _deepseek_call("Sopot"),
+        _deepseek_call("Gdansk") + "\n" + _deepseek_call("Sopot", "forecast"),
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "qwen-mixed",
         "function_parameter_tags",
-        _qwen_call("Gdansk") + _qwen_call("Sopot"),
+        _qwen_call("Gdansk") + _qwen_call("Sopot", "forecast"),
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "json-value-close",
         "json_arg_value_close",
-        f"{_native_call('Gdansk')}</arg_value>{TOOL_CALL_OPEN}{_native_call('Sopot')}</arg_value>",
+        f"{_native_call('Gdansk')}</arg_value>{TOOL_CALL_OPEN}"
+        f"{_native_call('Sopot', 'forecast')}</arg_value>",
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "json-open-separator",
         "json_arg_value_close",
-        f"{_native_call('Gdansk')}{TOOL_CALL_OPEN}{_native_call('Sopot')}",
+        f"{_native_call('Gdansk')}{TOOL_CALL_OPEN}{_native_call('Sopot', 'forecast')}",
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "arg-key-mixed",
         "arg_key_value_repair",
-        f'weather<arg_key>city":"Gdansk"}}{TOOL_CALL_OPEN}weather<arg_key>city":"Sopot"}}',
+        f'weather<arg_key>city":"Gdansk"}}{TOOL_CALL_OPEN}forecast<arg_key>city":"Sopot"}}',
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "bare-open-separator",
         "bare_call",
-        f'weather{{"city":"Gdansk"}}{TOOL_CALL_OPEN}weather{{"city":"Sopot"}}',
+        f'weather{{"city":"Gdansk"}}{TOOL_CALL_OPEN}forecast{{"city":"Sopot"}}',
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "bare-value-close",
         "bare_call",
         f'weather{{"city":"Gdansk"}}</arg_value>{TOOL_CALL_OPEN}'
-        'weather{"city":"Sopot"}</arg_value>',
+        'forecast{"city":"Sopot"}</arg_value>',
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
     PackedRecoveryFixture(
+        "python-mixed",
         "python_call",
-        f'weather({{"city":"Gdansk"}}){TOOL_CALL_OPEN}weather({{"city":"Sopot"}})',
+        f'weather({{"city":"Gdansk"}}){TOOL_CALL_OPEN}forecast({{"city":"Sopot"}})',
+        _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
 )
@@ -194,6 +254,148 @@ _SINGLE_CALL_DECODERS = frozenset(
         "arg_key_value",
         "bare_name",
     }
+)
+
+_REJECTION_FIXTURES = (
+    RejectionFixture(
+        "arg-key-marker-in-value",
+        f'{TOOL_CALL_OPEN}write_file<arg_key>content":"safe{TOOL_CALL_OPEN}'
+        f'delete_file<arg_key>path":"notes.txt"}}{TOOL_CALL_CLOSE}',
+        frozenset({"write_file", "delete_file"}),
+        2,
+    ),
+    RejectionFixture(
+        "arg-key-marker-after-escaped-quotes",
+        f'{TOOL_CALL_OPEN}write_file<arg_key>content":"safe \\"quoted\\" '
+        f"{TOOL_CALL_OPEN}"
+        f'delete_file<arg_key>path":"notes.txt"}}{TOOL_CALL_CLOSE}',
+        frozenset({"write_file", "delete_file"}),
+        2,
+    ),
+    RejectionFixture(
+        "arg-key-marker-after-brace-in-quoted-value",
+        f'{TOOL_CALL_OPEN}write_file<arg_key>content":"safe}}{TOOL_CALL_OPEN}'
+        f'delete_file<arg_key>path":"notes.txt"}}{TOOL_CALL_CLOSE}',
+        frozenset({"write_file", "delete_file"}),
+        2,
+    ),
+    RejectionFixture(
+        "arg-key-marker-after-brace-in-proper-value",
+        f"{TOOL_CALL_OPEN}write_file<arg_key>content</arg_key>"
+        f"<arg_value>safe}}{TOOL_CALL_OPEN}"
+        f'delete_file<arg_key>path":"notes.txt"}}{TOOL_CALL_CLOSE}',
+        frozenset({"write_file", "delete_file"}),
+        2,
+    ),
+    RejectionFixture(
+        "arg-key-unterminated-quoted-value",
+        f'{TOOL_CALL_OPEN}weather<arg_key>command":"echo safe }} {TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-quoted-close-before-real-close",
+        f'{TOOL_CALL_OPEN}weather<arg_key>command":"echo {TOOL_CALL_CLOSE} safely"}}'
+        f"{TOOL_CALL_CLOSE}",
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-doubled-separator",
+        f"{TOOL_CALL_OPEN}{TOOL_CALL_OPEN}{TOOL_CALL_OPEN}"
+        f'weather<arg_key>city":"Gdansk"}}{TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-trailing-separator",
+        f'{TOOL_CALL_OPEN}weather<arg_key>city":"Gdansk"}}{TOOL_CALL_OPEN}{TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-truncated-control-prefix",
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}<arg_',
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-control-marker-in-key",
+        f'{TOOL_CALL_OPEN}weather<arg_key>bad<arg_key>key":"x"{TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-segment-without-key-marker",
+        f'{TOOL_CALL_OPEN}weather<arg_key>city":"Gdansk"}}{TOOL_CALL_OPEN}'
+        f'weather{{"city":"Sopot"}}{TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+        2,
+    ),
+    RejectionFixture(
+        "qwen-missing-parameter-close",
+        f"{TOOL_CALL_OPEN}<function=weather><parameter=city>Gdansk"
+        f"<parameter=unit>c</parameter></function>{TOOL_CALL_CLOSE}",
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "fence-trailing-garbage",
+        f"{TOOL_CALL_OPEN}```json\n{_NATIVE_CALL}\n```garbage{TOOL_CALL_CLOSE}",
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "multiple-argument-aliases",
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}},'
+        f'"parameters":{{"city":"Sopot"}}}}{TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "pipe-declared-type-mismatch",
+        f"{PIPE_TAG_DIALECT.open_marker}"
+        '<|open|>call tool="weather"<|sep|>'
+        '<|open|>argument key="days" type="number"<|sep|>'
+        "many<|close|>argument<|sep|><|close|>call<|sep|>"
+        f"{PIPE_TAG_DIALECT.close_marker}",
+        frozenset({"weather"}),
+    ),
+)
+
+_DIALECTS_BY_NAME = {dialect.name: dialect for dialect in MARKER_DIALECTS}
+_OVER_CAP_STREAMS = (
+    (
+        "pipe-tag",
+        _DIALECTS_BY_NAME["pipe_tag"].open_marker
+        + "".join(_pipe_tag_call("Gdansk", index) for index in range(MAX_PACKED_CALLS + 1))
+        + _DIALECTS_BY_NAME["pipe_tag"].close_marker,
+    ),
+    (
+        "kimi",
+        _DIALECTS_BY_NAME["kimi_k2"].open_marker
+        + "".join(_kimi_call("Gdansk", index) for index in range(MAX_PACKED_CALLS + 1))
+        + _DIALECTS_BY_NAME["kimi_k2"].close_marker,
+    ),
+    (
+        "deepseek",
+        _DIALECTS_BY_NAME["deepseek"].open_marker
+        + "".join(_deepseek_call("Gdansk") for _ in range(MAX_PACKED_CALLS + 1))
+        + _DIALECTS_BY_NAME["deepseek"].close_marker,
+    ),
+    (
+        "qwen",
+        TOOL_CALL_OPEN
+        + "".join(_qwen_call("Gdansk") for _ in range(MAX_PACKED_CALLS + 1))
+        + TOOL_CALL_CLOSE,
+    ),
+    (
+        "json-value-close",
+        TOOL_CALL_OPEN
+        + f"</arg_value>{TOOL_CALL_OPEN}".join(
+            _native_call("Gdansk") for _ in range(MAX_PACKED_CALLS + 1)
+        )
+        + TOOL_CALL_CLOSE,
+    ),
+    (
+        "arg-key",
+        TOOL_CALL_OPEN
+        + TOOL_CALL_OPEN.join(
+            'weather<arg_key>city":"Gdansk"}' for _ in range(MAX_PACKED_CALLS + 1)
+        )
+        + TOOL_CALL_CLOSE,
+    ),
 )
 
 
@@ -210,11 +412,12 @@ def _assert_tool_call(
 
 def _assert_tool_calls(
     emissions: Sequence[object],
+    expected_names: tuple[str, ...],
     expected_arguments: tuple[dict[str, Any], ...],
 ) -> None:
     calls = [emission for emission in emissions if isinstance(emission, ToolCallEmission)]
     assert len(calls) == len(emissions)
-    assert [call.name for call in calls] == ["weather"] * len(expected_arguments)
+    assert [call.name for call in calls] == list(expected_names)
     assert [json.loads(call.arguments) for call in calls] == list(expected_arguments)
 
 
@@ -236,6 +439,15 @@ def _feed_in_chunks(
     for index in range(0, len(stream), chunk_size):
         emissions.extend(parser.feed(stream[index : index + chunk_size]))
     return emissions
+
+
+def _feed_and_finish_in_chunks(
+    parser: ToolCallStreamParser,
+    stream: str,
+    chunk_size: int,
+) -> None:
+    _feed_in_chunks(parser, stream, chunk_size)
+    parser.finish()
 
 
 def test_marker_recovery_matrix_matches_every_registered_dialect() -> None:
@@ -271,6 +483,27 @@ def test_every_dialect_handles_every_two_chunk_boundary(
         emissions.extend(parser.finish())
 
         _assert_tool_call(emissions, fixture.expected_arguments)
+
+
+@pytest.mark.parametrize(
+    "dialect",
+    [dialect for dialect in MARKER_DIALECTS if dialect.json_quoted_close],
+    ids=lambda dialect: dialect.name,
+)
+def test_json_dialects_ignore_close_markers_inside_argument_strings(
+    dialect: MarkerDialect,
+) -> None:
+    payload = _close_collision_payload(dialect)
+    stream = dialect.open_marker + payload + dialect.close_marker
+    expected = {"text": f'quoted " {dialect.close_marker}'}
+
+    for boundary in range(len(stream) + 1):
+        parser = ToolCallStreamParser(frozenset({"weather"}))
+        emissions = parser.feed(stream[:boundary])
+        emissions.extend(parser.feed(stream[boundary:]))
+        emissions.extend(parser.finish())
+
+        _assert_tool_call(emissions, expected)
 
 
 @pytest.mark.parametrize("dialect", MARKER_DIALECTS, ids=lambda dialect: dialect.name)
@@ -327,6 +560,23 @@ def test_decoder_recovery_matrix_matches_every_registered_decoder() -> None:
 
 
 @pytest.mark.parametrize("fixture", _DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+def test_decoder_fixture_matches_expected_precedence_order(
+    fixture: RecoveryFixture,
+) -> None:
+    matches = [
+        decoder.name
+        for decoder in PAYLOAD_DECODERS
+        if decoder.decode(fixture.payload, frozenset({"weather"})) is not None
+    ]
+
+    expected = {
+        "arg_key_value": ["arg_key_value", "arg_key_value_repair"],
+        "bare_name": ["bare_name", "bare_call"],
+    }.get(fixture.name, [fixture.name])
+    assert matches == expected
+
+
+@pytest.mark.parametrize("fixture", _DECODER_FIXTURES, ids=lambda fixture: fixture.name)
 def test_every_decoder_recovers_from_every_partial_native_close_marker(
     fixture: RecoveryFixture,
 ) -> None:
@@ -350,7 +600,7 @@ def test_packed_decoder_matrix_accounts_for_every_registered_decoder() -> None:
     assert packed | _SINGLE_CALL_DECODERS == {decoder.name for decoder in PAYLOAD_DECODERS}
 
 
-@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.case_id)
 def test_every_packing_decoder_recovers_every_call_from_every_partial_close_marker(
     fixture: PackedRecoveryFixture,
 ) -> None:
@@ -359,18 +609,22 @@ def test_every_packing_decoder_recovers_every_call_from_every_partial_close_mark
         for chunk_size in _CHUNK_SIZES:
             variants: list[str] = []
             parser = ToolCallStreamParser(
-                frozenset({"weather"}),
+                frozenset(fixture.expected_names),
                 max_tool_calls=len(fixture.expected_arguments),
                 trace_payload=_variant_tracer(variants),
             )
             assert _feed_in_chunks(parser, stream, chunk_size) == []
 
-            _assert_tool_calls(parser.finish(), fixture.expected_arguments)
+            _assert_tool_calls(
+                parser.finish(),
+                fixture.expected_names,
+                fixture.expected_arguments,
+            )
             # The decoder repair is traced first, the packing it returned second.
             assert variants == [fixture.name, "packed_objects"]
 
 
-@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.case_id)
 def test_every_packing_decoder_handles_every_two_chunk_boundary(
     fixture: PackedRecoveryFixture,
 ) -> None:
@@ -378,24 +632,66 @@ def test_every_packing_decoder_handles_every_two_chunk_boundary(
 
     for boundary in range(len(stream) + 1):
         parser = ToolCallStreamParser(
-            frozenset({"weather"}),
+            frozenset(fixture.expected_names),
             max_tool_calls=len(fixture.expected_arguments),
         )
         emissions = parser.feed(stream[:boundary])
         emissions.extend(parser.feed(stream[boundary:]))
         emissions.extend(parser.finish())
 
-        _assert_tool_calls(emissions, fixture.expected_arguments)
+        _assert_tool_calls(
+            emissions,
+            fixture.expected_names,
+            fixture.expected_arguments,
+        )
 
 
-@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.name)
+@pytest.mark.parametrize("fixture", _PACKED_DECODER_FIXTURES, ids=lambda fixture: fixture.case_id)
 def test_every_packing_decoder_rejects_more_calls_than_the_turn_allows(
     fixture: PackedRecoveryFixture,
 ) -> None:
     parser = ToolCallStreamParser(
-        frozenset({"weather"}),
+        frozenset(fixture.expected_names),
         max_tool_calls=len(fixture.expected_arguments) - 1,
     )
 
     with pytest.raises(ProtocolError, match="more tool calls than the configured maximum"):
         parser.feed(TOOL_CALL_OPEN + fixture.payload + TOOL_CALL_CLOSE)
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    _REJECTION_FIXTURES,
+    ids=lambda fixture: fixture.case_id,
+)
+@pytest.mark.parametrize("chunk_size", _CHUNK_SIZES)
+def test_malformed_recovery_shapes_fail_closed_for_every_chunk_size(
+    fixture: RejectionFixture,
+    chunk_size: int,
+) -> None:
+    parser = ToolCallStreamParser(
+        fixture.allowed_tool_names,
+        max_tool_calls=fixture.max_tool_calls,
+    )
+
+    with pytest.raises(ProtocolError):
+        _feed_and_finish_in_chunks(parser, fixture.stream, chunk_size)
+
+
+@pytest.mark.parametrize(
+    ("case_id", "stream"),
+    _OVER_CAP_STREAMS,
+    ids=[case_id for case_id, _ in _OVER_CAP_STREAMS],
+)
+def test_each_packing_decoder_rejects_payloads_over_the_global_cap(
+    case_id: str,
+    stream: str,
+) -> None:
+    del case_id
+    parser = ToolCallStreamParser(
+        frozenset({"weather"}),
+        max_tool_calls=MAX_PACKED_CALLS + 1,
+    )
+
+    with pytest.raises(ProtocolError):
+        _feed_and_finish_in_chunks(parser, stream, len(stream))

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -107,6 +107,23 @@ def test_the_fixture_directory_is_not_empty() -> None:
     assert FIXTURES, "replay fixtures are the offline safety net; do not delete them all"
 
 
+def test_replay_fixture_identities_are_unique() -> None:
+    identities: dict[tuple[str, str, bool], Path] = {}
+    for path in FIXTURES:
+        first = path.read_text(encoding="utf-8").splitlines()[0]
+        meta = json.loads(first)
+        assert meta["kind"] == "meta"
+        identity = (
+            meta["scenario"],
+            meta["recorded_model"],
+            meta["stream"],
+        )
+        assert identity not in identities, (
+            f"{path.name} duplicates replay identity from {identities[identity].name}"
+        )
+        identities[identity] = path
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("path", FIXTURES, ids=lambda path: path.stem)
 async def test_recorded_events_keep_satisfying_the_contract(


### PR DESCRIPTION
## Summary

- Make close-marker framing quote-aware across native, Kimi, Harmony,
  DeepSeek, and InternLM tool-call dialects.
- Reject ambiguous or malformed recovery shapes, including argument alias
  collisions, Qwen truncation, fenced trailing data, invalid pipe types,
  truncated control markers, and embedded-marker second-call injection.
- Enforce UTF-8 validity, stable JSON-depth limits, and a shared 64-call repair
  cap across Python versions, parser, structured-output, and packed decoders.
- Keep recovery bounded with iterative depth checks, capped JSON decoding,
  and cursor-based `arg_key` splitting.
- Expand chunk-boundary, collision, replay, ASGI, configuration, and exact-limit
  regression coverage, plus document strict behavior and capture policy.

Strict rejection of previously tolerated ambiguous model output is intentional.
No redistributable live-model payload accompanied these confirmed findings, so
regressions use minimized deterministic fixtures rather than production data.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
      (1538 passed, 100% branch coverage on Python 3.11)
- [x] `uv run --extra dev --python 3.12 pytest -q` (1538 passed)
- [x] Focused nesting regressions on Python 3.14 (7 passed)
- [x] `uv build`
- [x] `uv lock --check`
- [x] `uv run python scripts/generate_openapi.py`
- [x] `prs validate && prs diff --all --no-color && prs check`

`openapi.json` remains semantically unchanged, so generated key-order churn was
not committed.

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.
