### PR TITLE
feat(protocol): recover GLM fused name-key tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ text. Every accepted form lives in one table in
 | `name<arg_key>key</arg_key><arg_value>value</arg_value>` | GLM |
 | a JSON array of calls inside one marker pair | Mistral, Jamba, Granite and xLAM style output |
 | `name","key":"value"...}` with the opening `{"name":"` bytes lost | GLM, only with `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX=true` |
+| `namekey":"value"...}` with both the `{"name":"` opening and the `","arguments":{"` infix lost, name fused to the first key | GLM 5.2 |
 
 Translation never widens validation. An unknown tool name, a duplicate
 argument key, or prose after a call still fails the turn. A payload truncated

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ text. Every accepted form lives in one table in
 | `<｜tool▁calls▁begin｜>` … `<｜tool▁calls▁end｜>` | DeepSeek V3 and V3.1 |
 | `<\|action_start\|><\|plugin\|>{"name":...}<\|action_end\|>` | InternLM2 |
 | `name<arg_key>key</arg_key><arg_value>value</arg_value>` | GLM |
+| the same arg_key form with every `<arg_key>` opener lost, so `name</arg_value>key</arg_key><arg_value>value</arg_value>` arrives | GLM |
 | a JSON array of calls inside one marker pair | Mistral, Jamba, Granite and xLAM style output |
 | `name","key":"value"...}` with the opening `{"name":"` bytes lost | GLM, only with `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX=true` |
 | `namekey":"value"...}` with both the `{"name":"` opening and the `","arguments":{"` infix lost, name fused to the first key | GLM 5.2 |

--- a/README.md
+++ b/README.md
@@ -1208,7 +1208,7 @@ error types.
 | `FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS` | `10` | Total budget for session cleanup |
 | `FACTORY_DROID_OPENAI_UVICORN_LIMIT_CONCURRENCY` | `64` | Uvicorn connection limit |
 | `FACTORY_DROID_OPENAI_UVICORN_BACKLOG` | `128` | Uvicorn listen backlog |
-| `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `8` | Tool calls accepted per Droid turn, from 1 through 64 |
+| `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `64` | Tool calls accepted per Droid turn, from 1 through 64; the prompt asks the model for at most 8 at a time |
 | `FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS` | `0.5` | Wait for further events after a complete tool call |
 | `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX` | `false` | Repair tool-call payloads missing their opening `{"name":"` bytes |
 | `FACTORY_DROID_OPENAI_MAX_ATTACHMENTS` | `16` | Inline attachments per request |

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ text. Every accepted form lives in one table in
 | a JSON array of calls inside one marker pair | Mistral, Jamba, Granite and xLAM style output |
 | `name","key":"value"...}` with the opening `{"name":"` bytes lost | GLM, only with `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX=true` |
 | `namekey":"value"...}` with both the `{"name":"` opening and the `","arguments":{"` infix lost, name fused to the first key | GLM 5.2 |
+| the same fused form with the escaping lost inside a value, so `"command":"echo "x""}` carries bare quotes and raw newlines | GLM 5.2 |
 
 Translation never widens validation. An unknown tool name, a duplicate
 argument key, or prose after a call still fails the turn. A payload truncated

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -46,7 +46,10 @@ class Settings:
     cleanup_timeout_seconds: float = 10.0
     server_limit_concurrency: int = 64
     server_backlog: int = 128
-    max_tool_calls: int = 8
+    # Defaults to the parser's own packing cap: a model that answers with a
+    # burst of calls is asking the client for work it can run, and dropping the
+    # turn over the count alone only costs a retry.
+    max_tool_calls: int = MAX_PACKED_CALLS
     tool_call_drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS
     max_attachments: int = 16
     max_attachment_bytes: int = 8_388_608
