### PR TITLE
feat(tools): call client tools natively over MCP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,31 @@ uv run python scripts/e2e_matrix.py compare traces/run-a.jsonl traces/run-b.json
 `compare` exits non-zero on any pass to non-pass transition, which makes it the
 A/B tool for prompt and parser changes.
 
+The matrix talks to whatever bridge answers on `--base-url`, so comparing the
+two tool-calling paths means running it twice against two bridges that differ
+only in the flag:
+
+```bash
+export FACTORY_HOME_OVERRIDE="$PWD/traces/profile"
+env -u FACTORY_APPEND_SYSTEM_PROMPT uv run factory-droid-openai --port 8798 &
+FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS=true \
+  env -u FACTORY_APPEND_SYSTEM_PROMPT uv run factory-droid-openai --port 8799 &
+uv run python scripts/e2e_matrix.py run --base-url http://127.0.0.1:8798 --out traces/text.jsonl
+uv run python scripts/e2e_matrix.py run --base-url http://127.0.0.1:8799 --out traces/native.jsonl
+uv run python scripts/e2e_matrix.py compare traces/text.jsonl traces/native.jsonl
+```
+
+Native runs need the profile override. A tool-bearing request publishes an MCP
+server to Droid, which then waits for every other MCP server the profile
+configures, and one stuck on a login prompt exhausts the session-init timeout.
+Both bridges must run under the same profile, or the comparison measures the
+profile instead of the flag.
+
+Read the transitions, not the pass rates: a model that answers a tool contract
+in one path and not the other is the finding. `model_behavior` on the native
+path still means the model chose that, but a native run that reports a client
+tool as a Factory-native tool is a bridge defect in the prefix handling.
+
 Turn what a live run found into offline regression tests:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -340,8 +340,10 @@ put the native path ahead of the text path: no bridge defect on either, and
 fifteen tool contracts that the text path lost to unrecognized answers are met.
 Two caveats survive. A model may still call a tool again after the transcript
 already carries the result, because its session-side tool history is empty on
-every request, and a machine whose own MCP servers are slow to start eats into
-the session-init timeout for tool-bearing requests.
+every request. And a tool-bearing request waits for the machine's own MCP
+servers too, so one that is slow or stuck on a login prompt eats into Droid's
+session-init timeout; point `FACTORY_HOME_OVERRIDE` at a Droid profile without
+those servers to keep them out of the session.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,14 @@ request, and it is mounted only while the flag is on. Droid reaches it at
 `http://127.0.0.1:<port>`; set `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL`
 when the bridge answers on a different address than it binds.
 
+A full e2e matrix run over every model the bridge lists (905 requests per path)
+put the native path ahead of the text path: no bridge defect on either, and
+fifteen tool contracts that the text path lost to unrecognized answers are met.
+Two caveats survive. A model may still call a tool again after the transcript
+already carries the result, because its session-side tool history is empty on
+every request, and a machine whose own MCP servers are slow to start eats into
+the session-init timeout for tool-bearing requests.
+
 ## Requirements
 
 - Python 3.11 or newer

--- a/README.md
+++ b/README.md
@@ -309,6 +309,32 @@ Two forms are not supported:
 
 Both stay out until a captured sample justifies the added parsing surface.
 
+### Native tool calling
+
+`FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS=true` takes tool calling off the text
+channel entirely. The bridge serves the request's tools to Droid as an MCP
+server on its own HTTP port, Droid registers them as real tools, and the model
+calls them through its own tool slot. The bridge then reports the call as
+`tool_calls` exactly as before.
+
+What changes with the flag on:
+
+- Tool schemas leave the prompt. They are published over MCP instead, so a
+  request carrying a large toolset sends far fewer prompt bytes.
+- No dialect has to be recognized, because no tool call is written as text.
+  The dialect table above still applies to the default path.
+- A tool-bearing request no longer uses a warm session, because Droid attaches
+  MCP servers only when a session starts. Requests without tools still do.
+- Droid's own tools stay disabled, apart from the deferred-tool loader the
+  model needs to reach the published tools at all.
+- The bridge refuses every published call at Droid's permission gate. The
+  OpenAI client runs the tool and resubmits the result, as it always has.
+
+The endpoint lives at `/factory/mcp/{token}` with a single-use token per
+request, and it is mounted only while the flag is on. Droid reaches it at
+`http://127.0.0.1:<port>`; set `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL`
+when the bridge answers on a different address than it binds.
+
 ## Requirements
 
 - Python 3.11 or newer
@@ -1212,6 +1238,8 @@ error types.
 | `FACTORY_DROID_OPENAI_MAX_TOOL_CALLS` | `64` | Tool calls accepted per Droid turn, from 1 through 64; the prompt asks the model for at most 8 at a time |
 | `FACTORY_DROID_OPENAI_TOOL_CALL_DRAIN_SECONDS` | `0.5` | Wait for further events after a complete tool call |
 | `FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX` | `false` | Repair tool-call payloads missing their opening `{"name":"` bytes |
+| `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS` | `false` | Publish client tools to Droid over MCP instead of describing them in the prompt |
+| `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL` | unset | Base URL Droid uses to reach the bridge's MCP endpoint |
 | `FACTORY_DROID_OPENAI_MAX_ATTACHMENTS` | `16` | Inline attachments per request |
 | `FACTORY_DROID_OPENAI_MAX_ATTACHMENT_BYTES` | `8388608` | Total encoded attachment bytes |
 | `FACTORY_DROID_OPENAI_MAX_CHOICES` | `4` | Upper bound for `n` |

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -27,6 +27,12 @@ from factory_droid_openai.logs import bind_request, current_timeline
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import info as log_info
 from factory_droid_openai.logs import warning as log_warning
