### PR TITLE
test(app): wait for warm pool readiness

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4218,7 +4218,12 @@ async def test_lifespan_prewarms_and_drains_the_pool(tmp_path: Path) -> None:
     app = create_app(settings, runner_factory=cast("RunnerFactory", lambda: runner))
 
     async with app.router.lifespan_context(app):
-        await asyncio.sleep(0.05)
+        async with asyncio.timeout(5.0):
+            while (
+                len(runner.warmed) < 2
+                or "factory_droid_openai_warm_sessions 2" not in app.state.metrics.render()
+            ):
+                await asyncio.sleep(0)
         # One session per concurrency slot plus a spare for the refill window.
         assert runner.warmed == [SessionKey(model_id=None, reasoning_effort=None)] * 2
         assert "factory_droid_openai_warm_sessions 2" in app.state.metrics.render()


### PR DESCRIPTION
## Summary

- replace the fixed 50 ms lifespan sleep with readiness polling
- bound the wait with a 5 second timeout
- preserve warm-session and drain assertions

## Validation

- readiness test repeated 20 times: 20 passed
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- 1676 passed
- 100% branch coverage
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- OpenAPI generation and validation: passed
- `uv lock --check`: passed
- `uv build`: passed

Stacked on #91. Closes #83