@@ -197,7 +200,7 @@ class Settings:
         )
         max_tool_calls = _positive_int(
             "FACTORY_DROID_OPENAI_MAX_TOOL_CALLS",
-            default=8,
+            default=MAX_PACKED_CALLS,
         )
         tool_call_drain_seconds = _positive_float(
             "FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS",

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -831,8 +831,11 @@ def _skip_whitespace(value: str, index: int) -> int:
 
 # GLM-5.2 drops both the ``{"name":"`` opening and the ``","arguments":{"``
 # infix, so the first argument key fuses onto the tool name. The fused key is
-# still a plain identifier followed by the JSON ``":"`` separator.
+# still a plain identifier followed by the JSON ``":"`` separator, the only
+# shape observed on the wire: a first argument that is not a string stays
+# rejected rather than guessed at.
 _FUSED_FIRST_KEY_PATTERN = re.compile(r'[A-Za-z_][A-Za-z0-9_]*":"')
+_FUSED_OBJECT_OPEN = '{"'
 
 
 def _decode_lost_prefix_fused(
@@ -843,55 +846,80 @@ def _decode_lost_prefix_fused(
 
     Observed on GLM-5.2 turns: the payload drops the ``{"name":"`` opening and
     the ``","arguments":{"`` infix, so ``run_in_terminalmode":"sync",...}``
-    repeats per call, packed by a bare ``<tool_call>`` without any close. The
-    split between name and key must be the single allowed tool whose remainder
-    strict-parses as a JSON object; zero or multiple parses fail closed, so an
-    alias collision or plain garbage stays rejected.
+    repeats per call, packed by a bare ``<tool_call>`` without any close. A
+    single GLM value-close residue may separate segments or terminate the
+    payload; other residue and partial calls remain rejected.
+
+    The split between name and key must be the single allowed tool whose
+    remainder strict-parses as a JSON object; zero or several parses fail
+    closed, so an alias collision or plain garbage stays rejected. Segments are
+    walked from the end offset the strict decoder reports instead of split on
+    the marker, so an argument value holding a literal ``<tool_call>`` survives
+    intact.
+
+    This form loses more bytes than the opt-in lost-prefix repair yet stays
+    always-on, because it anchors on an exact allowed tool name, a complete
+    strict JSON object and a single surviving reading, where that repair only
+    has the name and the ``","`` the wire kept.
     """
-    segments = body.split(TOOL_CALL_OPEN)
-    # The segment count bounds the work below; ``_append_packed_call`` would
-    # only repeat the same cap.
-    if len(segments) > MAX_PACKED_CALLS:
-        return None
+    stripped = body.strip()
     calls: list[dict[str, Any]] = []
-    for segment in segments:
-        parsed = _decode_fused_segment(segment, allowed_tool_names)
+    index = 0
+    while len(calls) < MAX_PACKED_CALLS:
+        parsed = _decode_fused_segment(stripped, index, allowed_tool_names)
         if parsed is None:
             return None
-        calls.append(parsed)
-    return calls
+        call, index = parsed
+        calls.append(call)
+        index = _skip_whitespace(stripped, index)
+        if stripped.startswith(_ARG_VALUE_CLOSE, index):
+            index = _skip_whitespace(stripped, index + len(_ARG_VALUE_CLOSE))
+        if index == len(stripped):
+            return calls
+        if not stripped.startswith(TOOL_CALL_OPEN, index):
+            return None
+        index = _skip_whitespace(stripped, index + len(TOOL_CALL_OPEN))
+        if index == len(stripped):
+            return None
+    return None
 
 
 def _decode_fused_segment(
     segment: str,
+    index: int,
     allowed_tool_names: frozenset[str],
-) -> dict[str, Any] | None:
-    text = segment.strip()
-    if text.endswith(_ARG_VALUE_CLOSE):
-        # One GLM value-close residue may terminate a segment; anything after
-        # it is prose and keeps the payload rejected.
-        text = text[: -len(_ARG_VALUE_CLOSE)].strip()
-    if not text:
-        return None
-    candidates: list[tuple[str, dict[str, Any]]] = []
+) -> tuple[dict[str, Any], int] | None:
+    candidates: list[tuple[str, dict[str, Any], int, bool]] = []
     for name in allowed_tool_names:
-        if not text.startswith(name):
+        if not segment.startswith(name, index):
             continue
-        remainder = text[len(name) :]
-        if not _FUSED_FIRST_KEY_PATTERN.match(remainder):
-            continue
+        start = index + len(name)
         try:
-            parsed = parse_strict_json('{"' + remainder)
+            # The forced ``{"`` opening means a successful parse is always a
+            # dict, and its end offset maps back by the two forced bytes.
+            arguments, end = raw_decode_strict(_FUSED_OBJECT_OPEN + segment[start:], 0)
         except JsonNestingError:
             raise
         except (json.JSONDecodeError, ValueError):
             continue
-        # The forced ``{"`` opening means a successful parse is always a dict.
-        candidates.append((name, parsed))
+        candidates.append(
+            (
+                name,
+                arguments,
+                start + end - len(_FUSED_OBJECT_OPEN),
+                _FUSED_FIRST_KEY_PATTERN.match(segment, start) is not None,
+            )
+        )
     if len(candidates) != 1:
+        # Ambiguity is counted before the key shape is judged: a split the key
+        # pattern would reject still proves the payload has two readings, and
+        # keeping the surviving one would dispatch a different tool than the
+        # model asked for.
         return None
-    name, arguments = candidates[0]
-    return {"name": name, "arguments": arguments}
+    name, arguments, end, fused_key = candidates[0]
+    if not fused_key:
+        return None
+    return {"name": name, "arguments": arguments}, end
 
 
 _ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE)

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from factory_droid_openai.strictjson import (
     JsonNestingError,
@@ -834,8 +834,21 @@ def _skip_whitespace(value: str, index: int) -> int:
 # still a plain identifier followed by the JSON ``":"`` separator, the only
 # shape observed on the wire: a first argument that is not a string stays
 # rejected rather than guessed at.
-_FUSED_FIRST_KEY_PATTERN = re.compile(r'[A-Za-z_][A-Za-z0-9_]*":"')
+_FUSED_KEY_PATTERN = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)":"')
+_FUSED_NEXT_PAIR_PATTERN = re.compile(r'","[A-Za-z_][A-Za-z0-9_]*":"')
 _FUSED_OBJECT_OPEN = '{"'
+_FUSED_PAIR_SEPARATOR = '","'
+_FUSED_VALUE_CLOSE = '"}'
+# A raw control character is data the model failed to escape, not a value
+# terminator, so the repair scan re-escapes the five JSON names for them and
+# rejects every other control byte.
+_FUSED_CONTROL_ESCAPES = {
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
 
 
 def _decode_lost_prefix_fused(
@@ -862,11 +875,20 @@ def _decode_lost_prefix_fused(
     strict JSON object and a single surviving reading, where that repair only
     has the name and the ``","`` the wire kept.
     """
+    return _walk_fused_calls(body, allowed_tool_names, _decode_fused_segment)
+
+
+def _walk_fused_calls(
+    body: str,
+    allowed_tool_names: frozenset[str],
+    decode_segment: Callable[[str, int, frozenset[str]], tuple[dict[str, Any], int] | None],
+) -> list[dict[str, Any]] | None:
+    """Walks the fused segments a payload packs, one per decoded call."""
     stripped = body.strip()
     calls: list[dict[str, Any]] = []
     index = 0
     while len(calls) < MAX_PACKED_CALLS:
-        parsed = _decode_fused_segment(stripped, index, allowed_tool_names)
+        parsed = decode_segment(stripped, index, allowed_tool_names)
         if parsed is None:
             return None
         call, index = parsed
@@ -907,7 +929,7 @@ def _decode_fused_segment(
                 name,
                 arguments,
                 start + end - len(_FUSED_OBJECT_OPEN),
-                _FUSED_FIRST_KEY_PATTERN.match(segment, start) is not None,
+                _FUSED_KEY_PATTERN.match(segment, start) is not None,
             )
         )
     if len(candidates) != 1:
@@ -920,6 +942,149 @@ def _decode_fused_segment(
     if not fused_key:
         return None
     return {"name": name, "arguments": arguments}, end
+
+
+def _decode_lost_prefix_fused_repair(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> list[dict[str, Any]] | None:
+    """Rebuilds fused GLM calls whose string values lost their escaping.
+
+    Observed on the same GLM-5.2 turns as the strict fused form: a ``command``
+    value carries bare ``"`` and raw newlines, so no reading of the segment
+    parses as JSON. A segment is scanned this way only after its strict reading
+    fails, and then the template shape has to carry it alone: identifier keys
+    joined by ``","``, string values only, and a closing ``"}`` that a segment
+    boundary follows. Bare quotes stay data while backslash escapes keep their
+    JSON meaning, so an invalid escape, a duplicate key, a value that is not a
+    string, a control byte JSON cannot name or a missing terminator still fails
+    the turn.
+
+    A name another allowed name prefixes fails closed here. The strict split
+    can weigh two readings against each other byte for byte; this scan cannot,
+    so it refuses rather than picking one.
+
+    The value ends at the first ``","key":"`` or boundary-anchored ``"}``, which
+    is what keeps the packed segments aligned. A value that itself contains one
+    of those sequences therefore splits early, so the repair widens what the
+    bridge accepts, never what it forwards unvalidated.
+    """
+    return _walk_fused_calls(body, allowed_tool_names, _decode_fused_segment_repair)
+
+
+def _decode_fused_segment_repair(
+    segment: str,
+    index: int,
+    allowed_tool_names: frozenset[str],
+) -> tuple[dict[str, Any], int] | None:
+    strict = _decode_fused_segment(segment, index, allowed_tool_names)
+    if strict is not None and _at_fused_boundary(segment, strict[1]):
+        # The exact reading wins where it ends on a boundary, keeping the value
+        # types and escapes the model wrote. Ending short of one means the
+        # strict decoder stopped inside a value that holds a ``"}`` of its own,
+        # so the scan below gets to read the whole segment instead.
+        return strict
+    prefixes = [name for name in allowed_tool_names if segment.startswith(name, index)]
+    if len(prefixes) != 1:
+        return None
+    name = prefixes[0]
+    scanned = _scan_fused_pairs(segment, index + len(name))
+    if scanned is None:
+        return None
+    arguments, end = scanned
+    return {"name": name, "arguments": arguments}, end
+
+
+def _scan_fused_pairs(segment: str, index: int) -> tuple[dict[str, Any], int] | None:
+    arguments: dict[str, Any] = {}
+    cursor = index
+    while True:
+        pair = _FUSED_KEY_PATTERN.match(segment, cursor)
+        if pair is None:
+            return None
+        key = pair.group(1)
+        if key in arguments:
+            return None
+        bounds = _find_fused_value_end(segment, pair.end())
+        if bounds is None:
+            return None
+        value_end, cursor = bounds
+        value = _repair_fused_string(segment[pair.end() : value_end])
+        if value is None:
+            return None
+        arguments[key] = value
+        if cursor < 0:
+            return arguments, value_end + len(_FUSED_VALUE_CLOSE)
+
+
+def _find_fused_value_end(segment: str, start: int) -> tuple[int, int] | None:
+    """Returns where a scanned value ends and where the next key starts.
+
+    A negative second element means the closing ``"}`` ended the segment.
+    """
+    terminator = _find_fused_terminator(segment, start)
+    pair = _FUSED_NEXT_PAIR_PATTERN.search(segment, start)
+    if pair is not None and (terminator < 0 or pair.start() < terminator):
+        return pair.start(), pair.start() + len(_FUSED_PAIR_SEPARATOR)
+    if terminator < 0:
+        return None
+    return terminator, -1
+
+
+def _find_fused_terminator(segment: str, start: int) -> int:
+    """Finds the ``"}`` a segment boundary follows, or -1.
+
+    A ``"}`` inside a value is only a terminator when the payload continues
+    with its own packing marker or ends, so quoted braces stay data.
+    """
+    index = segment.find(_FUSED_VALUE_CLOSE, start)
+    while index >= 0:
+        if _at_fused_boundary(segment, index + len(_FUSED_VALUE_CLOSE)):
+            return index
+        index = segment.find(_FUSED_VALUE_CLOSE, index + 1)
+    return -1
+
+
+def _at_fused_boundary(segment: str, index: int) -> bool:
+    """Reports whether a reading ends where the packing lets a segment end."""
+    after = _skip_whitespace(segment, index)
+    return (
+        after == len(segment)
+        or segment.startswith(_ARG_VALUE_CLOSE, after)
+        or segment.startswith(TOOL_CALL_OPEN, after)
+    )
+
+
+def _repair_fused_string(raw: str) -> str | None:
+    """Reads a scanned value as the JSON string the model meant to write.
+
+    Escapes the model lost are restored, escapes it wrote keep their meaning,
+    and strict JSON still decides the result, so ``\\q`` or a trailing
+    backslash fails closed instead of reaching the client mangled.
+    """
+    parts: list[str] = []
+    index = 0
+    while index < len(raw):
+        char = raw[index]
+        if char == "\\" and index + 1 < len(raw):
+            parts.append(raw[index : index + 2])
+            index += 2
+            continue
+        if char == '"':
+            parts.append('\\"')
+        elif char in _FUSED_CONTROL_ESCAPES:
+            parts.append(_FUSED_CONTROL_ESCAPES[char])
+        elif char < " ":
+            return None
+        else:
+            parts.append(char)
+        index += 1
+    try:
+        decoded = parse_strict_json(f'"{"".join(parts)}"')
+    except (json.JSONDecodeError, ValueError):
+        return None
+    # The forced quotes mean a successful parse is always a string.
+    return cast("str", decoded)
 
 
 _ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE)
@@ -1133,6 +1298,7 @@ PAYLOAD_DECODERS: tuple[PayloadDecoder, ...] = (
     PayloadDecoder("python_call", _decode_python_call),
     PayloadDecoder("arg_key_value_repair", _decode_arg_key_value_repair),
     PayloadDecoder("lost_prefix_fused", _decode_lost_prefix_fused),
+    PayloadDecoder("lost_prefix_fused_repair", _decode_lost_prefix_fused_repair),
     PayloadDecoder("bare_name", _decode_bare_name),
     PayloadDecoder("bare_call", _decode_bare_call),
 )

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -829,6 +829,71 @@ def _skip_whitespace(value: str, index: int) -> int:
     return index
 
 
+# GLM-5.2 drops both the ``{"name":"`` opening and the ``","arguments":{"``
+# infix, so the first argument key fuses onto the tool name. The fused key is
+# still a plain identifier followed by the JSON ``":"`` separator.
+_FUSED_FIRST_KEY_PATTERN = re.compile(r'[A-Za-z_][A-Za-z0-9_]*":"')
+
+
+def _decode_lost_prefix_fused(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> list[dict[str, Any]] | None:
+    """Rebuilds GLM calls whose tool name fuses with the first argument key.
+
+    Observed on GLM-5.2 turns: the payload drops the ``{"name":"`` opening and
+    the ``","arguments":{"`` infix, so ``run_in_terminalmode":"sync",...}``
+    repeats per call, packed by a bare ``<tool_call>`` without any close. The
+    split between name and key must be the single allowed tool whose remainder
+    strict-parses as a JSON object; zero or multiple parses fail closed, so an
+    alias collision or plain garbage stays rejected.
+    """
+    segments = body.split(TOOL_CALL_OPEN)
+    # The segment count bounds the work below; ``_append_packed_call`` would
+    # only repeat the same cap.
+    if len(segments) > MAX_PACKED_CALLS:
+        return None
+    calls: list[dict[str, Any]] = []
+    for segment in segments:
+        parsed = _decode_fused_segment(segment, allowed_tool_names)
+        if parsed is None:
+            return None
+        calls.append(parsed)
+    return calls
+
+
+def _decode_fused_segment(
+    segment: str,
+    allowed_tool_names: frozenset[str],
+) -> dict[str, Any] | None:
+    text = segment.strip()
+    if text.endswith(_ARG_VALUE_CLOSE):
+        # One GLM value-close residue may terminate a segment; anything after
+        # it is prose and keeps the payload rejected.
+        text = text[: -len(_ARG_VALUE_CLOSE)].strip()
+    if not text:
+        return None
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    for name in allowed_tool_names:
+        if not text.startswith(name):
+            continue
+        remainder = text[len(name) :]
+        if not _FUSED_FIRST_KEY_PATTERN.match(remainder):
+            continue
+        try:
+            parsed = parse_strict_json('{"' + remainder)
+        except JsonNestingError:
+            raise
+        except (json.JSONDecodeError, ValueError):
+            continue
+        # The forced ``{"`` opening means a successful parse is always a dict.
+        candidates.append((name, parsed))
+    if len(candidates) != 1:
+        return None
+    name, arguments = candidates[0]
+    return {"name": name, "arguments": arguments}
+
+
 _ARG_KEY_REPAIR_TERMINATORS = ("<arg_key>", _ARG_VALUE_CLOSE)
 
 
@@ -1039,6 +1104,7 @@ PAYLOAD_DECODERS: tuple[PayloadDecoder, ...] = (
     PayloadDecoder("arg_key_value", _decode_arg_key_value),
     PayloadDecoder("python_call", _decode_python_call),
     PayloadDecoder("arg_key_value_repair", _decode_arg_key_value_repair),
+    PayloadDecoder("lost_prefix_fused", _decode_lost_prefix_fused),
     PayloadDecoder("bare_name", _decode_bare_name),
     PayloadDecoder("bare_call", _decode_bare_call),
 )

--- a/src/factory_droid_openai/dialects.py
+++ b/src/factory_droid_openai/dialects.py
@@ -1248,6 +1248,76 @@ def _arg_key_repair_value(text: str, *, quoted: bool) -> tuple[Any, str]:
     return _coerce_arg_value(raw.strip()), remainder
 
 
+_ARG_KEY_NAME_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_.-]*\Z")
+
+
+def _decode_arg_key_lost_open(
+    body: str,
+    allowed_tool_names: frozenset[str],
+) -> list[dict[str, Any]] | None:
+    """Rebuilds GLM's arg_key form after every ``<arg_key>`` opener is lost.
+
+    Observed shape per segment:
+    ``name</arg_value>key</arg_key><arg_value>value</arg_value>`` repeated once
+    per argument, with several calls packed behind ``<tool_call>``. Only the
+    opening key tag went missing, so ``</arg_key>`` and the value tags still
+    delimit every field and nothing has to be guessed. The stray
+    ``</arg_value>`` after the name is the same mismatched close this template
+    emits elsewhere, and it is what separates the name from the first key.
+    A payload that kept an ``<arg_key>`` belongs to the stricter decoders.
+    """
+    if _ARG_KEY_OPEN in body or _ARG_KEY_CLOSE not in body:
+        return None
+    value = body.replace(TOOL_CALL_CLOSE, TOOL_CALL_OPEN).strip()
+    # An empty segment means a doubled or dangling separator, which says the
+    # payload lost more than the key tags, so it stays rejected.
+    segments = [segment.strip() for segment in value.split(TOOL_CALL_OPEN)]
+    if len(segments) > MAX_PACKED_CALLS or not all(segments):
+        return None
+    calls: list[dict[str, Any]] = []
+    for segment in segments:
+        parsed = _decode_arg_key_lost_open_segment(segment, allowed_tool_names)
+        if parsed is None:
+            return None
+        calls.append(parsed)
+    return calls or None
+
+
+def _decode_arg_key_lost_open_segment(
+    segment: str,
+    allowed_tool_names: frozenset[str],
+) -> dict[str, Any] | None:
+    key_close = segment.find(_ARG_KEY_CLOSE)
+    if key_close < 0:
+        return None
+    name, separator, key = segment[:key_close].partition(_ARG_VALUE_CLOSE)
+    if not separator or name.strip() not in allowed_tool_names:
+        return None
+    arguments: dict[str, Any] = {}
+    index = key_close
+    while True:
+        key = key.strip()
+        if not _ARG_KEY_NAME_PATTERN.fullmatch(key) or key in arguments:
+            return None
+        index += len(_ARG_KEY_CLOSE)
+        if not segment.startswith(_ARG_VALUE_OPEN, index):
+            return None
+        index += len(_ARG_VALUE_OPEN)
+        value_end = segment.find(_ARG_VALUE_CLOSE, index)
+        if value_end < 0:
+            # A truncated value would silently drop data, so fail closed.
+            return None
+        arguments[key] = _coerce_arg_value(segment[index:value_end].strip())
+        index = value_end + len(_ARG_VALUE_CLOSE)
+        key_close = segment.find(_ARG_KEY_CLOSE, index)
+        if key_close < 0:
+            if segment[index:].strip():
+                return None
+            return {"name": name.strip(), "arguments": arguments}
+        key = segment[index:key_close]
+        index = key_close
+
+
 _WRAPPER_KEYS = ("arguments", "parameters", "args", "input")
 
 
@@ -1297,6 +1367,7 @@ PAYLOAD_DECODERS: tuple[PayloadDecoder, ...] = (
     PayloadDecoder("arg_key_value", _decode_arg_key_value),
     PayloadDecoder("python_call", _decode_python_call),
     PayloadDecoder("arg_key_value_repair", _decode_arg_key_value_repair),
+    PayloadDecoder("arg_key_lost_open", _decode_arg_key_lost_open),
     PayloadDecoder("lost_prefix_fused", _decode_lost_prefix_fused),
     PayloadDecoder("lost_prefix_fused_repair", _decode_lost_prefix_fused_repair),
     PayloadDecoder("bare_name", _decode_bare_name),

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -894,9 +894,12 @@ class ToolCallStreamParser:
                     tool_name=tool_name,
                     dialect=self._dialect.name,
                     payload_bytes=len(body.encode("utf-8")),
-                    # Strict-decode failure class and position only; the
-                    # message never carries payload content, so the recovery
-                    # path (which swallows the exception) stays diagnosable.
+                    # The strict-decode failure class plus whatever the parser
+                    # quotes from the payload, a duplicate key or a rejected
+                    # literal among them. It sits beside head and tail at the
+                    # same trace level, so it discloses nothing they do not,
+                    # and it keeps the recovery path, which swallows this
+                    # exception, diagnosable.
                     error=f"{type(exc).__name__}: {exc}"[:_UNPARSED_ERROR_CHARS],
                 )
                 self._trace_payload("tool_call.unparsed", body)

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -58,6 +58,7 @@ _ARGUMENT_KEYS = ("arguments", "parameters", "args", "input")
 _ARG_KEY_REPAIR_MARKER = "<arg_key>"
 _ARG_VALUE_REPAIR_CLOSE = "</arg_value>"
 _UNPARSED_HEAD_CHARS = 64
+_UNPARSED_ERROR_CHARS = 200
 _MESSAGE_JSON_PATTERN = re.compile(r'\{\s*"(?:role|content|tool_calls|id|type)"\s*:')
 _MESSAGE_JSON_KEYS = ("role", "content", "tool_calls", "id", "type")
 _MAX_MESSAGE_JSON_PREFIX_CHARS = 64
@@ -893,6 +894,10 @@ class ToolCallStreamParser:
                     tool_name=tool_name,
                     dialect=self._dialect.name,
                     payload_bytes=len(body.encode("utf-8")),
+                    # Strict-decode failure class and position only; the
+                    # message never carries payload content, so the recovery
+                    # path (which swallows the exception) stays diagnosable.
+                    error=f"{type(exc).__name__}: {exc}"[:_UNPARSED_ERROR_CHARS],
                 )
                 self._trace_payload("tool_call.unparsed", body)
                 self._report_repair("tool_call.unparsed")

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -59,6 +59,9 @@ _ARG_KEY_REPAIR_MARKER = "<arg_key>"
 _ARG_VALUE_REPAIR_CLOSE = "</arg_value>"
 _UNPARSED_HEAD_CHARS = 64
 _UNPARSED_ERROR_CHARS = 200
+# How many parallel calls the prompt asks for at most, independent of how many
+# the parser accepts.
+_SUGGESTED_TOOL_CALLS = 8
 _MESSAGE_JSON_PATTERN = re.compile(r'\{\s*"(?:role|content|tool_calls|id|type)"\s*:')
 _MESSAGE_JSON_KEYS = ("role", "content", "tool_calls", "id", "type")
 _MAX_MESSAGE_JSON_PREFIX_CHARS = 64
@@ -195,8 +198,12 @@ def build_prompt(
 
     if tool_names:
         if max_tool_calls > 1:
+            # The prompt suggests far less than the limit accepts. A high number
+            # here reads as an invitation to burst, and a model that bursts
+            # anyway still has every call accepted up to max_tool_calls.
+            suggested = min(max_tool_calls, _SUGGESTED_TOOL_CALLS)
             count_rule = (
-                f"If tools are needed, output up to {max_tool_calls} tool requests "
+                f"If tools are needed, output up to {suggested} tool requests "
                 "back to back, each using "
             )
             trailing_rule = (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -449,6 +449,19 @@ def test_settings_accepts_the_tool_call_repair_cap(tmp_path: Path) -> None:
     assert settings.max_tool_calls == MAX_PACKED_CALLS
 
 
+def test_settings_default_tool_call_limit_matches_the_repair_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # The prompt quotes this number to the model, so the dataclass default and
+    # the environment default have to agree.
+    _clear_environment(monkeypatch)
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+
+    assert Settings(workdir=tmp_path).max_tool_calls == MAX_PACKED_CALLS
+    assert Settings.from_env().max_tool_calls == MAX_PACKED_CALLS
+
+
 def test_settings_rejects_tool_call_limit_over_the_repair_cap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -827,6 +827,7 @@ def test_stream_parser_logs_unparsed_payload_details() -> None:
     assert event["tail"] == body[-64:]
     assert event["payload_bytes"] == 80
     assert event["dialect"] == "native"
+    assert event["error"].startswith("JSONDecodeError: ")
     assert "tool_name" not in event
 
 
@@ -1361,6 +1362,103 @@ def test_stream_parser_lost_prefix_keeps_scalar_wrapper_key() -> None:
 )
 def test_stream_parser_lost_prefix_stays_fail_closed(body: str) -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), repair_lost_prefix=True)
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_recovers_fused_name_payload() -> None:
+    # The fused form is always-on: no repair_lost_prefix flag needed.
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalmode":"sync","command":"pwd"}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "run_in_terminal"
+    assert json.loads(emissions[0].arguments) == {"mode": "sync", "command": "pwd"}
+
+
+def test_stream_parser_recovers_fused_name_payload_at_stream_end() -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(f'{TOOL_CALL_OPEN}run_in_terminalmode":"sync","command":"pwd"}}')
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "run_in_terminal"
+    assert json.loads(emissions[0].arguments) == {"mode": "sync", "command": "pwd"}
+
+
+def test_stream_parser_recovers_packed_fused_name_payloads() -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}), max_tool_calls=4)
+    body = (
+        'run_in_terminalmode":"sync","command":"pwd"}'
+        f"{TOOL_CALL_OPEN}"
+        'run_in_terminalmode":"sync","command":"ls"}'
+    )
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{body}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 2
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert isinstance(emissions[1], ToolCallEmission)
+    assert json.loads(emissions[0].arguments)["command"] == "pwd"
+    assert json.loads(emissions[1].arguments)["command"] == "ls"
+
+
+def test_stream_parser_recovers_fused_name_with_value_close_residue() -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalmode":"sync","command":"pwd"}}</arg_value>'
+        f"{TOOL_CALL_CLOSE}"
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"mode": "sync", "command": "pwd"}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # The name must come from the allowed set.
+        'unknownmode":"sync"}',
+        # The reconstructed object must close.
+        'run_in_terminalmode":"sync"',
+        # The fused key must be an identifier, not a digit-led fragment.
+        'run_in_terminal12":"sync"}',
+        # Prose after the value-close residue is not ignorable scaffolding.
+        'run_in_terminalmode":"sync"}</arg_value>prose',
+        # A segment left empty by a doubled marker fails closed.
+        'run_in_terminalmode":"sync"}<tool_call>',
+        # Duplicate keys in the reconstruction stay rejected.
+        'run_in_terminalmode":"a","mode":"b"}',
+    ],
+)
+def test_stream_parser_fused_name_stays_fail_closed(body: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_fused_name_rejects_alias_collision() -> None:
+    # Both splits strict-parse, so the fused form is ambiguous and fails closed.
+    parser = ToolCallStreamParser(frozenset({"run", "run_in_terminal"}))
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f'{TOOL_CALL_OPEN}run_in_terminalmode":"sync"}}{TOOL_CALL_CLOSE}')
+
+
+def test_stream_parser_fused_name_bounds_packed_segments() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=MAX_PACKED_CALLS)
+    body = TOOL_CALL_OPEN.join(['weathermode":"sync"}'] * (MAX_PACKED_CALLS + 1))
 
     with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
         parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