+from factory_droid_openai.mcp_tools import (
+    NativeToolBinding,
+    NativeToolRegistry,
+    build_router,
+    to_mcp_tools,
+)
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.models import (
     ChatCompletionRequest,
@@ -750,6 +756,10 @@ def create_app(
         endpoint=DEFAULT_TELEMETRY_ENDPOINT,
         enabled=resolved_settings.telemetry,
     )
+    native_tools = NativeToolRegistry(
+        base_url=resolved_settings.native_tool_call_base_url(),
+        max_sessions=resolved_settings.max_tracked_sessions,
+    )
 
     @contextlib.asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
@@ -825,6 +835,12 @@ def create_app(
     application.state.reaper = reaper
     application.state.quarantine = quarantine
     application.state.telemetry = telemetry
+    application.state.native_tools = native_tools
+    if resolved_settings.native_tool_calls:
+        # The token in each path is the credential, so the endpoint carries no
+        # API-key dependency: only the Droid process this bridge started is
+        # ever told the URL.
+        application.include_router(build_router(native_tools))
 
     async def require_auth(credentials: BearerCredentials) -> None:
         expected = resolved_settings.api_key
@@ -1264,6 +1280,7 @@ def create_app(
                 max_attachments=resolved_settings.max_attachments,
                 max_attachment_bytes=resolved_settings.max_attachment_bytes,
                 continuation=session_id is not None,
+                native_tools=resolved_settings.native_tool_calls,
             )
         except RequestTooLargeError as exc:
             metrics.increment_payload_rejections()
@@ -1368,7 +1385,24 @@ def create_app(
                     session_use.release()
             raise
 
-        if session_id is None:
+        native_binding: NativeToolBinding | None = None
+        if plan.native_tools:
+            native_binding = native_tools.open(to_mcp_tools(plan.native_tools))
+            metrics.record_features(("native_tool_calls",))
+            run_request = replace(run_request, native_tools=native_binding)
+            log_debug(
+                "chat.native_tools_published",
+                tools=len(plan.native_tools),
+                open_catalogs=len(native_tools),
+            )
+
+        def release_native_tools() -> None:
+            if native_binding is not None:
+                native_tools.close(native_binding.token)
+
+        # Droid attaches MCP servers when a session starts, so a session warmed
+        # without this request's tools cannot serve the turn.
+        if session_id is None and native_binding is None:
             warm_session = pool.acquire(requested_key)
             if warm_session is not None:
                 metrics.record_features(("warm_session",))
@@ -1447,6 +1481,7 @@ def create_app(
                     reaper=reaper,
                     runner_factory=resolved_runner_factory,
                     session_use=session_use,
+                    release_native_tools=release_native_tools,
                 ),
                 headers={
                     "Cache-Control": "no-cache",
@@ -1513,8 +1548,11 @@ def create_app(
             note_runner_failure(payload.model, exc)
             return _error_response(str(exc), exc.status_code, exc.error_type)
         finally:
-            if session_use is not None:
-                session_use.release()
+            try:
+                if session_use is not None:
+                    session_use.release()
+            finally:
+                release_native_tools()
 
         log_info(
             "chat.completed",
@@ -2143,6 +2181,7 @@ async def _finalize_stream(
     reaper: BackgroundReaper | None = None,
     runner_factory: RunnerFactory | None = None,
     session_use: SessionUseLease | None = None,
+    release_native_tools: Callable[[], None] | None = None,
 ) -> None:
     close = getattr(stream, "aclose", None)
     try:
@@ -2163,8 +2202,12 @@ async def _finalize_stream(
         try:
             await lease.release()
         finally:
-            if session_use is not None:
-                session_use.release()
+            try:
+                if session_use is not None:
+                    session_use.release()
+            finally:
+                if release_native_tools is not None:
+                    release_native_tools()
 
 
 def _apply_emissions(

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -74,6 +74,14 @@ class Settings:
     # Off by default: the payload lost bytes, so the repair trusts less of the
     # wire than the always-on decoders do.
     repair_lost_prefix: bool = False
+    # Off by default: publishing tools over MCP moves tool calling off the text
+    # channel, which changes how a turn ends and costs a warm session per
+    # tool-bearing request.
+    native_tool_calls: bool = False
+    # Where the Droid process reaches this bridge back. The bind host can be a
+    # wildcard, which is not a usable target, so the loopback address is the
+    # default and an override exists for a bridge behind a different port.
+    native_tool_call_url: str | None = None
     # Off by default: prompts and tool payloads are private user content.
     trace_payloads: str = "off"
     trace_payload_file: Path | None = None
@@ -135,6 +143,11 @@ class Settings:
             "FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX",
             default=False,
         )
+        native_tool_calls = _boolean(
+            "FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS",
+            default=False,
+        )
+        native_tool_call_url = os.getenv("FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL") or None
         telemetry = _telemetry_enabled()
         max_queue_size = _non_negative_int(
             "FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE",
@@ -320,9 +333,17 @@ class Settings:
             detached_cleanup=detached_cleanup,
             telemetry=telemetry,
             repair_lost_prefix=repair_lost_prefix,
+            native_tool_calls=native_tool_calls,
+            native_tool_call_url=native_tool_call_url,
             trace_payloads=trace_payloads,
             trace_payload_file=trace_payload_file,
         )
+
+    def native_tool_call_base_url(self) -> str:
+        """Base URL the Droid process uses to reach the bridge's MCP endpoint."""
+        if self.native_tool_call_url is not None:
+            return self.native_tool_call_url
+        return f"http://127.0.0.1:{self.port}"
 
 
 def _positive_float(name: str, *, default: float) -> float:

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -22,6 +22,11 @@ _MCP_POLL_SECONDS = 0.1
 _TOOL_DISABLE_RETRIES = 3
 _TOOL_DISABLE_RETRY_SECONDS = 0.1
 _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
+# Droid keeps the deferred-tool loader callable in any session that has a tool
+# left to load, which is every session that publishes tools over MCP. It only
+# fetches a schema Droid already holds, and the model needs it to reach those
+# tools at all.
+_DEFERRED_TOOL_LOADER_IDS = frozenset({"tool-search-cli"})
 
 
 class _ProtocolEngine(Protocol):
@@ -115,22 +120,37 @@ class DroidRpcExtension:
             params,
         )
 
-    async def disable_native_tools(self, client: DroidClient) -> None:
+    async def disable_native_tools(
+        self,
+        client: DroidClient,
+        *,
+        keep_tool_prefix: str | None = None,
+    ) -> None:
+        """Disable every Droid tool, optionally sparing one id prefix.
+
+        ``keep_tool_prefix`` leaves the tools the bridge itself published over
+        MCP callable. Everything Droid owns still goes away, so a turn can only
+        reach tools the OpenAI client asked for.
+        """
         await self._wait_for_mcp_catalog(client)
         tools = await self._list_tools(client)
         if not tools:
             raise DroidClientError("Droid returned an empty native tool catalog")
         tool_ids = {_required_str(tool, "id") for tool in tools}
+        tolerated = _UNAVOIDABLE_TOOL_IDS
+        if keep_tool_prefix is not None:
+            tolerated = tolerated | _DEFERRED_TOOL_LOADER_IDS
         unexpected: set[str] = set()
         for attempt in range(_TOOL_DISABLE_RETRIES):
+            kept = _matching(tool_ids, keep_tool_prefix)
             await self._request(
                 client,
                 DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
                 {
                     "interactionMode": DroidInteractionMode.Auto.value,
                     "autonomyLevel": AutonomyLevel.Off.value,
-                    "enabledToolIds": [],
-                    "disabledToolIds": sorted(tool_ids),
+                    "enabledToolIds": sorted(kept),
+                    "disabledToolIds": sorted(tool_ids - kept),
                 },
             )
             remaining: set[str] = set()
@@ -139,7 +159,7 @@ class DroidRpcExtension:
                 tool_ids.add(tool_id)
                 if _required_bool(tool, "currentlyAllowed"):
                     remaining.add(tool_id)
-            unexpected = remaining - _UNAVOIDABLE_TOOL_IDS
+            unexpected = remaining - tolerated - _matching(remaining, keep_tool_prefix)
             if not unexpected:
                 return
             if attempt + 1 < _TOOL_DISABLE_RETRIES:
@@ -245,6 +265,12 @@ class DroidRpcExtension:
         if not isinstance(result, dict):
             raise DroidClientError(f"{method} returned a malformed result")
         return result
+
+
+def _matching(tool_ids: set[str], prefix: str | None) -> set[str]:
+    if prefix is None:
+        return set()
+    return {tool_id for tool_id in tool_ids if tool_id.startswith(prefix)}
 
 
 def _protocol(client: DroidClient) -> _ProtocolEngine:

--- a/src/factory_droid_openai/mcp_tools.py
+++ b/src/factory_droid_openai/mcp_tools.py
@@ -1,0 +1,208 @@
+"""Publish client tools to Droid natively over an in-process MCP endpoint.
+
+By default the bridge asks the model to write tool calls as text and recovers
+them from the answer, which means tolerating every dialect a model invents.
+This module offers the other route: the tools a request carries are served to
+Droid as an MCP server, so Droid renders them through the model's own tool slot
+and reports each call as a structured event. Nothing has to be parsed out of
+free text.
+
+The endpoint holds no conversation state. A single-use token in the URL binds
+one MCP server to one chat completion, and the tool catalog is all the endpoint
+serves: the OpenAI client, never the bridge, executes the tools, so a call is
+answered with a refusal and the bridge reads the call itself off the session's
+events instead.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
+
+from factory_droid_openai.logs import debug as log_debug
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
+# Droid derives both public names of an MCP tool from the server name: the
+# model sees "<server>___<tool>" and session settings key the same tool as
+# "mcp_<server>_<tool>".
+MCP_SERVER_NAME: Final = "openai-bridge"
+MCP_TOOL_PREFIX: Final = f"{MCP_SERVER_NAME}___"
+MCP_TOOL_ID_PREFIX: Final = f"mcp_{MCP_SERVER_NAME}_"
+# Latest revision Droid's client negotiates down to without complaint. Droid
+# offers a newer one and accepts this answer.
+MCP_PROTOCOL_VERSION: Final = "2025-06-18"
+MCP_ROUTE_PREFIX: Final = "/factory/mcp"
+# Answered to a tool call that reaches the endpoint anyway, which only happens
+# when a Droid setting pre-approves MCP tools and skips the permission gate.
+_CALL_REFUSAL: Final = (
+    "This tool is executed by the OpenAI client, not by Factory Droid. "
+    "The call has been reported to the client."
+)
+_JSONRPC_VERSION: Final = "2.0"
+_METHOD_NOT_FOUND: Final = -32601
+_INVALID_REQUEST: Final = -32600
+
+
+@dataclass(frozen=True, slots=True)
+class NativeToolBinding:
+    """What one request needs to reach its own MCP endpoint."""
+
+    token: str
+    url: str
+
+    def server_config(self) -> dict[str, Any]:
+        """Render the MCP server entry Droid's session initializer expects."""
+        return {"name": MCP_SERVER_NAME, "type": "http", "url": self.url}
+
+
+class NativeToolRegistry:
+    """Tool catalogs of in-flight requests, keyed by single-use token."""
+
+    def __init__(self, *, base_url: str, max_sessions: int = 256) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._max_sessions = max_sessions
+        self._catalogs: dict[str, tuple[dict[str, Any], ...]] = {}
+
+    def open(self, tools: Sequence[Mapping[str, Any]]) -> NativeToolBinding:
+        """Publish ``tools`` under a fresh token and return how to reach them."""
+        token = secrets.token_urlsafe(24)
+        while len(self._catalogs) >= self._max_sessions:
+            # A request that never closed its catalog must not pin memory for
+            # the life of the process. The oldest entry belongs to the oldest
+            # request, whose turn is over by the time the cap is reached.
+            self._catalogs.pop(next(iter(self._catalogs)))
+        self._catalogs[token] = tuple(dict(tool) for tool in tools)
+        return NativeToolBinding(token=token, url=f"{self._base_url}{MCP_ROUTE_PREFIX}/{token}")
+
+    def close(self, token: str) -> None:
+        self._catalogs.pop(token, None)
+
+    def catalog(self, token: str) -> tuple[dict[str, Any], ...] | None:
+        return self._catalogs.get(token)
+
+    def __len__(self) -> int:
+        return len(self._catalogs)
+
+
+def to_mcp_tools(tools: Iterable[Any]) -> tuple[dict[str, Any], ...]:
+    """Convert OpenAI tool definitions into MCP tool descriptors."""
+    published: list[dict[str, Any]] = []
+    for tool in tools:
+        function = tool.function
+        # MCP requires an object schema; OpenAI allows a tool with none, which
+        # means "no arguments".
+        schema = dict(function.parameters) if function.parameters else {"type": "object"}
+        entry: dict[str, Any] = {"name": function.name, "inputSchema": schema}
+        if function.description:
+            entry["description"] = function.description
+        published.append(entry)
+    return tuple(published)
+
+
+def strip_tool_prefix(tool_name: str) -> str | None:
+    """Return the client's own tool name, or ``None`` for a foreign tool."""
+    if not tool_name.startswith(MCP_TOOL_PREFIX):
+        return None
+    return tool_name[len(MCP_TOOL_PREFIX) :] or None
+
+
+def is_bridge_tool_id(tool_id: str) -> bool:
+    """Whether a Droid tool id belongs to the tools this bridge published."""
+    return tool_id.startswith(MCP_TOOL_ID_PREFIX)
+
+
+def handle_rpc(
+    catalog: tuple[dict[str, Any], ...],
+    message: Any,
+) -> tuple[int, dict[str, Any] | None]:
+    """Answer one JSON-RPC message, as ``(status_code, body)``.
+
+    A body of ``None`` means the message was a notification, which the MCP
+    transport acknowledges with an empty 202.
+    """
+    if not isinstance(message, dict):
+        return 400, _error(None, _INVALID_REQUEST, "request must be a JSON-RPC object")
+    method = message.get("method")
+    call_id = message.get("id")
+    if not isinstance(method, str):
+        return 400, _error(call_id, _INVALID_REQUEST, "request is missing a method")
+    if method.startswith("notifications/"):
+        return 202, None
+    if method == "initialize":
+        return 200, _result(
+            call_id,
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": MCP_SERVER_NAME, "version": "1"},
+            },
+        )
+    if method == "ping":
+        return 200, _result(call_id, {})
+    if method == "tools/list":
+        return 200, _result(call_id, {"tools": list(catalog)})
+    if method == "tools/call":
+        return 200, _result(
+            call_id,
+            {"content": [{"type": "text", "text": _CALL_REFUSAL}], "isError": True},
+        )
+    return 200, _error(call_id, _METHOD_NOT_FOUND, f"unsupported method {method}")
+
+
+def build_router(registry: NativeToolRegistry) -> APIRouter:
+    """Serve every open tool catalog under its own token."""
+    router = APIRouter(include_in_schema=False)
+    path = f"{MCP_ROUTE_PREFIX}/{{token}}"
+
+    @router.post(path)
+    async def rpc(token: str, request: Request) -> Response:
+        catalog = registry.catalog(token)
+        if catalog is None:
+            return JSONResponse({"error": "unknown MCP session"}, status_code=404)
+        try:
+            message = await request.json()
+        except ValueError:
+            return JSONResponse(
+                _error(None, _INVALID_REQUEST, "request body is not JSON"),
+                status_code=400,
+            )
+        status, body = handle_rpc(catalog, message)
+        log_debug(
+            "mcp.request",
+            method=message.get("method") if isinstance(message, dict) else None,
+            status=status,
+            tools=len(catalog),
+        )
+        if body is None:
+            return Response(status_code=status)
+        # Droid keys follow-up requests by this header, and a stateless
+        # endpoint can hand back the token it already routed on.
+        return JSONResponse(body, status_code=status, headers={"Mcp-Session-Id": token})
+
+    @router.get(path)
+    async def stream() -> Response:
+        # The bridge never pushes server-initiated messages, and the MCP spec
+        # lets such a server refuse the event stream. Droid carries on.
+        return Response(status_code=405)
+
+    @router.delete(path)
+    async def terminate() -> Response:
+        # The request that opened the catalog closes it, so a client-side
+        # teardown has nothing left to release.
+        return Response(status_code=204)
+
+    return router
+
+
+def _result(call_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": _JSONRPC_VERSION, "id": call_id, "result": result}
+
+
+def _error(call_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": _JSONRPC_VERSION, "id": call_id, "error": {"code": code, "message": message}}

--- a/src/factory_droid_openai/mcp_tools.py
+++ b/src/factory_droid_openai/mcp_tools.py
@@ -55,10 +55,26 @@ class NativeToolBinding:
 
     token: str
     url: str
+    names: frozenset[str]
 
     def server_config(self) -> dict[str, Any]:
         """Render the MCP server entry Droid's session initializer expects."""
         return {"name": MCP_SERVER_NAME, "type": "http", "url": self.url}
+
+    def resolve(self, tool_name: str) -> str | None:
+        """Return the published tool an event names, or ``None`` for a foreign one.
+
+        Droid spells one MCP tool three ways: the model calls it
+        ``<server>___<tool>``, session settings key it ``mcp_<server>_<tool>``,
+        and a tool reached through the deferred-tool loader is reported under
+        its own bare name. Membership in this request's catalog is what makes
+        the bare spelling safe to honour.
+        """
+        for prefix in (MCP_TOOL_PREFIX, MCP_TOOL_ID_PREFIX):
+            if tool_name.startswith(prefix):
+                tool_name = tool_name[len(prefix) :]
+                break
+        return tool_name if tool_name in self.names else None
 
 
 class NativeToolRegistry:
@@ -77,8 +93,13 @@ class NativeToolRegistry:
             # the life of the process. The oldest entry belongs to the oldest
             # request, whose turn is over by the time the cap is reached.
             self._catalogs.pop(next(iter(self._catalogs)))
-        self._catalogs[token] = tuple(dict(tool) for tool in tools)
-        return NativeToolBinding(token=token, url=f"{self._base_url}{MCP_ROUTE_PREFIX}/{token}")
+        catalog = tuple(dict(tool) for tool in tools)
+        self._catalogs[token] = catalog
+        return NativeToolBinding(
+            token=token,
+            url=f"{self._base_url}{MCP_ROUTE_PREFIX}/{token}",
+            names=frozenset(str(tool["name"]) for tool in catalog),
+        )
 
     def close(self, token: str) -> None:
         self._catalogs.pop(token, None)
@@ -103,18 +124,6 @@ def to_mcp_tools(tools: Iterable[Any]) -> tuple[dict[str, Any], ...]:
             entry["description"] = function.description
         published.append(entry)
     return tuple(published)
-
-
-def strip_tool_prefix(tool_name: str) -> str | None:
-    """Return the client's own tool name, or ``None`` for a foreign tool."""
-    if not tool_name.startswith(MCP_TOOL_PREFIX):
-        return None
-    return tool_name[len(MCP_TOOL_PREFIX) :] or None
-
-
-def is_bridge_tool_id(tool_id: str) -> bool:
-    """Whether a Droid tool id belongs to the tools this bridge published."""
-    return tool_id.startswith(MCP_TOOL_ID_PREFIX)
 
 
 def handle_rpc(

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -101,6 +101,10 @@ class PromptPlan:
     allowed_tool_names: frozenset[str]
     require_tool_call: bool
     attachments: AttachmentSet = field(default_factory=AttachmentSet)
+    # Populated only for a native tool-calling request: the tools tool_choice
+    # left callable, for the caller to publish over MCP instead of in the
+    # prompt.
+    native_tools: tuple[ToolDefinition, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +134,7 @@ def build_prompt(
     max_attachments: int = 16,
     max_attachment_bytes: int = 8_388_608,
     continuation: bool = False,
+    native_tools: bool = False,
 ) -> PromptPlan:
     if len(request.messages) > max_messages:
         raise RequestTooLargeError(f"request exceeds maximum of {max_messages} messages")
@@ -175,13 +180,18 @@ def build_prompt(
         message_bytes += serialized_bytes
         serialized_messages.append(serialized)
 
+    # Native tool calling publishes the schemas over MCP, so repeating them in
+    # the transcript would only spend context. They are still serialized above,
+    # which is what enforces the schema size and depth limits.
+    transcript_tools = [] if native_tools else serialized_tools
+    transcript_tool_bytes = 0 if native_tools else tool_schema_bytes
     transcript_bytes = (
         len(b'{"messages":[')
         + message_bytes
         + max(0, len(serialized_messages) - 1)
         + len(b'],"tools":[')
-        + tool_schema_bytes
-        + max(0, len(serialized_tools) - 1)
+        + transcript_tool_bytes
+        + max(0, len(transcript_tools) - 1)
         + len(b"]}")
     )
     if transcript_bytes > max_transcript_bytes:
@@ -191,12 +201,37 @@ def build_prompt(
         '{"messages":['
         + ",".join(serialized_messages)
         + '],"tools":['
-        + ",".join(serialized_tools)
+        + ",".join(transcript_tools)
         + "]}"
     )
     tool_names = frozenset(tool.function.name for tool in selected_tools)
 
-    if tool_names:
+    if tool_names and native_tools:
+        # Droid registers these as real tools, so the prompt only has to keep
+        # the model from answering in the text dialect the other path needs.
+        available = ", ".join(sorted(tool_names))
+        tool_rule = (
+            f"The client provides these callable tools: {available}. "
+            "They are registered as tools in this session, so call them the way "
+            "you call any tool. Never write a tool call as text, never emit "
+            f"{TOOL_CALL_OPEN} or {TOOL_CALL_CLOSE}, and do not call "
+            "Droid-native tools."
+        )
+        if any(message.role == "tool" for message in prompt_messages):
+            # The session's own tool history is empty on every request, so a
+            # model that trusts only what it called itself would run the same
+            # call again instead of answering from the result it was given.
+            tool_rule += (
+                " Results of earlier calls are in the transcript below. Treat "
+                "them as final and do not repeat a call the transcript already "
+                "answers."
+            )
+        if require_tool_call:
+            tool_rule += (
+                " A tool call is required for this response: call a tool instead "
+                "of explaining or asking a question."
+            )
+    elif tool_names:
         if max_tool_calls > 1:
             # The prompt suggests far less than the limit accepts. A high number
             # here reads as an invitation to burst, and a model that bursts
@@ -271,6 +306,7 @@ def build_prompt(
         allowed_tool_names=tool_names,
         require_tool_call=require_tool_call,
         attachments=attachments,
+        native_tools=tuple(selected_tools) if native_tools else (),
     )
 
 

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -222,9 +222,10 @@ def build_prompt(
             # model that trusts only what it called itself would run the same
             # call again instead of answering from the result it was given.
             tool_rule += (
-                " Results of earlier calls are in the transcript below. Treat "
-                "them as final and do not repeat a call the transcript already "
-                "answers."
+                " The transcript below already carries the results of earlier "
+                "calls. Those results are final: answer the user from them, and "
+                "call a tool again only for something the transcript does not "
+                "answer yet."
             )
         if require_tool_call:
             tool_rule += (

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -51,7 +51,6 @@ from factory_droid_openai.logs import warning as log_warning
 from factory_droid_openai.mcp_tools import (
     MCP_TOOL_ID_PREFIX,
     NativeToolBinding,
-    strip_tool_prefix,
 )
 
 # droid exec flags the SDK's ProcessTransport always passes. Overriding
@@ -613,7 +612,7 @@ class DroidRunner:
                         yield RunComplete(usage)
                     elif isinstance(event, (ToolUse, ToolResult, ToolProgress)):
                         if request.native_tools is not None:
-                            published = strip_tool_prefix(event.tool_name)
+                            published = request.native_tools.resolve(event.tool_name)
                             if published is not None:
                                 if isinstance(event, ToolUse):
                                     native_tool_calls += 1

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import re
 import signal
 import time
@@ -33,6 +34,7 @@ from droid_sdk.schemas.enums import (
 )
 
 from factory_droid_openai.config import DEFAULT_MODEL_ALIAS
+from factory_droid_openai.dialects import TOOL_CALL_CLOSE, TOOL_CALL_OPEN
 from factory_droid_openai.droid_rpc import (
     CompactionResult,
     ContextBreakdown,
@@ -46,6 +48,11 @@ from factory_droid_openai.logs import enabled as log_enabled
 from factory_droid_openai.logs import millis as _millis
 from factory_droid_openai.logs import trace as log_trace
 from factory_droid_openai.logs import warning as log_warning
+from factory_droid_openai.mcp_tools import (
+    MCP_TOOL_ID_PREFIX,
+    NativeToolBinding,
+    strip_tool_prefix,
+)
 
 # droid exec flags the SDK's ProcessTransport always passes. Overriding
 # exec_args replaces this list wholesale, so extra flags must be appended
@@ -86,6 +93,20 @@ _MODEL_FAMILY_PREFIXES = (
 def _is_ignorable_native_tool(tool_name: str) -> bool:
     """Report whether an event names a Droid meta tool the bridge tolerates."""
     return tool_name.replace("-", "").replace("_", "").casefold() in _IGNORED_NATIVE_TOOLS
+
+
+def _native_tool_marker(name: str, arguments: Any) -> str:
+    """Render a structured tool call in the bridge's own marker form."""
+    payload = json.dumps(
+        {"name": name, "arguments": arguments if isinstance(arguments, dict) else {}},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    # An argument value may legitimately contain marker text. Escaping every
+    # "<" keeps the markers the only ones in the stream and decodes back to the
+    # value the model sent.
+    escaped = payload.replace("<", "\\u003c")
+    return f"{TOOL_CALL_OPEN}{escaped}{TOOL_CALL_CLOSE}"
 
 
 def model_family(model: str) -> str:
@@ -179,6 +200,9 @@ class RunRequest:
     session_id: str | None = None
     output_format: dict[str, Any] | None = None
     warm_session: WarmSession | None = None
+    # Set when the request's tools are published to Droid over MCP instead of
+    # being described in the prompt.
+    native_tools: NativeToolBinding | None = None
 
     def session_key(self) -> SessionKey:
         return SessionKey.from_request(
@@ -430,10 +454,18 @@ class DroidRunner:
             client.set_ask_user_handler(
                 lambda _params: {"cancelled": True, "answers": []},
             )
+        if warm is not None and request.native_tools is not None:
+            # A warm session was initialized without the request's MCP server,
+            # and Droid attaches those only when a session starts.
+            raise RunnerError(
+                "A warm Droid session cannot serve a native tool-calling turn.",
+            )
+        mcp_servers = [] if request.native_tools is None else [request.native_tools.server_config()]
         initialized = warm is not None
         completed = False
         ignored_native_tool = False
         saw_assistant_text = False
+        native_tool_calls = 0
         unmapped_event_kind: str | None = None
         usage = Usage()
 
@@ -463,13 +495,13 @@ class DroidRunner:
                         # the new turn is sent instead of the whole transcript.
                         await client.load_session(
                             session_id=request.session_id,
-                            mcp_servers=[],
+                            mcp_servers=mcp_servers,
                         )
                     else:
                         await client.initialize_session(
                             machine_id="factory-droid-openai",
                             cwd=str(self._workdir),
-                            mcp_servers=[],
+                            mcp_servers=mcp_servers,
                             model_id=_resolve_model_id(request.model, request.model_alias),
                             reasoning_effort=reasoning_effort,
                             interaction_mode=DroidInteractionMode.Auto,
@@ -478,7 +510,12 @@ class DroidRunner:
                             enabled_tool_ids=[],
                         )
                     initialized = True
-                    await self._rpc.disable_native_tools(client)
+                    await self._rpc.disable_native_tools(
+                        client,
+                        keep_tool_prefix=(
+                            None if request.native_tools is None else MCP_TOOL_ID_PREFIX
+                        ),
+                    )
                 else:
                     await self._retune(warm, request.session_key())
                 session_timeline = current_timeline()
@@ -544,8 +581,10 @@ class DroidRunner:
                         usage = _map_usage(event)
                         yield UsageUpdate(usage)
                     elif isinstance(event, TurnComplete):
-                        if not saw_assistant_text and (
-                            ignored_native_tool or unmapped_event_kind is not None
+                        if (
+                            not saw_assistant_text
+                            and not native_tool_calls
+                            and (ignored_native_tool or unmapped_event_kind is not None)
                         ):
                             reason = (
                                 "a disabled Droid meta-tool attempt"
@@ -573,6 +612,24 @@ class DroidRunner:
                         )
                         yield RunComplete(usage)
                     elif isinstance(event, (ToolUse, ToolResult, ToolProgress)):
+                        if request.native_tools is not None:
+                            published = strip_tool_prefix(event.tool_name)
+                            if published is not None:
+                                if isinstance(event, ToolUse):
+                                    native_tool_calls += 1
+                                    log_debug("droid.native_tool_call", tool=published)
+                                    # Reusing the marker form runs the call
+                                    # through the same validation, cap and
+                                    # de-duplication path as a text answer.
+                                    yield TextDelta(
+                                        _native_tool_marker(published, event.tool_input)
+                                    )
+                                continue
+                            if native_tool_calls and not event.tool_name:
+                                # The bridge refuses the call so the OpenAI
+                                # client can run it, and Droid reports that
+                                # refusal as a nameless result.
+                                continue
                         if _is_ignorable_native_tool(event.tool_name):
                             ignored_native_tool = True
                             log_debug("droid.native_tool_ignored", tool=event.tool_name)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4746,3 +4746,164 @@ def test_request_outcome_falls_back_to_the_status_code() -> None:
     scope = cast("Any", {"state": {"stream_outcome": "pending"}})
 
     assert _request_outcome(200, scope) == "success"
+
+
+def _native_settings(tmp_path: Path) -> Settings:
+    return Settings(
+        droid_path="droid",
+        workdir=tmp_path,
+        timeout_seconds=30.0,
+        native_tool_calls=True,
+    )
+
+
+def _weather_payload(**overrides: object) -> dict[str, object]:
+    return _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "weather",
+                    "description": "Read the weather.",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            }
+        ],
+        **overrides,
+    )
+
+
+class CatalogWatchingRunner(FakeRunner):
+    """Records what the MCP endpoint would serve while the turn is running."""
+
+    def __init__(self, events: list[RunEvent], registry: Any) -> None:
+        super().__init__(events)
+        self.registry = registry
+        self.catalog_in_flight: tuple[dict[str, Any], ...] | None = None
+
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+        if request.native_tools is not None:
+            self.catalog_in_flight = self.registry.catalog(request.native_tools.token)
+        async for event in super().run(request):
+            yield event
+
+
+@pytest.mark.asyncio
+async def test_native_tool_calls_publish_the_request_tools_for_the_turn(tmp_path: Path) -> None:
+    marker = (
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}{TOOL_CALL_CLOSE}'
+    )
+    runner = CatalogWatchingRunner([TextDelta(marker), RunComplete(Usage())], registry=None)
+    app = create_app(
+        _native_settings(tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    runner.registry = app.state.native_tools
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
+
+    assert response.status_code == 200
+    message = response.json()["choices"][0]["message"]
+    assert message["tool_calls"][0]["function"] == {
+        "name": "weather",
+        "arguments": '{"city":"Gdansk"}',
+    }
+    assert response.json()["choices"][0]["finish_reason"] == "tool_calls"
+    assert runner.catalog_in_flight == (
+        {
+            "name": "weather",
+            "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}},
+            "description": "Read the weather.",
+        },
+    )
+    # The prompt no longer has to describe the tools, and the catalog is gone
+    # once the turn that published it is over.
+    assert "Read the weather." not in runner.requests[0].prompt
+    assert runner.requests[0].warm_session is None
+    assert len(app.state.native_tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_native_tool_calls_serve_the_catalog_over_the_mcp_endpoint(tmp_path: Path) -> None:
+    app = create_app(
+        _native_settings(tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: FakeRunner([RunComplete(Usage())])),
+    )
+    binding = app.state.native_tools.open(({"name": "weather", "inputSchema": {}},))
+
+    async with _client(app) as client:
+        response = await client.post(
+            f"/factory/mcp/{binding.token}",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["tools"] == [{"name": "weather", "inputSchema": {}}]
+
+
+@pytest.mark.asyncio
+async def test_the_mcp_endpoint_stays_unmounted_by_default(tmp_path: Path) -> None:
+    app = _app(tmp_path, FakeRunner([RunComplete(Usage())]))
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/factory/mcp/anything",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+
+    assert response.status_code == 404
+    assert "mcp" not in json.dumps(app.openapi()["paths"])
+
+
+@pytest.mark.asyncio
+async def test_a_streamed_native_turn_closes_its_catalog(tmp_path: Path) -> None:
+    marker = (
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}{TOOL_CALL_CLOSE}'
+    )
+    runner = FakeRunner([TextDelta(marker), RunComplete(Usage())])
+    app = create_app(
+        _native_settings(tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_weather_payload(stream=True),
+        )
+
+    assert response.status_code == 200
+    assert '"tool_calls"' in response.text
+    assert runner.requests[0].native_tools is not None
+    assert len(app.state.native_tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_failed_native_turn_closes_its_catalog(tmp_path: Path) -> None:
+    runner = FakeRunner([], error=RunnerError("droid failed"))
+    app = create_app(
+        _native_settings(tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
+
+    assert response.status_code == 502
+    assert len(app.state.native_tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_native_request_without_tools_publishes_nothing(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("hello"), RunComplete(Usage())])
+    app = create_app(
+        _native_settings(tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload())
+
+    assert response.status_code == 200
+    assert runner.requests[0].native_tools is None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -996,7 +996,10 @@ async def test_tool_call_drain_keeps_delayed_parallel_calls(
                 self.closed = True
 
     runner = DelayedParallelRunner([])
-    app = _feature_app(tmp_path, runner, tool_call_drain_seconds=0.05)
+    # The window has to outlast the gap the runner leaves between the two
+    # calls by a wide margin: a loaded CI machine stretches a 10 ms sleep far
+    # past its nominal length, and a window that close drops the second call.
+    app = _feature_app(tmp_path, runner, tool_call_drain_seconds=0.5)
     payload = _payload(
         stream=stream,
         tools=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -691,3 +691,47 @@ def test_settings_trace_file_rejects_symlink(
 
     with pytest.raises(ValueError, match="must not be a symlink"):
         Settings.from_env()
+
+
+def test_native_tool_calls_are_off_until_the_environment_asks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+
+    default = Settings.from_env()
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS", "true")
+    enabled = Settings.from_env()
+
+    assert default.native_tool_calls is False
+    assert enabled.native_tool_calls is True
+
+
+def test_native_tool_call_url_defaults_to_the_bridge_port(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_PORT", "9001")
+    # A wildcard bind address is not a target Droid can call back on.
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_HOST", "0.0.0.0")
+
+    settings = Settings.from_env()
+
+    assert settings.native_tool_call_url is None
+    assert settings.native_tool_call_base_url() == "http://127.0.0.1:9001"
+
+
+def test_native_tool_call_url_can_be_overridden(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(tmp_path))
+    monkeypatch.setenv(
+        "FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL",
+        "http://bridge.internal:8080",
+    )
+
+    settings = Settings.from_env()
+
+    assert settings.native_tool_call_base_url() == "http://bridge.internal:8080"

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -389,3 +389,63 @@ async def test_protocol_engine_contract_carries_no_default_behavior() -> None:
     engine: _ProtocolEngine = FakeProtocol(lambda _method, _params: {"result": {}})
 
     assert not await _ProtocolEngine.send_request(engine, "droid.list_tools", {})
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_spares_the_tools_the_bridge_published() -> None:
+    disabled: set[str] = set()
+    enabled: set[str] = set()
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {"id": "read-cli", "currentlyAllowed": "read-cli" not in disabled},
+                        {"id": "exit-spec-mode", "currentlyAllowed": True},
+                        # Droid keeps its deferred-tool loader callable in a
+                        # session that still has a tool to load.
+                        {"id": "tool-search-cli", "currentlyAllowed": True},
+                        {"id": "mcp_openai-bridge_get_weather", "currentlyAllowed": True},
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            disabled.update(params["disabledToolIds"])
+            enabled.update(params["enabledToolIds"])
+            return {"result": {}}
+        raise AssertionError(method)
+
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension().disable_native_tools(
+        _client(protocol),
+        keep_tool_prefix="mcp_openai-bridge_",
+    )
+
+    assert enabled == {"mcp_openai-bridge_get_weather"}
+    assert disabled == {"exit-spec-mode", "read-cli", "tool-search-cli"}
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_still_fails_on_a_tool_that_stays_callable() -> None:
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        del params
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {"id": "execute-cli", "currentlyAllowed": True},
+                        {"id": "mcp_openai-bridge_get_weather", "currentlyAllowed": True},
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            return {"result": {}}
+        raise AssertionError(method)
+
+    with pytest.raises(DroidClientError, match="execute-cli"):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            keep_tool_prefix="mcp_openai-bridge_",
+        )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -13,8 +13,6 @@ from factory_droid_openai.mcp_tools import (
     NativeToolRegistry,
     build_router,
     handle_rpc,
-    is_bridge_tool_id,
-    strip_tool_prefix,
     to_mcp_tools,
 )
 from factory_droid_openai.models import ToolDefinition
@@ -125,21 +123,23 @@ def test_openai_tools_become_mcp_descriptors() -> None:
 @pytest.mark.parametrize(
     ("tool_name", "expected"),
     [
+        # Every spelling Droid uses for a published tool resolves to the name
+        # the OpenAI client knows.
         (f"{MCP_SERVER_NAME}___get_weather", "get_weather"),
+        (f"mcp_{MCP_SERVER_NAME}_get_weather", "get_weather"),
+        ("get_weather", "get_weather"),
         (f"{MCP_SERVER_NAME}___", None),
-        ("get_weather", None),
+        (f"{MCP_SERVER_NAME}___read-cli", None),
         ("other-server___get_weather", None),
+        ("read-cli", None),
     ],
 )
-def test_only_the_bridge_prefix_names_a_published_tool(
+def test_a_binding_resolves_only_the_tools_it_published(
     tool_name: str, expected: str | None
 ) -> None:
-    assert strip_tool_prefix(tool_name) == expected
+    binding = NativeToolRegistry(base_url="http://127.0.0.1:8787").open(_catalog())
 
-
-def test_only_the_bridge_prefix_names_a_published_tool_id() -> None:
-    assert is_bridge_tool_id(f"mcp_{MCP_SERVER_NAME}_get_weather")
-    assert not is_bridge_tool_id("read-cli")
+    assert binding.resolve(tool_name) == expected
 
 
 def test_initialize_answers_with_the_negotiated_protocol() -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from factory_droid_openai.mcp_tools import (
+    MCP_PROTOCOL_VERSION,
+    MCP_ROUTE_PREFIX,
+    MCP_SERVER_NAME,
+    NativeToolRegistry,
+    build_router,
+    handle_rpc,
+    is_bridge_tool_id,
+    strip_tool_prefix,
+    to_mcp_tools,
+)
+from factory_droid_openai.models import ToolDefinition
+
+
+def _tool(**overrides: Any) -> ToolDefinition:
+    function: dict[str, Any] = {
+        "name": "get_weather",
+        "description": "Return the weather.",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    }
+    function.update(overrides)
+    return ToolDefinition(type="function", function=cast("Any", function))
+
+
+def _registry(**overrides: Any) -> NativeToolRegistry:
+    options: dict[str, Any] = {"base_url": "http://127.0.0.1:8787"}
+    options.update(overrides)
+    return NativeToolRegistry(**options)
+
+
+def _catalog() -> tuple[dict[str, Any], ...]:
+    return to_mcp_tools([_tool()])
+
+
+def _app(registry: NativeToolRegistry) -> FastAPI:
+    application = FastAPI()
+    application.include_router(build_router(registry))
+    return application
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+
+def test_registry_publishes_a_catalog_under_a_single_use_token() -> None:
+    registry = _registry()
+
+    binding = registry.open(_catalog())
+
+    assert binding.url == f"http://127.0.0.1:8787{MCP_ROUTE_PREFIX}/{binding.token}"
+    assert registry.catalog(binding.token) == _catalog()
+    assert len(registry) == 1
+    assert binding.server_config() == {
+        "name": MCP_SERVER_NAME,
+        "type": "http",
+        "url": binding.url,
+    }
+
+
+def test_registry_trims_a_trailing_slash_from_the_base_url() -> None:
+    registry = _registry(base_url="http://127.0.0.1:8787/")
+
+    binding = registry.open(())
+
+    assert binding.url == f"http://127.0.0.1:8787{MCP_ROUTE_PREFIX}/{binding.token}"
+
+
+def test_registry_forgets_a_closed_catalog() -> None:
+    registry = _registry()
+    binding = registry.open(_catalog())
+
+    registry.close(binding.token)
+    registry.close(binding.token)
+
+    assert registry.catalog(binding.token) is None
+    assert len(registry) == 0
+
+
+def test_registry_evicts_the_oldest_catalog_at_the_cap() -> None:
+    registry = _registry(max_sessions=1)
+    first = registry.open(_catalog())
+
+    second = registry.open(_catalog())
+
+    assert registry.catalog(first.token) is None
+    assert registry.catalog(second.token) == _catalog()
+
+
+def test_registry_copies_the_published_tools() -> None:
+    registry = _registry()
+    tool: dict[str, Any] = {"name": "get_weather", "inputSchema": {"type": "object"}}
+
+    binding = registry.open([tool])
+    tool["name"] = "mutated"
+
+    catalog = registry.catalog(binding.token)
+    assert catalog is not None
+    assert catalog[0]["name"] == "get_weather"
+
+
+def test_openai_tools_become_mcp_descriptors() -> None:
+    published = to_mcp_tools([_tool(), _tool(name="ping", description="", parameters={})])
+
+    assert published == (
+        {
+            "name": "get_weather",
+            "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}},
+            "description": "Return the weather.",
+        },
+        {"name": "ping", "inputSchema": {"type": "object"}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        (f"{MCP_SERVER_NAME}___get_weather", "get_weather"),
+        (f"{MCP_SERVER_NAME}___", None),
+        ("get_weather", None),
+        ("other-server___get_weather", None),
+    ],
+)
+def test_only_the_bridge_prefix_names_a_published_tool(
+    tool_name: str, expected: str | None
+) -> None:
+    assert strip_tool_prefix(tool_name) == expected
+
+
+def test_only_the_bridge_prefix_names_a_published_tool_id() -> None:
+    assert is_bridge_tool_id(f"mcp_{MCP_SERVER_NAME}_get_weather")
+    assert not is_bridge_tool_id("read-cli")
+
+
+def test_initialize_answers_with_the_negotiated_protocol() -> None:
+    status, body = handle_rpc(_catalog(), {"jsonrpc": "2.0", "id": 0, "method": "initialize"})
+
+    assert status == 200
+    assert body is not None
+    assert body["result"]["protocolVersion"] == MCP_PROTOCOL_VERSION
+    assert body["result"]["serverInfo"]["name"] == MCP_SERVER_NAME
+    assert body["result"]["capabilities"] == {"tools": {"listChanged": False}}
+
+
+def test_tools_list_serves_the_request_catalog() -> None:
+    status, body = handle_rpc(_catalog(), {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+    assert status == 200
+    assert body is not None
+    assert body["result"] == {"tools": list(_catalog())}
+
+
+def test_ping_is_answered_with_an_empty_result() -> None:
+    status, body = handle_rpc((), {"jsonrpc": "2.0", "id": 2, "method": "ping"})
+
+    assert (status, body) == (200, {"jsonrpc": "2.0", "id": 2, "result": {}})
+
+
+def test_a_notification_is_acknowledged_without_a_body() -> None:
+    status, body = handle_rpc((), {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    assert (status, body) == (202, None)
+
+
+def test_a_tool_call_is_refused_because_the_client_runs_the_tool() -> None:
+    status, body = handle_rpc(
+        _catalog(),
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "get_weather", "arguments": {"city": "Gdansk"}},
+        },
+    )
+
+    assert status == 200
+    assert body is not None
+    assert body["result"]["isError"] is True
+    assert "OpenAI client" in body["result"]["content"][0]["text"]
+
+
+def test_an_unsupported_method_is_reported_as_such() -> None:
+    status, body = handle_rpc((), {"jsonrpc": "2.0", "id": 4, "method": "resources/list"})
+
+    assert status == 200
+    assert body is not None
+    assert body["error"]["code"] == -32601
+
+
+@pytest.mark.parametrize("message", [["not", "an", "object"], {"jsonrpc": "2.0", "id": 5}])
+def test_a_malformed_request_is_rejected(message: Any) -> None:
+    status, body = handle_rpc((), message)
+
+    assert status == 400
+    assert body is not None
+    assert body["error"]["code"] == -32600
+
+
+@pytest.mark.asyncio
+async def test_endpoint_serves_the_catalog_of_an_open_request() -> None:
+    registry = _registry()
+    binding = registry.open(_catalog())
+
+    async with _client(_app(registry)) as client:
+        response = await client.post(
+            f"{MCP_ROUTE_PREFIX}/{binding.token}",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["mcp-session-id"] == binding.token
+    assert response.json()["result"]["tools"][0]["name"] == "get_weather"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_answers_a_notification_with_an_empty_body() -> None:
+    registry = _registry()
+    binding = registry.open(())
+
+    async with _client(_app(registry)) as client:
+        response = await client.post(
+            f"{MCP_ROUTE_PREFIX}/{binding.token}",
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+@pytest.mark.asyncio
+async def test_endpoint_rejects_an_unknown_token() -> None:
+    registry = _registry()
+
+    async with _client(_app(registry)) as client:
+        response = await client.post(
+            f"{MCP_ROUTE_PREFIX}/nope",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "unknown MCP session"}
+
+
+@pytest.mark.asyncio
+async def test_endpoint_rejects_a_body_that_is_not_json() -> None:
+    registry = _registry()
+    binding = registry.open(())
+
+    async with _client(_app(registry)) as client:
+        response = await client.post(
+            f"{MCP_ROUTE_PREFIX}/{binding.token}",
+            content=b"{not json",
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == -32600
+
+
+@pytest.mark.asyncio
+async def test_endpoint_refuses_the_event_stream_and_accepts_teardown() -> None:
+    registry = _registry()
+    binding = registry.open(())
+
+    async with _client(_app(registry)) as client:
+        stream = await client.get(f"{MCP_ROUTE_PREFIX}/{binding.token}")
+        teardown = await client.delete(f"{MCP_ROUTE_PREFIX}/{binding.token}")
+
+    assert stream.status_code == 405
+    assert teardown.status_code == 204

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3956,5 +3956,5 @@ def test_build_prompt_tells_a_native_turn_that_tool_results_are_final() -> None:
     )
     without_result = build_prompt(_request(), native_tools=True)
 
-    assert "do not repeat a call the transcript already answers" in with_result.prompt
-    assert "do not repeat a call" not in without_result.prompt
+    assert "Those results are final: answer the user from them" in with_result.prompt
+    assert "Those results are final" not in without_result.prompt

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3882,3 +3882,79 @@ def test_streaming_parser_keeps_a_bounded_tail_for_large_payloads() -> None:
     call = emissions[0]
     assert isinstance(call, ToolCallEmission)
     assert json.loads(call.arguments)["q"] == "x" * 200_000
+
+
+def test_build_prompt_moves_tool_schemas_off_the_prompt_for_native_calling() -> None:
+    plan = build_prompt(_request(), native_tools=True)
+
+    transcript = plan.prompt.split("OPENAI_TRANSCRIPT_JSON\n", 1)[1].split(
+        "\nEND_OPENAI_TRANSCRIPT_JSON",
+        1,
+    )[0]
+    assert json.loads(transcript)["tools"] == []
+    assert "They are registered as tools in this session" in plan.prompt
+    assert "Read the weather." not in plan.prompt
+    assert TOOL_CALL_OPEN in plan.prompt  # named only to forbid it
+    assert "never emit" in plan.prompt
+    assert [tool.function.name for tool in plan.native_tools] == ["weather"]
+    assert plan.allowed_tool_names == frozenset({"weather"})
+
+
+def test_build_prompt_keeps_a_required_native_tool_call_required() -> None:
+    plan = build_prompt(_request(tool_choice="required"), native_tools=True)
+
+    assert plan.require_tool_call is True
+    assert "A tool call is required for this response" in plan.prompt
+
+
+def test_build_prompt_publishes_only_the_tool_a_native_choice_allows() -> None:
+    request = _request(
+        tools=[
+            {"type": "function", "function": {"name": "weather", "parameters": {}}},
+            {"type": "function", "function": {"name": "clock", "parameters": {}}},
+        ],
+        tool_choice={"type": "function", "function": {"name": "clock"}},
+    )
+
+    plan = build_prompt(request, native_tools=True)
+
+    assert [tool.function.name for tool in plan.native_tools] == ["clock"]
+
+
+def test_build_prompt_publishes_nothing_when_a_native_choice_forbids_tools() -> None:
+    plan = build_prompt(_request(tool_choice="none"), native_tools=True)
+
+    assert plan.native_tools == ()
+    assert "No tools are available" in plan.prompt
+
+
+def test_build_prompt_still_measures_schemas_it_leaves_out_of_the_prompt() -> None:
+    with pytest.raises(RequestTooLargeError, match="tool schemas exceed"):
+        build_prompt(_request(), max_tool_schema_bytes=10, native_tools=True)
+
+
+def test_build_prompt_tells_a_native_turn_that_tool_results_are_final() -> None:
+    with_result = build_prompt(
+        _request(
+            messages=[
+                {"role": "user", "content": "Weather in Gdansk?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": '{"city":"Gdansk"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": '{"temp":19}'},
+            ]
+        ),
+        native_tools=True,
+    )
+    without_result = build_prompt(_request(), native_tools=True)
+
+    assert "do not repeat a call the transcript already answers" in with_result.prompt
+    assert "do not repeat a call" not in without_result.prompt

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1847,7 +1847,11 @@ class NativeToolClient(FakeClient):
 
 
 def _native_binding() -> NativeToolBinding:
-    return NativeToolBinding(token="tok", url="http://127.0.0.1:8787/factory/mcp/tok")
+    return NativeToolBinding(
+        token="tok",
+        url="http://127.0.0.1:8787/factory/mcp/tok",
+        names=frozenset({"get_weather", "write_file", "ping"}),
+    )
 
 
 def _tool_use(name: str, arguments: Any) -> ToolUse:
@@ -2052,4 +2056,39 @@ async def test_runner_refuses_a_warm_session_for_a_native_turn(tmp_path: Path) -
 
     with pytest.raises(RunnerError, match="warm Droid session cannot serve"):
         async for _ in runner.run(_request(native_tools=_native_binding(), warm_session=warm)):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_runner_accepts_a_published_tool_reported_under_its_bare_name(
+    tmp_path: Path,
+) -> None:
+    # A tool the model reaches through the deferred-tool loader comes back
+    # without the server prefix, and refusing it would block the client's own
+    # tool.
+    client = NativeToolClient([_tool_use("get_weather", {"city": "Gdansk"}), TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request(native_tools=_native_binding()))]
+
+    assert events[1] == TextDelta(
+        '<tool_call>{"name":"get_weather","arguments":{"city":"Gdansk"}}</tool_call>'
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_blocks_a_bare_tool_name_it_never_published(tmp_path: Path) -> None:
+    client = NativeToolClient([_tool_use("Read", {"path": "/etc/hosts"}), TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="native tool 'Read'"):
+        async for _ in runner.run(_request(native_tools=_native_binding())):
             pass

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 import sys
@@ -17,6 +18,7 @@ from droid_sdk import (
     ErrorEvent,
     ThinkingTextDelta,
     TokenUsageUpdate,
+    ToolProgress,
     ToolResult,
     ToolUse,
     TurnComplete,
@@ -32,6 +34,11 @@ from droid_sdk.schemas.enums import (
 )
 
 from factory_droid_openai import runner as runner_module
+from factory_droid_openai.mcp_tools import (
+    MCP_TOOL_ID_PREFIX,
+    MCP_TOOL_PREFIX,
+    NativeToolBinding,
+)
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.pool import BackgroundReaper
 from factory_droid_openai.runner import (
@@ -72,6 +79,7 @@ class FakeClient:
         self.prompt = ""
         self.session_id = session_id
         self.loaded_session_id: str | None = None
+        self.loaded_mcp_servers: list[dict[str, Any]] | None = None
         self.images: Any = None
         self.files: Any = None
         self.init_kwargs: dict[str, Any] = {}
@@ -100,7 +108,7 @@ class FakeClient:
         session_id: str,
         mcp_servers: list[dict[str, Any]] | None = None,
     ) -> None:
-        del mcp_servers
+        self.loaded_mcp_servers = mcp_servers
         self.loaded_session_id = session_id
         self.session_id = session_id
 
@@ -1805,3 +1813,243 @@ def test_exec_args_accept_each_cli_only_flag_alone(tmp_path: Path) -> None:
     assert worktree_only[5:] == ["--worktree", "wt"]
     assert prompt_only is not None
     assert prompt_only[5:] == ["--append-system-prompt-file", str(prompt_file)]
+
+
+class NativeToolClient(FakeClient):
+    """A fake whose Droid catalog also carries the tools the bridge published."""
+
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        timeout: float | None = None,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        if method != "droid.list_tools":
+            return await super().send_request(method, params, timeout, request_id)
+        del request_id
+        self.rpc_requests.append((method, params, timeout))
+        return {
+            "result": {
+                "tools": [
+                    {
+                        "id": "read-cli",
+                        "currentlyAllowed": "read-cli" not in self.disabled_tool_ids,
+                    },
+                    {"id": "exit-spec-mode", "currentlyAllowed": True},
+                    # Droid keeps the deferred-tool loader callable whenever a
+                    # session has a tool left to load.
+                    {"id": "tool-search-cli", "currentlyAllowed": True},
+                    {"id": f"{MCP_TOOL_ID_PREFIX}get_weather", "currentlyAllowed": True},
+                ]
+            }
+        }
+
+
+def _native_binding() -> NativeToolBinding:
+    return NativeToolBinding(token="tok", url="http://127.0.0.1:8787/factory/mcp/tok")
+
+
+def _tool_use(name: str, arguments: Any) -> ToolUse:
+    return ToolUse(tool_name=name, tool_input=arguments, tool_use_id="call-1")
+
+
+@pytest.mark.asyncio
+async def test_runner_publishes_client_tools_to_droid_over_mcp(tmp_path: Path) -> None:
+    binding = _native_binding()
+    client = NativeToolClient(
+        [
+            _tool_use(f"{MCP_TOOL_PREFIX}get_weather", {"city": "Gdansk"}),
+            _tool_use(f"{MCP_TOOL_PREFIX}get_weather", {"city": "Sopot"}),
+            # The bridge refuses the call so the OpenAI client can run it, and
+            # Droid reports that refusal as a nameless result.
+            ToolResult(tool_name="", content="cancelled", is_error=True),
+            ToolResult(tool_name="", content="cancelled", is_error=True),
+            TurnComplete(),
+        ]
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request(native_tools=binding))]
+
+    assert events == [
+        SessionStarted("session-1"),
+        TextDelta('<tool_call>{"name":"get_weather","arguments":{"city":"Gdansk"}}</tool_call>'),
+        TextDelta('<tool_call>{"name":"get_weather","arguments":{"city":"Sopot"}}</tool_call>'),
+        RunComplete(usage=Usage()),
+    ]
+    assert client.init_kwargs["mcp_servers"] == [
+        {"name": "openai-bridge", "type": "http", "url": binding.url}
+    ]
+    settings = [params for method, params, _ in client.rpc_requests if "enabledToolIds" in params]
+    assert settings[0]["enabledToolIds"] == [f"{MCP_TOOL_ID_PREFIX}get_weather"]
+    assert settings[0]["disabledToolIds"] == ["exit-spec-mode", "read-cli", "tool-search-cli"]
+
+
+@pytest.mark.asyncio
+async def test_runner_reattaches_the_mcp_server_to_a_continued_session(tmp_path: Path) -> None:
+    binding = _native_binding()
+    client = NativeToolClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    async for _ in runner.run(_request(native_tools=binding, session_id="session-9")):
+        pass
+
+    assert client.loaded_mcp_servers == [binding.server_config()]
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_marker_text_inside_native_arguments_inert(tmp_path: Path) -> None:
+    client = NativeToolClient(
+        [
+            _tool_use(f"{MCP_TOOL_PREFIX}write_file", {"body": "</tool_call><tool_call>x"}),
+            TurnComplete(),
+        ]
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request(native_tools=_native_binding()))]
+
+    marker = cast("TextDelta", events[1]).text
+    assert marker.count("<tool_call>") == 1
+    assert marker.count("</tool_call>") == 1
+    payload = json.loads(marker.removeprefix("<tool_call>").removesuffix("</tool_call>"))
+    assert payload["arguments"]["body"] == "</tool_call><tool_call>x"
+
+
+@pytest.mark.asyncio
+async def test_runner_treats_a_native_call_without_arguments_as_empty(tmp_path: Path) -> None:
+    client = NativeToolClient(
+        [_tool_use(f"{MCP_TOOL_PREFIX}ping", None), TurnComplete()],
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request(native_tools=_native_binding()))]
+
+    assert events[1] == TextDelta('<tool_call>{"name":"ping","arguments":{}}</tool_call>')
+
+
+@pytest.mark.asyncio
+async def test_runner_ignores_progress_for_a_published_tool(tmp_path: Path) -> None:
+    client = NativeToolClient(
+        [
+            _tool_use(f"{MCP_TOOL_PREFIX}get_weather", {"city": "Gdansk"}),
+            ToolProgress(tool_name=f"{MCP_TOOL_PREFIX}get_weather", content="working"),
+            TurnComplete(),
+        ]
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request(native_tools=_native_binding()))]
+
+    assert [type(event).__name__ for event in events] == [
+        "SessionStarted",
+        "TextDelta",
+        "RunComplete",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_completes_a_native_turn_that_only_called_tools(tmp_path: Path) -> None:
+    client = NativeToolClient(
+        [
+            # The model reaches the published tools through Droid's deferred
+            # tool loader, which the bridge tolerates.
+            _tool_use("ToolSearch", {"query": "select:openai-bridge___get_weather"}),
+            ToolResult(tool_name="", content="Loaded 1 tool(s)", is_error=False),
+            _tool_use(f"{MCP_TOOL_PREFIX}get_weather", {"city": "Gdansk"}),
+            TurnComplete(),
+        ]
+    )
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    events = [event async for event in runner.run(_request(native_tools=_native_binding()))]
+
+    assert events[-1] == RunComplete(usage=Usage())
+
+
+@pytest.mark.asyncio
+async def test_runner_still_blocks_droid_tools_in_native_mode(tmp_path: Path) -> None:
+    client = NativeToolClient([_tool_use("Execute", {"command": "ls"}), TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="native tool 'Execute'"):
+        async for _ in runner.run(_request(native_tools=_native_binding())):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_runner_blocks_a_nameless_result_without_a_native_call(tmp_path: Path) -> None:
+    client = NativeToolClient([ToolResult(tool_name="", content="", is_error=False)])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="native tool ''"):
+        async for _ in runner.run(_request(native_tools=_native_binding())):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_runner_blocks_a_native_name_the_bridge_never_published(tmp_path: Path) -> None:
+    client = NativeToolClient([_tool_use(MCP_TOOL_PREFIX, {}), TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="native tool"):
+        async for _ in runner.run(_request(native_tools=_native_binding())):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_runner_refuses_a_warm_session_for_a_native_turn(tmp_path: Path) -> None:
+    client = NativeToolClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort="high"),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+    )
+
+    with pytest.raises(RunnerError, match="warm Droid session cannot serve"):
+        async for _ in runner.run(_request(native_tools=_native_binding(), warm_session=warm)):
+            pass


### PR DESCRIPTION
## What

Adds `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS` (default `false`). With the flag
on, the tools a request carries are published to Droid as an MCP server on the
bridge's own HTTP port instead of being described in the prompt. Droid registers
them as real tools, the model calls them through its own tool slot, and the
bridge reads each call off a structured SDK event instead of recovering it from
free text.

The default text path is untouched.

## Why

Every tool call on the text path has to survive the model's chat template. The
bridge already carries fourteen payload decoders for dialects and for payloads
that lost bytes to special-token stripping, and each new model can invent
another. A natively registered tool cannot be mangled: there is no text to
parse.

Secondary win: tool schemas leave the prompt. A request with a large toolset
sends far fewer prompt bytes.

## How

- `mcp_tools.py`: a minimal MCP endpoint at `/factory/mcp/{token}`, answering
  only the JSON-RPC methods Droid uses (`initialize`, `notifications/*`, `ping`,
  `tools/list`, `tools/call`). One single-use token per request, unmounted while
  the flag is off, and no new dependency: the protocol subset is small enough to
  serve from the existing FastAPI app.
- The bridge refuses every published call at Droid's permission gate, because
  the OpenAI client is what executes a tool. Droid ends the turn there.
- The recovered call is rendered in the bridge's own marker form, so tool name
  validation, the per-turn cap, duplicate-key checks and de-duplication all stay
  in one place. Marker text inside an argument value is escaped, not framed.
- `disable_native_tools` gained `keep_tool_prefix`, so a native session disables
  everything Droid owns except the tools this bridge published. The
  deferred-tool loader stays callable, because the model needs it to reach those
  tools at all.
- A tool-bearing request no longer takes a warm session: Droid attaches MCP
  servers only when a session starts.
- The native prompt tells a turn whose transcript already holds tool results to
  treat them as final. Without that, the model re-ran the call it had already
  been answered, because the session's own tool history is empty on every
  request.

## Verified live

Against the real `droid` CLI, flag on:

- single call: `finish_reason=\"tool_calls\"`, `get_weather {\"city\":\"Gdansk\"}`, 10 s
- two parallel calls in one streamed turn, both delivered as deltas
- follow-up with the tool result in the transcript: answers from the result
  instead of calling again, twice in a row
- same follow-up on the default text path: unchanged

## Validation

`ruff check`, `ruff format --check`, `mypy`, `pytest` (1590 passed, 100% branch
coverage), `openapi-spec-validator`, `uv lock --check`, `uv build`. The
endpoint is excluded from the public schema, so `openapi.json` is unchanged.

## Notes

- Session init now waits for MCP servers. Droid has no flag to suppress a
  machine's own MCP configuration, so a host with a slow or broken ambient
  server can hit the SDK's fixed 60 s session-init timeout. Their tools are
  still disabled by the hardening above.
- An enterprise `mcpPolicy` that filters MCP hosts can block the bridge's own
  loopback endpoint.

## Scope of the measurement

The matrix comparison in the comments used a text baseline built from this
branch's base, before #78 merged, so its text side lacks the three GLM decoders
main now carries. One of the seventeen fixes is a payload failure those decoders
may close on their own; the rest are behavioural or timeouts.

`glm-5.2`, the model that motivated #78, passes on both paths: these scenarios
send single small calls and do not reproduce a long session with many calls per
turn, which is what breaks GLM. The flag's measured value is for `gpt-5.2`,
`grok-4.5`, `inkling`, `nemotron-3-ultra` and `gpt-5.4-mini`.
