### PR TITLE
fix(runner): classify transient connection errors

### DIFF
--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -72,6 +72,8 @@ _MODEL_DENIED_PATTERN = re.compile(
     r"|invalid model id)",
     re.IGNORECASE,
 )
+# Droid emits this generic message for a transient upstream connection blip.
+_TRANSIENT_CONNECTION_PATTERN = re.compile(r"connection error\.?", re.IGNORECASE)
 # Droid keeps two of its own meta tools callable whatever a session disables:
 # exit-spec-mode, and the loader that would fetch a deferred tool. Neither
 # touches the machine, and Droid refuses to run them in a session with every
@@ -987,6 +989,12 @@ def _error_event_failure(event: ErrorEvent, *, model: str | None) -> RunnerError
     denied = _model_denied_error(message, model=model)
     if denied is not None:
         return denied
+    if _TRANSIENT_CONNECTION_PATTERN.fullmatch(message.strip()):
+        return RunnerError(
+            message,
+            status_code=503,
+            error_type="factory_droid_unavailable",
+        )
     # The SDK labels error events with its own class names, such as "Error".
     # Forwarding those as OpenAI error types would put undocumented values in
     # the public contract, so the detail stays in the message instead.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -394,6 +394,38 @@ async def test_runner_maps_sdk_error_event(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_runner_maps_transient_connection_error_event(tmp_path: Path) -> None:
+    client = FakeClient([ErrorEvent("Connection error.", "Error")])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="Connection error") as error:
+        _ = [event async for event in runner.run(_request())]
+
+    assert error.value.status_code == 503
+    assert error.value.error_type == "factory_droid_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_detailed_connection_error_as_bridge_error(tmp_path: Path) -> None:
+    client = FakeClient([ErrorEvent("Connection error while parsing response.", "Error")])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="Connection error while parsing") as error:
+        _ = [event async for event in runner.run(_request())]
+
+    assert error.value.status_code == 502
+    assert error.value.error_type == "factory_droid_error"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "message",
     [


### PR DESCRIPTION
## Summary

- map the exact Droid `Connection error.` event to `503/factory_droid_unavailable`
- keep detailed connection messages and generic SDK failures as bridge errors

## Validation

- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- 1676 passed
- 100% branch coverage
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`

Stacked on #90. Closes #82