@@ -2025,7 +2123,7 @@ def test_stream_parser_rejects_mismatched_pipe_tag_argument_types(
         )
 
 
-@pytest.mark.parametrize("decoder", ["pipe-tag", "qwen", "arg-key"])
+@pytest.mark.parametrize("decoder", ["pipe-tag", "qwen", "arg-key", "fused"])
 def test_recovery_decoders_do_not_downgrade_excessive_json_nesting(
     decoder: str,
 ) -> None:
@@ -2043,6 +2141,8 @@ def test_recovery_decoders_do_not_downgrade_excessive_json_nesting(
             f"{TOOL_CALL_OPEN}<function=weather><parameter=value>{nested}"
             f"</parameter></function>{TOOL_CALL_CLOSE}"
         )
+    elif decoder == "fused":
+        stream = f'{TOOL_CALL_OPEN}weathera":"b","c":{nested}}}{TOOL_CALL_CLOSE}'
     else:
         stream = (
             f"{TOOL_CALL_OPEN}weather<arg_key>value</arg_key>"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1433,6 +1433,8 @@ def test_stream_parser_recovers_fused_name_with_value_close_residue() -> None:
         'run_in_terminalmode":"sync"',
         # The fused key must be an identifier, not a digit-led fragment.
         'run_in_terminal12":"sync"}',
+        # The first fused argument must be a string, the only observed shape.
+        'run_in_terminaltimeout":30}',
         # Prose after the value-close residue is not ignorable scaffolding.
         'run_in_terminalmode":"sync"}</arg_value>prose',
         # A segment left empty by a doubled marker fails closed.
@@ -1448,12 +1450,35 @@ def test_stream_parser_fused_name_stays_fail_closed(body: str) -> None:
         parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
 
 
+def test_stream_parser_recovers_fused_name_value_holding_open_marker() -> None:
+    # The marker inside the value is argument data, not a packing separator.
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalcommand":"echo {TOOL_CALL_OPEN}"}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"command": f"echo {TOOL_CALL_OPEN}"}
+
+
 def test_stream_parser_fused_name_rejects_alias_collision() -> None:
     # Both splits strict-parse, so the fused form is ambiguous and fails closed.
     parser = ToolCallStreamParser(frozenset({"run", "run_in_terminal"}))
 
     with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
         parser.feed(f'{TOOL_CALL_OPEN}run_in_terminalmode":"sync"}}{TOOL_CALL_CLOSE}')
+
+
+def test_stream_parser_fused_name_rejects_digit_led_key_alias_collision() -> None:
+    # The digit-led key only fails the key pattern on the longer split, so
+    # counting the ambiguity after that check would dispatch 'read' with a
+    # '_file2fa' argument instead of rejecting the payload.
+    parser = ToolCallStreamParser(frozenset({"read", "read_file"}))
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f'{TOOL_CALL_OPEN}read_file2fa":"on"}}{TOOL_CALL_CLOSE}')
 
 
 def test_stream_parser_fused_name_bounds_packed_segments() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -15,6 +15,7 @@ from factory_droid_openai.dialects import (
 from factory_droid_openai.models import ChatCompletionRequest
 from factory_droid_openai.protocol import (
     _MAX_TOOL_PAYLOAD_BYTES,
+    _SUGGESTED_TOOL_CALLS,
     TOOL_CALL_CLOSE,
     TOOL_CALL_OPEN,
     IncompleteToolCallError,
@@ -3696,6 +3697,15 @@ def test_multi_tool_prompt_mentions_the_cap() -> None:
     plan = build_prompt(_request(), max_tool_calls=4)
 
     assert "up to 4 tool requests" in plan.prompt
+
+
+def test_multi_tool_prompt_caps_the_suggested_call_count() -> None:
+    # The parser accepts every call up to the limit; the prompt still asks for
+    # a modest burst instead of quoting the cap back to the model.
+    plan = build_prompt(_request(), max_tool_calls=MAX_PACKED_CALLS)
+
+    assert f"up to {_SUGGESTED_TOOL_CALLS} tool requests" in plan.prompt
+    assert f"up to {MAX_PACKED_CALLS} tool requests" not in plan.prompt
 
 
 def test_continuation_prompt_sends_only_messages_after_last_assistant() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1587,6 +1587,83 @@ def test_stream_parser_repaired_fused_value_rejects_prefixed_tool_name() -> None
         parser.feed(f'{TOOL_CALL_OPEN}run_in_terminalcommand":"echo "x""}}{TOOL_CALL_CLOSE}')
 
 
+def test_stream_parser_repairs_arg_key_form_with_lost_openers() -> None:
+    # GLM kept every closing tag but dropped all <arg_key> openers, and the
+    # name is separated from the first key by the template's stray close.
+    parser = ToolCallStreamParser(frozenset({"read_file"}))
+    body = (
+        "read_file</arg_value>filePath</arg_key><arg_value>/srv/content.json</arg_value>"
+        "startLine</arg_key><arg_value>1</arg_value>"
+        "endLine</arg_key><arg_value>400</arg_value>"
+    )
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert emissions[0].name == "read_file"
+    assert json.loads(emissions[0].arguments) == {
+        "filePath": "/srv/content.json",
+        "startLine": 1,
+        "endLine": 400,
+    }
+
+
+def test_stream_parser_repairs_packed_arg_key_forms_with_lost_openers() -> None:
+    parser = ToolCallStreamParser(frozenset({"read_file", "list_dir"}), max_tool_calls=2)
+    body = (
+        "read_file</arg_value>filePath</arg_key><arg_value>/srv/a.json</arg_value>"
+        f"{TOOL_CALL_OPEN}"
+        "list_dir</arg_value>path</arg_key><arg_value>/srv</arg_value>"
+    )
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+    assert [emission.name for emission in emissions if isinstance(emission, ToolCallEmission)] == [
+        "read_file",
+        "list_dir",
+    ]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # Without the stray close the name and the first key cannot be split.
+        "read_filefilePath</arg_key><arg_value>/srv/a.json</arg_value>",
+        # A truncated value would silently drop argument data.
+        "read_file</arg_value>filePath</arg_key><arg_value>/srv/a.json",
+        # The value has to open with its own tag, not bare text.
+        "read_file</arg_value>filePath</arg_key>/srv/a.json</arg_value>",
+        # Duplicate keys stay rejected here too.
+        "read_file</arg_value>filePath</arg_key><arg_value>a</arg_value>"
+        "filePath</arg_key><arg_value>b</arg_value>",
+        # Leaked prose after the last value still fails the turn.
+        "read_file</arg_value>filePath</arg_key><arg_value>a</arg_value>then I will read more",
+        # A key carrying prose is not an argument name.
+        "read_file</arg_value>let me read</arg_key><arg_value>a</arg_value>",
+        # An unknown name never dispatches, however clean the markup is.
+        "delete_file</arg_value>filePath</arg_key><arg_value>a</arg_value>",
+    ],
+)
+def test_stream_parser_arg_key_lost_openers_stay_fail_closed(body: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"read_file"}))
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_arg_key_lost_openers_reject_marker_inside_a_value() -> None:
+    # Values are raw text, so a literal <tool_call> inside one is
+    # indistinguishable from the packing separator and fails closed.
+    parser = ToolCallStreamParser(frozenset({"read_file"}), max_tool_calls=2)
+    body = (
+        f"read_file</arg_value>filePath</arg_key><arg_value>/srv/{TOOL_CALL_OPEN}a.json</arg_value>"
+    )
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+
 def test_stream_parser_fused_name_bounds_packed_segments() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=MAX_PACKED_CALLS)
     body = TOOL_CALL_OPEN.join(['weathermode":"sync"}'] * (MAX_PACKED_CALLS + 1))

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1481,6 +1481,111 @@ def test_stream_parser_fused_name_rejects_digit_led_key_alias_collision() -> Non
         parser.feed(f'{TOOL_CALL_OPEN}read_file2fa":"on"}}{TOOL_CALL_CLOSE}')
 
 
+def test_stream_parser_repairs_fused_value_with_lost_escaping() -> None:
+    # GLM-5.2 writes the shell quotes bare, so no reading of the segment parses.
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+    command = 'echo "CURRENT: $(git branch)" && ls'
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalmode":"sync","command":"{command}"}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"mode": "sync", "command": command}
+
+
+def test_stream_parser_repairs_fused_value_with_raw_control_characters() -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalcommand":"echo "one"\n\tls"}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"command": 'echo "one"\n\tls'}
+
+
+def test_stream_parser_repaired_fused_value_keeps_written_escapes() -> None:
+    # A value mixing bare quotes with escapes the model did write keeps both
+    # readings: the escape decodes, the bare quote stays data.
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalcommand":"echo "raw" \\"kept\\" \\u0041"}}'
+        f"{TOOL_CALL_CLOSE}"
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"command": 'echo "raw" "kept" A'}
+
+
+def test_stream_parser_repaired_fused_value_keeps_unanchored_value_close() -> None:
+    # The inner "} is followed by more value, so only the anchored one ends it.
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    emissions = parser.feed(
+        f'{TOOL_CALL_OPEN}run_in_terminalcommand":"echo "}} && ls "x""}}{TOOL_CALL_CLOSE}'
+    )
+
+    assert len(emissions) == 1
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"command": 'echo "} && ls "x"'}
+
+
+def test_stream_parser_repairs_packed_fused_values_after_one_strict_segment() -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}), max_tool_calls=4)
+    body = (
+        'run_in_terminalcommand":"pwd"}'
+        f"{TOOL_CALL_OPEN}"
+        'run_in_terminalcommand":"echo "hi""}</arg_value>'
+    )
+
+    emissions = parser.feed(f"{TOOL_CALL_OPEN}{body}")
+    emissions.extend(parser.finish())
+
+    assert len(emissions) == 2
+    assert isinstance(emissions[0], ToolCallEmission)
+    assert isinstance(emissions[1], ToolCallEmission)
+    assert json.loads(emissions[0].arguments) == {"command": "pwd"}
+    assert json.loads(emissions[1].arguments) == {"command": 'echo "hi"'}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # An escape JSON does not define stays rejected.
+        'run_in_terminalcommand":"echo "x" \\q"}',
+        # A value ending on a lone backslash is truncated, not repairable.
+        'run_in_terminalcommand":"echo "x" \\"}',
+        # A control byte JSON cannot name is not argument data.
+        'run_in_terminalcommand":"echo "x" \x00"}',
+        # The scan needs the closing "} the packing anchors.
+        'run_in_terminalmode":"sync","command":"echo "x"',
+        # Duplicate keys stay rejected on the scanned path too.
+        'run_in_terminalcommand":"echo "a"","command":"echo "b""}',
+        # Prose after the value-close residue still fails the turn.
+        'run_in_terminalcommand":"echo "x""}</arg_value>prose',
+    ],
+)
+def test_stream_parser_repaired_fused_value_stays_fail_closed(body: str) -> None:
+    parser = ToolCallStreamParser(frozenset({"run_in_terminal"}))
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f"{TOOL_CALL_OPEN}{body}{TOOL_CALL_CLOSE}")
+
+
+def test_stream_parser_repaired_fused_value_rejects_prefixed_tool_name() -> None:
+    # The scan cannot weigh two readings against each other, so any allowed
+    # name prefixing another fails closed instead of guessing the split.
+    parser = ToolCallStreamParser(frozenset({"run", "run_in_terminal"}))
+
+    with pytest.raises(MalformedToolCallError, match="invalid tool-call JSON"):
+        parser.feed(f'{TOOL_CALL_OPEN}run_in_terminalcommand":"echo "x""}}{TOOL_CALL_CLOSE}')
+
+
 def test_stream_parser_fused_name_bounds_packed_segments() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}), max_tool_calls=MAX_PACKED_CALLS)
     body = TOOL_CALL_OPEN.join(['weathermode":"sync"}'] * (MAX_PACKED_CALLS + 1))

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -166,6 +166,11 @@ _DECODER_FIXTURES = (
         'weather<arg_key>city":"Gdansk"}',
         {"city": "Gdansk"},
     ),
+    RecoveryFixture(
+        "lost_prefix_fused",
+        'weathercity":"Gdansk"}',
+        {"city": "Gdansk"},
+    ),
     RecoveryFixture("bare_name", 'weather\n{"city":"Gdansk"}', {"city": "Gdansk"}),
     RecoveryFixture("bare_call", 'weather{"city":"Gdansk"}', {"city": "Gdansk"}),
 )
@@ -242,6 +247,13 @@ _PACKED_DECODER_FIXTURES = (
         "python-mixed",
         "python_call",
         f'weather({{"city":"Gdansk"}}){TOOL_CALL_OPEN}forecast({{"city":"Sopot"}})',
+        _PACKED_NAMES,
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "fused-open-separator",
+        "lost_prefix_fused",
+        f'weathercity":"Gdansk"}}{TOOL_CALL_OPEN}forecastcity":"Sopot"}}',
         _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
@@ -394,6 +406,12 @@ _OVER_CAP_STREAMS = (
         + TOOL_CALL_OPEN.join(
             'weather<arg_key>city":"Gdansk"}' for _ in range(MAX_PACKED_CALLS + 1)
         )
+        + TOOL_CALL_CLOSE,
+    ),
+    (
+        "fused",
+        TOOL_CALL_OPEN
+        + TOOL_CALL_OPEN.join('weathercity":"Gdansk"}' for _ in range(MAX_PACKED_CALLS + 1))
         + TOOL_CALL_CLOSE,
     ),
 )

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -171,6 +171,11 @@ _DECODER_FIXTURES = (
         'weathercity":"Gdansk"}',
         {"city": "Gdansk"},
     ),
+    RecoveryFixture(
+        "lost_prefix_fused_repair",
+        'weathercity":"Gda"nsk"}',
+        {"city": 'Gda"nsk'},
+    ),
     RecoveryFixture("bare_name", 'weather\n{"city":"Gdansk"}', {"city": "Gdansk"}),
     RecoveryFixture("bare_call", 'weather{"city":"Gdansk"}', {"city": "Gdansk"}),
 )
@@ -256,6 +261,13 @@ _PACKED_DECODER_FIXTURES = (
         f'weathercity":"Gdansk"}}{TOOL_CALL_OPEN}forecastcity":"Sopot"}}',
         _PACKED_NAMES,
         _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "fused-lost-escaping",
+        "lost_prefix_fused_repair",
+        f'weathercity":"Gda"nsk"}}{TOOL_CALL_OPEN}forecastcity":"So"pot"}}',
+        _PACKED_NAMES,
+        ({"city": 'Gda"nsk'}, {"city": 'So"pot'}),
     ),
 )
 # These shapes carry exactly one call per marker pair, so packing them is not a
@@ -412,6 +424,12 @@ _OVER_CAP_STREAMS = (
         "fused",
         TOOL_CALL_OPEN
         + TOOL_CALL_OPEN.join('weathercity":"Gdansk"}' for _ in range(MAX_PACKED_CALLS + 1))
+        + TOOL_CALL_CLOSE,
+    ),
+    (
+        "fused-repair",
+        TOOL_CALL_OPEN
+        + TOOL_CALL_OPEN.join('weathercity":"Gda"nsk"}' for _ in range(MAX_PACKED_CALLS + 1))
         + TOOL_CALL_CLOSE,
     ),
 )
@@ -590,6 +608,7 @@ def test_decoder_fixture_matches_expected_precedence_order(
     expected = {
         "arg_key_value": ["arg_key_value", "arg_key_value_repair"],
         "bare_name": ["bare_name", "bare_call"],
+        "lost_prefix_fused": ["lost_prefix_fused", "lost_prefix_fused_repair"],
     }.get(fixture.name, [fixture.name])
     assert matches == expected
 

--- a/tests/test_protocol_recovery_matrix.py
+++ b/tests/test_protocol_recovery_matrix.py
@@ -167,6 +167,11 @@ _DECODER_FIXTURES = (
         {"city": "Gdansk"},
     ),
     RecoveryFixture(
+        "arg_key_lost_open",
+        "weather</arg_value>city</arg_key><arg_value>Gdansk</arg_value>",
+        {"city": "Gdansk"},
+    ),
+    RecoveryFixture(
         "lost_prefix_fused",
         'weathercity":"Gdansk"}',
         {"city": "Gdansk"},
@@ -230,6 +235,14 @@ _PACKED_DECODER_FIXTURES = (
         "arg-key-mixed",
         "arg_key_value_repair",
         f'weather<arg_key>city":"Gdansk"}}{TOOL_CALL_OPEN}forecast<arg_key>city":"Sopot"}}',
+        _PACKED_NAMES,
+        _PACKED_ARGUMENTS,
+    ),
+    PackedRecoveryFixture(
+        "arg-key-lost-open",
+        "arg_key_lost_open",
+        "weather</arg_value>city</arg_key><arg_value>Gdansk</arg_value>"
+        f"{TOOL_CALL_OPEN}forecast</arg_value>city</arg_key><arg_value>Sopot</arg_value>",
         _PACKED_NAMES,
         _PACKED_ARGUMENTS,
     ),
@@ -351,6 +364,31 @@ _REJECTION_FIXTURES = (
         2,
     ),
     RejectionFixture(
+        "arg-key-lost-open-name-without-stray-close",
+        f"{TOOL_CALL_OPEN}weathercity</arg_key><arg_value>Gdansk</arg_value>{TOOL_CALL_CLOSE}",
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-lost-open-segment-without-key-close",
+        f"{TOOL_CALL_OPEN}weather</arg_value>city</arg_key><arg_value>Gdansk</arg_value>"
+        f'{TOOL_CALL_OPEN}weather{{"city":"Sopot"}}</arg_value>{TOOL_CALL_CLOSE}',
+        frozenset({"weather"}),
+        2,
+    ),
+    RejectionFixture(
+        "arg-key-lost-open-doubled-separator",
+        f"{TOOL_CALL_OPEN}{TOOL_CALL_OPEN}weather</arg_value>city</arg_key>"
+        f"<arg_value>Gdansk</arg_value>{TOOL_CALL_CLOSE}",
+        frozenset({"weather"}),
+    ),
+    RejectionFixture(
+        "arg-key-lost-open-marker-in-value",
+        f"{TOOL_CALL_OPEN}weather</arg_value>city</arg_key><arg_value>Gda{TOOL_CALL_OPEN}"
+        f"nsk</arg_value>{TOOL_CALL_CLOSE}",
+        frozenset({"weather"}),
+        2,
+    ),
+    RejectionFixture(
         "qwen-missing-parameter-close",
         f"{TOOL_CALL_OPEN}<function=weather><parameter=city>Gdansk"
         f"<parameter=unit>c</parameter></function>{TOOL_CALL_CLOSE}",
@@ -417,6 +455,15 @@ _OVER_CAP_STREAMS = (
         TOOL_CALL_OPEN
         + TOOL_CALL_OPEN.join(
             'weather<arg_key>city":"Gdansk"}' for _ in range(MAX_PACKED_CALLS + 1)
+        )
+        + TOOL_CALL_CLOSE,
+    ),
+    (
+        "arg-key-lost-open",
+        TOOL_CALL_OPEN
+        + TOOL_CALL_OPEN.join(
+            "weather</arg_value>city</arg_key><arg_value>Gdansk</arg_value>"
+            for _ in range(MAX_PACKED_CALLS + 1)
         )
         + TOOL_CALL_CLOSE,
     ),

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -257,15 +257,15 @@ async def test_reporter_applies_one_deadline_to_all_batches(
         post=post,
     )
     assert await reporter.flush() is False
-    # One budget covers every batch, so a second send only gets what the first
-    # one left, here at least the 0.03 it slept. A per-batch budget would hand
-    # out the full 0.05 every time, and wall-clock timing cannot separate the
-    # two policies because both spend the same total.
-    assert 1 <= len(timeouts) <= 2
+    # The flush stopped short of the last batch, and every send it did make got
+    # what the previous one left rather than a fresh budget. How many sends fit
+    # inside one budget depends on the platform clock granularity, so only the
+    # shrinking is asserted; the 0.01 margin clears both float noise and a
+    # coarse monotonic clock while a per-batch budget, which never shrinks,
+    # still fails it.
+    assert timeouts
     assert all(timeout > 0 for timeout in timeouts)
-    # The 0.02 margin sits under the 0.03 the send slept, so only the shared
-    # deadline can satisfy it while float noise cannot.
-    assert all(timeouts[index] <= timeouts[index - 1] - 0.02 for index in range(1, len(timeouts)))
+    assert all(timeouts[index] <= timeouts[index - 1] - 0.01 for index in range(1, len(timeouts)))
 
 
 @pytest.mark.asyncio

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -210,10 +210,10 @@ async def test_reporter_bounds_sender_deadline() -> None:
     )
     assert await reporter.flush() is False
     # The send is still blocked here, so a flush that returns at all proves the
-    # deadline was enforced. What bounds it is the budget handed to the sender,
-    # which is deterministic, unlike wall-clock timing on a loaded runner.
+    # deadline was enforced, and the budget it handed out came from the caller
+    # rather than the default. Wall-clock timing would only measure the runner.
     assert len(timeouts) == 1
-    assert 0 < timeouts[0] <= 0.01
+    assert 0 < timeouts[0] < DEFAULT_TELEMETRY_TIMEOUT_SECONDS
     release.set()
     await asyncio.sleep(0)
     # A send that outran the deadline may or may not have landed, so aggregate
@@ -258,12 +258,14 @@ async def test_reporter_applies_one_deadline_to_all_batches(
     )
     assert await reporter.flush() is False
     # One budget covers every batch, so a second send only gets what the first
-    # one left: at most the 0.05 budget minus the 0.03 the first send slept.
-    # Wall-clock timing cannot separate the two policies here, since a per-batch
-    # budget would spend the same 0.1 seconds the shared one is allowed.
+    # one left, here at least the 0.03 it slept. A per-batch budget would hand
+    # out the full 0.05 every time, and wall-clock timing cannot separate the
+    # two policies because both spend the same total.
     assert 1 <= len(timeouts) <= 2
-    assert all(0 < timeout <= 0.05 for timeout in timeouts)
-    assert all(timeouts[index] <= timeouts[index - 1] - 0.03 for index in range(1, len(timeouts)))
+    assert all(timeout > 0 for timeout in timeouts)
+    # The 0.02 margin sits under the 0.03 the send slept, so only the shared
+    # deadline can satisfy it while float noise cannot.
+    assert all(timeouts[index] <= timeouts[index - 1] - 0.02 for index in range(1, len(timeouts)))
 
 
 @pytest.mark.asyncio

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -192,9 +192,11 @@ async def test_reporter_swallows_sender_exceptions() -> None:
 async def test_reporter_bounds_sender_deadline() -> None:
     release = threading.Event()
     bodies: list[dict[str, object]] = []
+    timeouts: list[float] = []
 
-    def post(_endpoint: str, body: bytes, _timeout: float) -> bool:
+    def post(_endpoint: str, body: bytes, timeout: float) -> bool:
         bodies.append(json.loads(body))
+        timeouts.append(timeout)
         release.wait()
         return True
 
@@ -206,10 +208,12 @@ async def test_reporter_bounds_sender_deadline() -> None:
         timeout_seconds=0.01,
         post=post,
     )
-    started_at = asyncio.get_running_loop().time()
-
     assert await reporter.flush() is False
-    assert asyncio.get_running_loop().time() - started_at < 0.1
+    # The send is still blocked here, so a flush that returns at all proves the
+    # deadline was enforced. What bounds it is the budget handed to the sender,
+    # which is deterministic, unlike wall-clock timing on a loaded runner.
+    assert len(timeouts) == 1
+    assert 0 < timeouts[0] <= 0.01
     release.set()
     await asyncio.sleep(0)
     # A send that outran the deadline may or may not have landed, so aggregate
@@ -252,13 +256,14 @@ async def test_reporter_applies_one_deadline_to_all_batches(
         timeout_seconds=0.05,
         post=post,
     )
-    started_at = asyncio.get_running_loop().time()
-
     assert await reporter.flush() is False
-    assert asyncio.get_running_loop().time() - started_at < 0.1
+    # One budget covers every batch, so a second send only gets what the first
+    # one left: at most the 0.05 budget minus the 0.03 the first send slept.
+    # Wall-clock timing cannot separate the two policies here, since a per-batch
+    # budget would spend the same 0.1 seconds the shared one is allowed.
     assert 1 <= len(timeouts) <= 2
-    assert all(timeout > 0 for timeout in timeouts)
-    assert all(timeouts[index] < timeouts[index - 1] for index in range(1, len(timeouts)))
+    assert all(0 < timeout <= 0.05 for timeout in timeouts)
+    assert all(timeouts[index] <= timeouts[index - 1] - 0.03 for index in range(1, len(timeouts)))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

GLM-5.2 turns served through Droid emit a fused tool-call form the bridge could not recover:

```
<tool_call>run_in_terminalmode":"sync","explanation":"...","command":"..."}
```

The model drops both the `{"name":"` opening and the `","arguments":{"` infix, so the tool name fuses with the first argument key. Calls arrive packed by repeated bare `<tool_call>` markers with no `</tool_call>` close (captured in the wild: 40 segments, 13 KB payload). The existing `lost_prefix` decoder requires the `name","` boundary, so these payloads fell through all eleven decoders and the turn failed closed with `finish_reason="length"`.

## Changes

- **New always-on `lost_prefix_fused` decoder** (`dialects.py`): splits the payload on `<tool_call>`, then per segment finds the allowed tool names that prefix the segment and whose remainder strict-parses as a JSON object when wrapped in `{"`. Exactly one parsing split accepts the call; zero or several (alias collision) fail closed, matching the lost-prefix collision policy. One trailing `</arg_value>` residue per segment is tolerated; prose after it is not. Segment count is bounded by `MAX_PACKED_CALLS`.
- **Diagnostics** (`protocol.py`): `tool_call.unparsed` now carries an `error` field with the strict decode failure class and position (e.g. `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`). The recovery path swallows the original exception, so until now the reason never reached the logs. No payload content is logged.
- **README**: dialect table row for the fused form.

## Validation preserved

Duplicate keys, unknown tool names, non-identifier fused keys, empty segments from doubled markers, over-cap packing and excessive JSON nesting all still fail closed. Prose interleaved between calls remains rejected (trailing-output validation unchanged).

## Testing

- 10 new parser tests: fused single/packed/stream-end recovery, value-close residue, six fail-closed shapes, alias collision, segment cap.
- Recovery-matrix fixtures for `lost_prefix_fused` (single, packed, over-cap, excessive-nesting parametrization).
- Full gauntlet green: ruff, ruff format, strict mypy, 1558 tests with 100% branch coverage, openapi-spec-validator, uv lock --check, uv build.
