### PR TITLE
feat(pool): reuse warm sessions for native tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,17 +325,32 @@ What changes with the flag on:
   in the prompt, because each request runs in a fresh Droid session.
 - No dialect has to be recognized, because no tool call is written as text.
   The dialect table above still applies to the default path.
-- A tool-bearing request no longer uses a warm session, because Droid attaches
-  MCP servers only when a session starts. Requests without tools still do.
+- A tool-bearing request reuses a warm session only when that session was
+  started for the same tool catalog, because Droid attaches MCP servers when a
+  session starts and the published catalog cannot change afterwards. The pool
+  therefore keys native sessions by the catalog itself; the first request for a
+  new catalog pays full session startup, and repeat requests with the same tools
+  hit the pool like any text request. Native and text demands draw on separate
+  halves of the pool, so rotating catalogs cannot starve the text keys.
 - Droid's own tools stay disabled, apart from the deferred-tool loader the
   model needs to reach the published tools at all.
 - The bridge refuses every published call at Droid's permission gate. The
   OpenAI client runs the tool and resubmits the result, as it always has.
 
-The endpoint lives at `/factory/mcp/{token}` with a single-use token per
-request, and it is mounted only while the flag is on. Droid reaches it at
-`http://127.0.0.1:<port>`; set `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL`
-when the bridge answers on a different address than it binds.
+The endpoint lives at `/factory/mcp/{token}` and is mounted only while the flag
+is on. Droid reaches it at `http://127.0.0.1:<port>`; set
+`FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL` when the bridge answers on a
+different address than it binds.
+
+The token in the path is the endpoint's only credential, because the API-key
+dependency would have to be handed to Droid to be useful. What that buys an
+attacker who already reaches the bind address is the tool schemas of one
+catalog: the endpoint serves `tools/list`, holds no conversation state, refuses
+every `tools/call`, and never receives a tool result, since the OpenAI client
+executes the tools. What it costs is a longer-lived secret than the default
+path has, because a warm session keeps its token for its whole warm life
+instead of one request. Bind the bridge to loopback, or to an address only
+trusted callers reach, whenever the flag is on.
 
 Enterprise-managed `mcpPolicy` settings must allow the MCP server hostname.
 For the default endpoint, the managed settings need an entry equivalent to:
@@ -350,18 +365,26 @@ For the default endpoint, the managed settings need an entry equivalent to:
 ```
 
 If `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL` is set, allow its hostname
-instead. The bridge checks that `openai-bridge` connects and that its exact
-request tool catalog is available before sending the prompt. A policy
-rejection fails closed as `factory_native_tool_unavailable` with HTTP `503`.
+instead. Before sending a prompt, the bridge checks that `openai-bridge`
+connected and that the session publishes exactly this request's tool catalog;
+a pooled session is checked the same way when it is warmed. A policy rejection
+fails closed as `factory_native_tool_unavailable` with HTTP `503`, and so does
+a catalog the bridge cannot publish at all. A policy change while a session sits
+warm is caught by the next request that has to warm one.
 Confirm the final managed-settings shape with your Factory administrator.
+
+`FACTORY_DROID_OPENAI_MAX_TRACKED_SESSIONS` also bounds how many tool catalogs
+the endpoint holds, so with the flag on it must be at least the warm session
+count plus `FACTORY_DROID_OPENAI_MAX_CONCURRENCY`; the bridge refuses to start
+otherwise.
 
 Whether the flag is worth it depends on the model. It pays off for a model that
 misses tool contracts on the text path: one that ignores `tool_choice=required`,
 answers in prose instead of calling a tool, or writes a call the parser has to
-guess at. A model that already satisfies those contracts gains nothing and pays
-about two seconds more per tool turn, since a tool-bearing request cannot reuse
-a warm session. `CONTRIBUTING.md` describes how to measure both paths against
-the models you actually use.
+guess at. A model that already satisfies those contracts gains nothing, and pays
+full session startup on every request whose toolset the pool has not warmed yet.
+`CONTRIBUTING.md` describes how to measure both paths against the models you
+actually use.
 
 Two caveats survive. A model may still call a tool again after the transcript
 already carries the result, because its session-side tool history is empty on

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -28,6 +28,7 @@ from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import info as log_info
 from factory_droid_openai.logs import warning as log_warning
 from factory_droid_openai.mcp_tools import (
+    NativeCatalogUnavailableError,
     NativeToolBinding,
     NativeToolRegistry,
     build_router,
@@ -840,8 +841,10 @@ def create_app(
     application.state.native_tools = native_tools
     if resolved_settings.native_tool_calls:
         # The token in each path is the credential, so the endpoint carries no
-        # API-key dependency: only the Droid process this bridge started is
-        # ever told the URL.
+        # API-key dependency: it is told to a Droid process this bridge
+        # started, and holding it only reveals that request's tool schemas. A
+        # warm session keeps its token for its whole warm life, so anything
+        # that can reach the bind address should be treated as trusted.
         application.include_router(build_router(native_tools))
 
     async def require_auth(credentials: BearerCredentials) -> None:
@@ -1413,10 +1416,12 @@ def create_app(
                 if warm_session is not None:
                     native_binding = warm_session.native_binding
                     if native_binding is None:
-                        raise RuntimeError("native warm session has no catalog binding")
+                        raise NativeCatalogUnavailableError(
+                            "warm Droid session published no tool catalog"
+                        )
                 else:
                     native_binding = native_tools.open_catalog(native_catalog)
-            except BaseException:
+            except BaseException as exc:
                 discard_unused_warm_session()
                 try:
                     await lease.release()
@@ -1426,7 +1431,18 @@ def create_app(
                             session_use.release()
                     finally:
                         release_native_tools()
-                raise
+                if not isinstance(exc, NativeCatalogUnavailableError):
+                    raise
+                # Native tool calls are the only channel this request has, so
+                # an unpublishable catalog fails closed instead of silently
+                # answering with no tools at all.
+                request.state.telemetry_error_type = "factory_native_tool_unavailable"
+                log_warning("chat.rejected", status=503, phase="native_tools")
+                return _error_response(
+                    f"Factory Droid native tool catalog is unavailable: {exc}",
+                    503,
+                    "factory_native_tool_unavailable",
+                )
             run_request = replace(run_request, native_tools=native_binding)
             log_debug(
                 "chat.native_tools_published",

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1400,6 +1400,14 @@ def create_app(
                 metrics.record_features(("warm_session",))
                 run_request = replace(run_request, warm_session=warm_session)
 
+        def release_native_tools() -> None:
+            if native_binding is not None:
+                native_tools.close(native_binding.token)
+
+        def discard_unused_warm_session() -> None:
+            if warm_session is not None and not warm_session.consumed:
+                reaper.submit(resolved_runner_factory().discard(warm_session))
+
         if native_catalog is not None:
             try:
                 if warm_session is not None:
@@ -1409,11 +1417,15 @@ def create_app(
                 else:
                     native_binding = native_tools.open_catalog(native_catalog)
             except BaseException:
+                discard_unused_warm_session()
                 try:
                     await lease.release()
                 finally:
-                    if session_use is not None:
-                        session_use.release()
+                    try:
+                        if session_use is not None:
+                            session_use.release()
+                    finally:
+                        release_native_tools()
                 raise
             run_request = replace(run_request, native_tools=native_binding)
             log_debug(
@@ -1421,10 +1433,6 @@ def create_app(
                 tools=len(plan.native_tools or ()),
                 open_catalogs=len(native_tools),
             )
-
-        def release_native_tools() -> None:
-            if native_binding is not None:
-                native_tools.close(native_binding.token)
 
         def record_repair(
             event: str,
@@ -1567,10 +1575,13 @@ def create_app(
             return _error_response(str(exc), exc.status_code, exc.error_type)
         finally:
             try:
-                if session_use is not None:
-                    session_use.release()
+                discard_unused_warm_session()
             finally:
-                release_native_tools()
+                try:
+                    if session_use is not None:
+                        session_use.release()
+                finally:
+                    release_native_tools()
 
         log_info(
             "chat.completed",

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -743,6 +743,10 @@ def create_app(
         max_queue_size=resolved_settings.max_queue_size,
         metrics=metrics,
     )
+    native_tools = NativeToolRegistry(
+        base_url=resolved_settings.native_tool_call_base_url(),
+        max_sessions=resolved_settings.max_tracked_sessions,
+    )
     pool = WarmSessionPool(
         runner_factory=resolved_runner_factory,
         reaper=reaper,
@@ -750,16 +754,13 @@ def create_app(
         warm_timeout_seconds=min(resolved_settings.timeout_seconds, _WARM_TIMEOUT_CEILING),
         ttl_seconds=resolved_settings.warm_session_ttl_seconds,
         metrics=metrics,
+        native_registry=native_tools,
     )
     telemetry = TelemetryReporter(
         metrics=metrics,
         app_version=_BRIDGE_VERSION,
         endpoint=DEFAULT_TELEMETRY_ENDPOINT,
         enabled=resolved_settings.telemetry,
-    )
-    native_tools = NativeToolRegistry(
-        base_url=resolved_settings.native_tool_call_base_url(),
-        max_sessions=resolved_settings.max_tracked_sessions,
     )
 
     @contextlib.asynccontextmanager
@@ -1387,27 +1388,43 @@ def create_app(
             raise
 
         native_binding: NativeToolBinding | None = None
+        native_catalog = None
         if plan.native_tools:
-            native_binding = native_tools.open(to_mcp_tools(plan.native_tools))
+            native_catalog = native_tools.catalog_identity(to_mcp_tools(plan.native_tools))
             metrics.record_features(("native_tool_calls",))
+
+        warm_session: WarmSession | None = None
+        if session_id is None:
+            warm_session = pool.acquire(requested_key, native_catalog)
+            if warm_session is not None:
+                metrics.record_features(("warm_session",))
+                run_request = replace(run_request, warm_session=warm_session)
+
+        if native_catalog is not None:
+            try:
+                if warm_session is not None:
+                    native_binding = warm_session.native_binding
+                    if native_binding is None:
+                        raise RuntimeError("native warm session has no catalog binding")
+                else:
+                    native_binding = native_tools.open_catalog(native_catalog)
+            except BaseException:
+                try:
+                    await lease.release()
+                finally:
+                    if session_use is not None:
+                        session_use.release()
+                raise
             run_request = replace(run_request, native_tools=native_binding)
             log_debug(
                 "chat.native_tools_published",
-                tools=len(plan.native_tools),
+                tools=len(plan.native_tools or ()),
                 open_catalogs=len(native_tools),
             )
 
         def release_native_tools() -> None:
             if native_binding is not None:
                 native_tools.close(native_binding.token)
-
-        # Droid attaches MCP servers when a session starts, so a session warmed
-        # without this request's tools cannot serve the turn.
-        if session_id is None and native_binding is None:
-            warm_session = pool.acquire(requested_key)
-            if warm_session is not None:
-                metrics.record_features(("warm_session",))
-                run_request = replace(run_request, warm_session=warm_session)
 
         def record_repair(
             event: str,

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -104,6 +104,12 @@ class Settings:
                 "session_init_timeout_seconds must be at most "
                 f"{MAX_SESSION_INIT_TIMEOUT_SECONDS:g} seconds"
             )
+        warm_count = self.warm_session_count()
+        if self.native_tool_calls and warm_count > 0 and self.max_tracked_sessions <= warm_count:
+            raise ValueError(
+                "max_tracked_sessions must be greater than warm sessions "
+                "when native_tool_calls is enabled"
+            )
         # The warm pool keys sessions by this value, so it has to match the
         # normalized effort the request path sends to Droid, and a bad value
         # has to fail at construction instead of on every request.

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -104,11 +104,15 @@ class Settings:
                 "session_init_timeout_seconds must be at most "
                 f"{MAX_SESSION_INIT_TIMEOUT_SECONDS:g} seconds"
             )
-        warm_count = self.warm_session_count()
-        if self.native_tool_calls and warm_count > 0 and self.max_tracked_sessions <= warm_count:
+        # Every warm session pins one catalog for its whole warm life, and every
+        # admitted request publishes one of its own, so the registry has to hold
+        # both at once. Sizing it any smaller makes the registry evict the
+        # catalog of a request that is still running.
+        required_sessions = self.warm_session_count() + self.max_concurrency
+        if self.native_tool_calls and self.max_tracked_sessions < required_sessions:
             raise ValueError(
-                "max_tracked_sessions must be greater than warm sessions "
-                "when native_tool_calls is enabled"
+                "max_tracked_sessions must be at least warm sessions plus max_concurrency "
+                f"({required_sessions}) when native_tool_calls is enabled"
             )
         # The warm pool keys sessions by this value, so it has to match the
         # normalized effort the request path sends to Droid, and a bad value

--- a/src/factory_droid_openai/mcp_tools.py
+++ b/src/factory_droid_openai/mcp_tools.py
@@ -7,20 +7,20 @@ Droid as an MCP server, so Droid renders them through the model's own tool slot
 and reports each call as a structured event. Nothing has to be parsed out of
 free text.
 
-The endpoint holds no conversation state. A single-use token in the URL binds
-one MCP server to one chat completion, and the tool catalog is all the endpoint
+The endpoint holds no conversation state. An unguessable token in the URL binds
+one MCP server to one Droid session, and the tool catalog is all the endpoint
 serves: the OpenAI client, never the bridge, executes the tools, so a call is
 answered with a refusal and the bridge reads the call itself off the session's
-events instead.
+events instead. A pooled warm session keeps its token for as long as it is
+warm, so the token outlives the request that created it.
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import secrets
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import APIRouter, Request, Response
@@ -52,20 +52,29 @@ _METHOD_NOT_FOUND: Final = -32601
 _INVALID_REQUEST: Final = -32600
 
 
+class NativeCatalogUnavailableError(RuntimeError):
+    """A request's tool catalog cannot be published to Droid."""
+
+
 @dataclass(frozen=True, slots=True)
 class NativeToolCatalog:
-    """Immutable identity and payload for one ordered MCP catalog."""
+    """Immutable identity and payload for one ordered MCP catalog.
+
+    ``serialized`` keeps the tools exactly as the client sent them, key order
+    included, because it is both what the model is shown and what decides
+    whether a warm session already publishes this catalog. Sorting keys here
+    would reorder the JSON Schema the model reads.
+    """
 
     serialized: str
-    fingerprint: str
-    names: frozenset[str]
+    names: frozenset[str] = field(compare=False)
 
     @property
     def tools(self) -> tuple[dict[str, Any], ...]:
         """Return a fresh catalog copy for an SDK or HTTP response."""
         decoded = json.loads(self.serialized)
         if not isinstance(decoded, list) or not all(isinstance(item, dict) for item in decoded):
-            raise RuntimeError("native tool catalog serialization is malformed")
+            raise NativeCatalogUnavailableError("native tool catalog serialization is malformed")
         return tuple(decoded)
 
 
@@ -76,7 +85,9 @@ class NativeToolBinding:
     token: str
     url: str
     names: frozenset[str]
-    catalog: NativeToolCatalog | None = None
+    # Required, so that "no catalog" can never read as "matches any catalog"
+    # when a warm session is offered to a request.
+    catalog: NativeToolCatalog
 
     def server_config(self) -> dict[str, Any]:
         """Render the MCP server entry Droid's session initializer expects."""
@@ -99,7 +110,13 @@ class NativeToolBinding:
 
 
 class NativeToolRegistry:
-    """Tool catalogs of in-flight requests, keyed by single-use token."""
+    """Tool catalogs Droid may fetch, keyed by an unguessable token.
+
+    A token lives as long as the session that was told about it. For a
+    per-request session that is the request; for a pooled warm session it is
+    the whole warm lifetime, so a token is not single-use. Pinned tokens
+    belong to warm sessions and are never evicted.
+    """
 
     def __init__(self, *, base_url: str, max_sessions: int = 256) -> None:
         self._base_url = base_url.rstrip("/")
@@ -120,7 +137,7 @@ class NativeToolRegistry:
         token = secrets.token_urlsafe(24)
         self._evict_unpinned()
         if len(self._catalogs) >= self._max_sessions:
-            raise RuntimeError("native tool catalog capacity is exhausted")
+            raise NativeCatalogUnavailableError("native tool catalog capacity is exhausted")
         self._catalogs[token] = catalog
         return NativeToolBinding(
             token=token,
@@ -137,9 +154,6 @@ class NativeToolRegistry:
         if token in self._catalogs:
             self._pinned.add(token)
 
-    def unpin(self, token: str) -> None:
-        self._pinned.discard(token)
-
     def catalog(self, token: str) -> tuple[dict[str, Any], ...] | None:
         catalog = self._catalogs.get(token)
         return None if catalog is None else catalog.tools
@@ -148,6 +162,13 @@ class NativeToolRegistry:
         return len(self._catalogs)
 
     def _evict_unpinned(self) -> None:
+        """Reclaim the oldest unpinned tokens to make room for a new one.
+
+        An unpinned token belongs to a request that is still running, so this
+        is a leak guard, not a capacity plan: ``validate_config`` sizes the
+        registry to hold every warm session plus every admitted request at
+        once, which leaves nothing to reclaim unless a token was orphaned.
+        """
         while len(self._catalogs) >= self._max_sessions:
             token = next((token for token in self._catalogs if token not in self._pinned), None)
             if token is None:
@@ -160,18 +181,13 @@ def _catalog(tools: Sequence[Mapping[str, Any]]) -> NativeToolCatalog:
         [dict(tool) for tool in tools],
         ensure_ascii=False,
         allow_nan=False,
-        sort_keys=True,
         separators=(",", ":"),
     )
     decoded = json.loads(serialized)
     if not isinstance(decoded, list) or not all(isinstance(item, dict) for item in decoded):
-        raise RuntimeError("native tool catalog serialization is malformed")
+        raise NativeCatalogUnavailableError("native tool catalog serialization is malformed")
     names = frozenset(str(tool["name"]) for tool in decoded)
-    return NativeToolCatalog(
-        serialized=serialized,
-        fingerprint=hashlib.sha256(serialized.encode("utf-8")).hexdigest(),
-        names=names,
-    )
+    return NativeToolCatalog(serialized=serialized, names=names)
 
 
 def to_mcp_tools(tools: Iterable[Any]) -> tuple[dict[str, Any], ...]:

--- a/src/factory_droid_openai/mcp_tools.py
+++ b/src/factory_droid_openai/mcp_tools.py
@@ -16,7 +16,10 @@ events instead.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import secrets
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
@@ -50,12 +53,30 @@ _INVALID_REQUEST: Final = -32600
 
 
 @dataclass(frozen=True, slots=True)
+class NativeToolCatalog:
+    """Immutable identity and payload for one ordered MCP catalog."""
+
+    serialized: str
+    fingerprint: str
+    names: frozenset[str]
+
+    @property
+    def tools(self) -> tuple[dict[str, Any], ...]:
+        """Return a fresh catalog copy for an SDK or HTTP response."""
+        decoded = json.loads(self.serialized)
+        if not isinstance(decoded, list) or not all(isinstance(item, dict) for item in decoded):
+            raise RuntimeError("native tool catalog serialization is malformed")
+        return tuple(decoded)
+
+
+@dataclass(frozen=True, slots=True)
 class NativeToolBinding:
     """What one request needs to reach its own MCP endpoint."""
 
     token: str
     url: str
     names: frozenset[str]
+    catalog: NativeToolCatalog | None = None
 
     def server_config(self) -> dict[str, Any]:
         """Render the MCP server entry Droid's session initializer expects."""
@@ -83,32 +104,74 @@ class NativeToolRegistry:
     def __init__(self, *, base_url: str, max_sessions: int = 256) -> None:
         self._base_url = base_url.rstrip("/")
         self._max_sessions = max_sessions
-        self._catalogs: dict[str, tuple[dict[str, Any], ...]] = {}
+        self._catalogs: OrderedDict[str, NativeToolCatalog] = OrderedDict()
+        self._pinned: set[str] = set()
 
     def open(self, tools: Sequence[Mapping[str, Any]]) -> NativeToolBinding:
         """Publish ``tools`` under a fresh token and return how to reach them."""
+        return self.open_catalog(self.catalog_identity(tools))
+
+    def catalog_identity(self, tools: Sequence[Mapping[str, Any]]) -> NativeToolCatalog:
+        """Canonicalize a request catalog without allocating a credential."""
+        return _catalog(tools)
+
+    def open_catalog(self, catalog: NativeToolCatalog) -> NativeToolBinding:
+        """Publish an existing catalog under a fresh token."""
         token = secrets.token_urlsafe(24)
-        while len(self._catalogs) >= self._max_sessions:
-            # A request that never closed its catalog must not pin memory for
-            # the life of the process. The oldest entry belongs to the oldest
-            # request, whose turn is over by the time the cap is reached.
-            self._catalogs.pop(next(iter(self._catalogs)))
-        catalog = tuple(dict(tool) for tool in tools)
+        self._evict_unpinned()
+        if len(self._catalogs) >= self._max_sessions:
+            raise RuntimeError("native tool catalog capacity is exhausted")
         self._catalogs[token] = catalog
         return NativeToolBinding(
             token=token,
             url=f"{self._base_url}{MCP_ROUTE_PREFIX}/{token}",
-            names=frozenset(str(tool["name"]) for tool in catalog),
+            names=catalog.names,
+            catalog=catalog,
         )
 
     def close(self, token: str) -> None:
         self._catalogs.pop(token, None)
+        self._pinned.discard(token)
+
+    def pin(self, token: str) -> None:
+        if token in self._catalogs:
+            self._pinned.add(token)
+
+    def unpin(self, token: str) -> None:
+        self._pinned.discard(token)
 
     def catalog(self, token: str) -> tuple[dict[str, Any], ...] | None:
-        return self._catalogs.get(token)
+        catalog = self._catalogs.get(token)
+        return None if catalog is None else catalog.tools
 
     def __len__(self) -> int:
         return len(self._catalogs)
+
+    def _evict_unpinned(self) -> None:
+        while len(self._catalogs) >= self._max_sessions:
+            token = next((token for token in self._catalogs if token not in self._pinned), None)
+            if token is None:
+                return
+            self._catalogs.pop(token)
+
+
+def _catalog(tools: Sequence[Mapping[str, Any]]) -> NativeToolCatalog:
+    serialized = json.dumps(
+        [dict(tool) for tool in tools],
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    decoded = json.loads(serialized)
+    if not isinstance(decoded, list) or not all(isinstance(item, dict) for item in decoded):
+        raise RuntimeError("native tool catalog serialization is malformed")
+    names = frozenset(str(tool["name"]) for tool in decoded)
+    return NativeToolCatalog(
+        serialized=serialized,
+        fingerprint=hashlib.sha256(serialized.encode("utf-8")).hexdigest(),
+        names=names,
+    )
 
 
 def to_mcp_tools(tools: Iterable[Any]) -> tuple[dict[str, Any], ...]:

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextlib
 from collections import defaultdict, deque
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -89,6 +89,14 @@ class _WarmDemand:
     catalog: NativeToolCatalog | None = None
 
 
+def _share(demands: Sequence[_WarmDemand], size: int) -> dict[_WarmDemand, int]:
+    """Hand ``size`` sessions to ``demands``, most recent first."""
+    if not demands:
+        return {}
+    base, extra = divmod(size, len(demands))
+    return {demand: base + (1 if index < extra else 0) for index, demand in enumerate(demands)}
+
+
 class WarmSessionPool:
     """Keeps initialized Droid sessions ready so requests skip session startup.
 
@@ -126,7 +134,6 @@ class WarmSessionPool:
         self._native_sessions: dict[_WarmDemand, deque[WarmSession]] = defaultdict(deque)
         self._wanted: list[SessionKey] = []
         self._native_wanted: list[_WarmDemand] = []
-        self._demand_order: list[_WarmDemand] = []
         self._wake = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
@@ -158,34 +165,25 @@ class WarmSessionPool:
         self._native_sessions.clear()
         self._wanted.clear()
         self._native_wanted.clear()
-        self._demand_order.clear()
         self._publish()
         for session in sessions:
             self._reaper.submit(self._discard_session(session))
 
     def note(self, key: SessionKey, catalog: NativeToolCatalog | None = None) -> None:
         demand = _WarmDemand(key, catalog)
-        if demand in self._demand_order:
-            self._demand_order.remove(demand)
-        self._demand_order.insert(0, demand)
         if catalog is None:
             if key in self._wanted:
                 self._wanted.remove(key)
             self._wanted.insert(0, key)
-            stale_keys = self._wanted[self._max_keys :]
-            for stale_key in stale_keys:
-                stale_demand = _WarmDemand(stale_key)
-                self._drop_demand(stale_demand)
-                self._demand_order.remove(stale_demand)
+            for stale_key in self._wanted[self._max_keys :]:
+                self._drop_demand(_WarmDemand(stale_key))
             del self._wanted[self._max_keys :]
         else:
             if demand in self._native_wanted:
                 self._native_wanted.remove(demand)
             self._native_wanted.insert(0, demand)
-            stale_demands = self._native_wanted[self._max_keys :]
-            for stale_demand in stale_demands:
+            for stale_demand in self._native_wanted[self._max_keys :]:
                 self._drop_demand(stale_demand)
-                self._demand_order.remove(stale_demand)
             del self._native_wanted[self._max_keys :]
         self._wake.set()
 
@@ -335,19 +333,22 @@ class WarmSessionPool:
                 self._wanted.remove(demand.key)
         elif demand in self._native_wanted:
             self._native_wanted.remove(demand)
-        if demand in self._demand_order:
-            self._demand_order.remove(demand)
         self._drop_demand(demand)
 
     def _targets(self) -> dict[_WarmDemand, int]:
-        """Split the pool size across the keys traffic is currently using."""
-        if not self._demand_order:
-            return {}
-        base, extra = divmod(self._size, len(self._demand_order))
-        return {
-            demand: base + (1 if index < extra else 0)
-            for index, demand in enumerate(self._demand_order)
-        }
+        """Split the pool size across the demands traffic is currently using.
+
+        Text and native demands draw on separate halves of the pool. Sharing
+        one budget let a client that rotates tool catalogs multiply the demand
+        count until the plain text keys landed on a target of zero, and the
+        next rebalance then discarded a live session the same traffic needed.
+        """
+        text = [_WarmDemand(key) for key in self._wanted]
+        native = list(self._native_wanted)
+        if not text or not native:
+            return _share(text or native, self._size)
+        native_size = self._size // 2
+        return _share(text, self._size - native_size) | _share(native, native_size)
 
     def _deficits(self) -> list[_WarmDemand]:
         deficits: list[_WarmDemand] = []

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -2,10 +2,16 @@ import asyncio
 import contextlib
 from collections import defaultdict, deque
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import warning as log_warning
+from factory_droid_openai.mcp_tools import (
+    NativeToolBinding,
+    NativeToolCatalog,
+    NativeToolRegistry,
+)
 from factory_droid_openai.metrics import WARM_RETUNE_EFFORT
 from factory_droid_openai.runner import DroidRunner, SessionKey, WarmSession
 
@@ -77,6 +83,12 @@ class BackgroundReaper:
             self._metrics.set_pending_reaps(len(self._tasks))
 
 
+@dataclass(frozen=True, slots=True)
+class _WarmDemand:
+    key: SessionKey
+    catalog: NativeToolCatalog | None = None
+
+
 class WarmSessionPool:
     """Keeps initialized Droid sessions ready so requests skip session startup.
 
@@ -99,6 +111,7 @@ class WarmSessionPool:
         max_keys: int = 2,
         retry_seconds: float = 5.0,
         metrics: PoolMetrics | None = None,
+        native_registry: NativeToolRegistry | None = None,
     ) -> None:
         self._runner_factory = runner_factory
         self._reaper = reaper
@@ -108,8 +121,12 @@ class WarmSessionPool:
         self._max_keys = max(1, max_keys)
         self._retry_seconds = retry_seconds
         self._metrics = metrics
-        self._sessions: dict[SessionKey, deque[WarmSession]] = defaultdict(deque)
+        self._native_registry = native_registry
+        self._sessions: dict[_WarmDemand, deque[WarmSession]] = defaultdict(deque)
+        self._native_sessions: dict[_WarmDemand, deque[WarmSession]] = defaultdict(deque)
         self._wanted: list[SessionKey] = []
+        self._native_wanted: list[_WarmDemand] = []
+        self._demand_order: list[_WarmDemand] = []
         self._wake = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
@@ -131,43 +148,79 @@ class WarmSessionPool:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
-        sessions = [session for queue in self._sessions.values() for session in queue]
+        sessions = [
+            session
+            for queues in (self._sessions, self._native_sessions)
+            for queue in queues.values()
+            for session in queue
+        ]
         self._sessions.clear()
+        self._native_sessions.clear()
+        self._wanted.clear()
+        self._native_wanted.clear()
+        self._demand_order.clear()
         self._publish()
         for session in sessions:
-            self._reaper.submit(self._runner_factory().discard(session))
+            self._reaper.submit(self._discard_session(session))
 
-    def note(self, key: SessionKey) -> None:
-        if key in self._wanted:
-            self._wanted.remove(key)
-        self._wanted.insert(0, key)
-        for stale in self._wanted[self._max_keys :]:
-            self._drop(stale)
-        del self._wanted[self._max_keys :]
+    def note(self, key: SessionKey, catalog: NativeToolCatalog | None = None) -> None:
+        demand = _WarmDemand(key, catalog)
+        if demand in self._demand_order:
+            self._demand_order.remove(demand)
+        self._demand_order.insert(0, demand)
+        if catalog is None:
+            if key in self._wanted:
+                self._wanted.remove(key)
+            self._wanted.insert(0, key)
+            stale_keys = self._wanted[self._max_keys :]
+            for stale_key in stale_keys:
+                stale_demand = _WarmDemand(stale_key)
+                self._drop_demand(stale_demand)
+                self._demand_order.remove(stale_demand)
+            del self._wanted[self._max_keys :]
+        else:
+            if demand in self._native_wanted:
+                self._native_wanted.remove(demand)
+            self._native_wanted.insert(0, demand)
+            stale_demands = self._native_wanted[self._max_keys :]
+            for stale_demand in stale_demands:
+                self._drop_demand(stale_demand)
+                self._demand_order.remove(stale_demand)
+            del self._native_wanted[self._max_keys :]
         self._wake.set()
 
     def offer(self, session: WarmSession) -> None:
         """Register an already warmed session, or discard it when unwanted."""
-        if len(self._sessions.get(session.key, ())) >= self._targets().get(session.key, 0):
+        demand = _WarmDemand(
+            session.key,
+            session.native_binding.catalog if session.native_binding is not None else None,
+        )
+        queues = self._native_sessions if demand.catalog is not None else self._sessions
+        if len(queues.get(demand, ())) >= self._targets().get(demand, 0):
             self._discard(session)
             return
-        self._sessions[session.key].append(session)
+        queues[demand].append(session)
         self._publish()
         log_debug("pool.warmed", model=session.key.model_id, warm_sessions=self._total())
 
-    def acquire(self, key: SessionKey) -> WarmSession | None:
+    def acquire(
+        self,
+        key: SessionKey,
+        catalog: NativeToolCatalog | None = None,
+    ) -> WarmSession | None:
         """Take a ready session for ``key``, or ``None`` when none is warm yet."""
         if not self.enabled:
             return None
-        self.note(key)
-        session = self._take(key)
+        demand = _WarmDemand(key, catalog)
+        self.note(key, catalog)
+        session = self._take_demand(demand)
         if session is not None:
             self._publish()
             if self._metrics is not None:
                 self._metrics.increment_warm_hits()
             log_debug("pool.hit", model=key.model_id, warm_sessions=self._total())
             return session
-        session = self._take_retunable(key)
+        session = self._take_retunable(demand)
         if session is not None:
             self._publish()
             if self._metrics is not None:
@@ -187,8 +240,9 @@ class WarmSessionPool:
         log_debug("pool.miss", model=key.model_id, warm_sessions=self._total())
         return None
 
-    def _take(self, key: SessionKey) -> WarmSession | None:
-        queue = self._sessions.get(key)
+    def _take_demand(self, demand: _WarmDemand) -> WarmSession | None:
+        queues = self._native_sessions if demand.catalog is not None else self._sessions
+        queue = queues.get(demand)
         while queue:
             session = queue.popleft()
             if self._usable(session):
@@ -196,10 +250,15 @@ class WarmSessionPool:
             self._discard(session)
         return None
 
-    def _take_retunable(self, key: SessionKey) -> WarmSession | None:
+    def _take_retunable(self, demand: _WarmDemand) -> WarmSession | None:
         """Borrow a session the runner can safely repoint."""
-        for warmed_key, queue in self._sessions.items():
-            if warmed_key == key or not key.can_retune_from(warmed_key):
+        queues = self._native_sessions if demand.catalog is not None else self._sessions
+        for warmed_demand, queue in queues.items():
+            if (
+                warmed_demand.catalog != demand.catalog
+                or warmed_demand.key == demand.key
+                or not demand.key.can_retune_from(warmed_demand.key)
+            ):
                 continue
             while queue:
                 session = queue.popleft()
@@ -228,7 +287,7 @@ class WarmSessionPool:
                 return
             # Droid startup is seconds of mostly idle waiting, so a burst that
             # drained the pool refills in one startup instead of N.
-            warmed = await asyncio.gather(*(self._warm(key) for key in deficits))
+            warmed = await asyncio.gather(*(self._warm(demand) for demand in deficits))
             for session in warmed:
                 if session is not None:
                     self.offer(session)
@@ -236,46 +295,75 @@ class WarmSessionPool:
                 await asyncio.sleep(self._retry_seconds)
                 return
 
-    async def _warm(self, key: SessionKey) -> WarmSession | None:
+    async def _warm(self, demand: _WarmDemand) -> WarmSession | None:
         runner = self._runner_factory()
+        binding: NativeToolBinding | None = None
         try:
-            return await runner.warm(key, timeout_seconds=self._warm_timeout_seconds)
+            if demand.catalog is not None:
+                if self._native_registry is None:
+                    raise RuntimeError("native warm pool has no catalog registry")
+                binding = self._native_registry.open_catalog(demand.catalog)
+                self._native_registry.pin(binding.token)
+                return await runner.warm(
+                    demand.key,
+                    timeout_seconds=self._warm_timeout_seconds,
+                    native_tools=binding,
+                )
+            return await runner.warm(demand.key, timeout_seconds=self._warm_timeout_seconds)
         except asyncio.CancelledError:
+            if binding is not None and self._native_registry is not None:
+                self._native_registry.close(binding.token)
             raise
         except Exception as exc:
+            if binding is not None and self._native_registry is not None:
+                self._native_registry.close(binding.token)
             if self._metrics is not None:
                 self._metrics.increment_warm_failures()
-            log_warning("pool.warm_failed", model=key.model_id, error=type(exc).__name__)
+            log_warning("pool.warm_failed", model=demand.key.model_id, error=type(exc).__name__)
             # Settings Droid rejects, such as a model an organization policy
             # blocks, would otherwise be retried for as long as they stay in
             # the wanted list. Traffic that still works re-adds the key.
-            self._forget(key)
+            self._forget_demand(demand)
             return None
 
     def _forget(self, key: SessionKey) -> None:
-        if key in self._wanted:
-            self._wanted.remove(key)
-        self._drop(key)
+        self._forget_demand(_WarmDemand(key))
 
-    def _targets(self) -> dict[SessionKey, int]:
+    def _forget_demand(self, demand: _WarmDemand) -> None:
+        if demand.catalog is None:
+            if demand.key in self._wanted:
+                self._wanted.remove(demand.key)
+        elif demand in self._native_wanted:
+            self._native_wanted.remove(demand)
+        if demand in self._demand_order:
+            self._demand_order.remove(demand)
+        self._drop_demand(demand)
+
+    def _targets(self) -> dict[_WarmDemand, int]:
         """Split the pool size across the keys traffic is currently using."""
-        if not self._wanted:
+        if not self._demand_order:
             return {}
-        base, extra = divmod(self._size, len(self._wanted))
-        return {key: base + (1 if index < extra else 0) for index, key in enumerate(self._wanted)}
+        base, extra = divmod(self._size, len(self._demand_order))
+        return {
+            demand: base + (1 if index < extra else 0)
+            for index, demand in enumerate(self._demand_order)
+        }
 
-    def _deficits(self) -> list[SessionKey]:
-        deficits: list[SessionKey] = []
-        for key, target in self._targets().items():
-            missing = target - len(self._sessions.get(key, ()))
-            deficits.extend([key] * max(0, missing))
+    def _deficits(self) -> list[_WarmDemand]:
+        deficits: list[_WarmDemand] = []
+        targets = self._targets()
+        for demand, target in targets.items():
+            queues = self._native_sessions if demand.catalog is not None else self._sessions
+            missing = target - len(queues.get(demand, ()))
+            deficits.extend([demand] * max(0, missing))
         return deficits
 
     def _rebalance(self) -> None:
         """Free capacity held for keys that traffic has moved away from."""
         targets = self._targets()
-        for key, target in reversed(list(targets.items())):
-            queue = self._sessions.get(key)
+        for demand, target in reversed(list(targets.items())):
+            queues = self._native_sessions if demand.catalog is not None else self._sessions
+            queue = queues.get(demand)
             while queue is not None and len(queue) > target:
                 self._discard(queue.pop())
         self._publish()
@@ -287,23 +375,39 @@ class WarmSessionPool:
         return age < self._ttl_seconds
 
     def _drop_stale(self) -> None:
-        for queue in self._sessions.values():
-            for session in tuple(queue):
-                if not self._usable(session):
-                    queue.remove(session)
-                    self._discard(session)
+        for queues in (self._sessions, self._native_sessions):
+            for queue in queues.values():
+                for session in tuple(queue):
+                    if not self._usable(session):
+                        queue.remove(session)
+                        self._discard(session)
         self._publish()
 
-    def _drop(self, key: SessionKey) -> None:
-        for session in self._sessions.pop(key, ()):
+    def _drop_demand(self, demand: _WarmDemand) -> None:
+        queues = self._native_sessions if demand.catalog is not None else self._sessions
+        for session in queues.pop(demand, ()):
             self._discard(session)
         self._publish()
 
+    def _drop(self, key: SessionKey) -> None:
+        self._drop_demand(_WarmDemand(key))
+
     def _discard(self, session: WarmSession) -> None:
-        self._reaper.submit(self._runner_factory().discard(session))
+        self._reaper.submit(self._discard_session(session))
+
+    async def _discard_session(self, session: WarmSession) -> None:
+        try:
+            await self._runner_factory().discard(session)
+        finally:
+            if session.native_binding is not None and self._native_registry is not None:
+                self._native_registry.close(session.native_binding.token)
 
     def _total(self) -> int:
-        return sum(len(queue) for queue in self._sessions.values())
+        return sum(
+            len(queue)
+            for queues in (self._sessions, self._native_sessions)
+            for queue in queues.values()
+        )
 
     def _publish(self) -> None:
         if self._metrics is not None:

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -516,19 +516,10 @@ class DroidRunner:
         started = loop.time()
         warm = request.warm_session
         if warm is not None:
-            warm.consumed = True
-            client, transport = warm.client, warm.transport
-        else:
-            client, transport = self._new_client()
-            client.set_permission_handler(lambda _params: "cancel")
-            client.set_ask_user_handler(
-                lambda _params: {"cancelled": True, "answers": []},
+            warm_catalog = None if warm.native_binding is None else warm.native_binding.catalog
+            requested_catalog = (
+                None if request.native_tools is None else request.native_tools.catalog
             )
-        warm_catalog = (
-            None if warm is None or warm.native_binding is None else warm.native_binding.catalog
-        )
-        requested_catalog = None if request.native_tools is None else request.native_tools.catalog
-        if warm is not None:
             warm_has_native = warm.native_binding is not None
             request_has_native = request.native_tools is not None
             if warm_has_native != request_has_native or (
@@ -537,6 +528,14 @@ class DroidRunner:
                 raise RunnerError(
                     "A warm Droid session cannot serve a different native tool catalog.",
                 )
+            warm.consumed = True
+            client, transport = warm.client, warm.transport
+        else:
+            client, transport = self._new_client()
+            client.set_permission_handler(lambda _params: "cancel")
+            client.set_ask_user_handler(
+                lambda _params: {"cancelled": True, "answers": []},
+            )
         mcp_servers = [] if request.native_tools is None else [request.native_tools.server_config()]
         initialized = warm is not None
         completed = False

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -100,6 +100,18 @@ def _is_ignorable_native_tool(tool_name: str) -> bool:
     return tool_name.replace("-", "").replace("_", "").casefold() in _IGNORED_NATIVE_TOOLS
 
 
+def _native_tool_ids(binding: NativeToolBinding | None) -> frozenset[str] | None:
+    """Tool ids Droid has to report for ``binding``, or ``None`` for text tools.
+
+    Both a warm session and a per-request session verify against this, so a
+    session that never published the request's catalog is never used to serve
+    a native turn.
+    """
+    if binding is None:
+        return None
+    return frozenset(f"{MCP_TOOL_ID_PREFIX}{name}" for name in binding.names)
+
+
 def _native_tool_marker(name: str, arguments: Any) -> str:
     """Render a structured tool call in the bridge's own marker form."""
     payload = json.dumps(
@@ -396,6 +408,8 @@ class DroidRunner:
                 await self._rpc.disable_native_tools(
                     client,
                     keep_tool_prefix=(None if native_tools is None else MCP_TOOL_ID_PREFIX),
+                    expected_tool_ids=_native_tool_ids(native_tools),
+                    native_server_url=(None if native_tools is None else native_tools.url),
                 )
 
             await self._run_session_init(
@@ -516,15 +530,14 @@ class DroidRunner:
         started = loop.time()
         warm = request.warm_session
         if warm is not None:
+            # A binding always carries its catalog, so ``None`` here means the
+            # side publishes no tools at all, and one comparison covers both a
+            # catalog mismatch and a native session offered to a text turn.
             warm_catalog = None if warm.native_binding is None else warm.native_binding.catalog
             requested_catalog = (
                 None if request.native_tools is None else request.native_tools.catalog
             )
-            warm_has_native = warm.native_binding is not None
-            request_has_native = request.native_tools is not None
-            if warm_has_native != request_has_native or (
-                warm_has_native and warm_catalog != requested_catalog
-            ):
+            if warm_catalog != requested_catalog:
                 raise RunnerError(
                     "A warm Droid session cannot serve a different native tool catalog.",
                 )
@@ -595,13 +608,7 @@ class DroidRunner:
                             keep_tool_prefix=(
                                 None if native_binding is None else MCP_TOOL_ID_PREFIX
                             ),
-                            expected_tool_ids=(
-                                None
-                                if native_binding is None
-                                else frozenset(
-                                    f"{MCP_TOOL_ID_PREFIX}{name}" for name in native_binding.names
-                                )
-                            ),
+                            expected_tool_ids=_native_tool_ids(native_binding),
                             native_server_url=(
                                 None if native_binding is None else native_binding.url
                             ),

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -186,6 +186,7 @@ class WarmSession:
     transport: _ManagedProcessTransport | None
     session_id: str | None
     created_at: float
+    native_binding: NativeToolBinding | None = None
     consumed: bool = False
 
     def is_alive(self) -> bool:
@@ -363,7 +364,13 @@ class DroidRunner:
             append_system_prompt_file=append_system_prompt_file,
         )
 
-    async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+    async def warm(
+        self,
+        key: SessionKey,
+        *,
+        timeout_seconds: float,
+        native_tools: NativeToolBinding | None = None,
+    ) -> WarmSession:
         """Start a Droid session that is initialized but has no turn yet."""
         client, transport = self._new_client()
         client.set_permission_handler(lambda _params: "cancel")
@@ -378,7 +385,7 @@ class DroidRunner:
                 await client.initialize_session(
                     machine_id="factory-droid-openai",
                     cwd=str(self._workdir),
-                    mcp_servers=[],
+                    mcp_servers=([] if native_tools is None else [native_tools.server_config()]),
                     model_id=key.model_id,
                     reasoning_effort=_resolve_reasoning_effort(key.reasoning_effort),
                     interaction_mode=DroidInteractionMode.Auto,
@@ -386,14 +393,26 @@ class DroidRunner:
                     skip_permissions_unsafe=False,
                     enabled_tool_ids=[],
                 )
-                await self._rpc.disable_native_tools(client)
+                await self._rpc.disable_native_tools(
+                    client,
+                    keep_tool_prefix=(None if native_tools is None else MCP_TOOL_ID_PREFIX),
+                )
 
             await self._run_session_init(
                 asyncio.get_running_loop().time() + timeout_seconds,
                 initialize,
             )
         except BaseException:
-            await self.discard(WarmSession(key, client, transport, None, started))
+            await self.discard(
+                WarmSession(
+                    key,
+                    client,
+                    transport,
+                    None,
+                    started,
+                    native_binding=native_tools,
+                )
+            )
             raise
         if self._metrics is not None:
             self._metrics.observe_droid_startup(time.perf_counter() - started)
@@ -403,6 +422,7 @@ class DroidRunner:
             transport=transport,
             session_id=client.session_id,
             created_at=asyncio.get_running_loop().time(),
+            native_binding=native_tools,
         )
 
     async def _run_session_init(
@@ -504,12 +524,19 @@ class DroidRunner:
             client.set_ask_user_handler(
                 lambda _params: {"cancelled": True, "answers": []},
             )
-        if warm is not None and request.native_tools is not None:
-            # A warm session was initialized without the request's MCP server,
-            # and Droid attaches those only when a session starts.
-            raise RunnerError(
-                "A warm Droid session cannot serve a native tool-calling turn.",
-            )
+        warm_catalog = (
+            None if warm is None or warm.native_binding is None else warm.native_binding.catalog
+        )
+        requested_catalog = None if request.native_tools is None else request.native_tools.catalog
+        if warm is not None:
+            warm_has_native = warm.native_binding is not None
+            request_has_native = request.native_tools is not None
+            if warm_has_native != request_has_native or (
+                warm_has_native and warm_catalog != requested_catalog
+            ):
+                raise RunnerError(
+                    "A warm Droid session cannot serve a different native tool catalog.",
+                )
         mcp_servers = [] if request.native_tools is None else [request.native_tools.server_config()]
         initialized = warm is not None
         completed = False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4921,10 +4921,13 @@ async def test_native_tool_calls_reject_a_warm_session_without_its_binding(
         cast("Any", lambda _key, _catalog: warm),
     )
 
-    with pytest.raises(RuntimeError, match="no catalog binding"):
-        async with _client(app) as client:
-            await client.post("/v1/chat/completions", json=_weather_payload())
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
 
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["type"] == "factory_native_tool_unavailable"
+    assert "published no tool catalog" in body["error"]["message"]
     await app.state.reaper.drain()
     assert runner.discarded == ([] if consumed else [warm])
     assert len(app.state.native_tools) == 0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -93,6 +93,8 @@ class FakeRunner:
 
     async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
         self.requests.append(request)
+        if request.warm_session is not None:
+            request.warm_session.consumed = True
         try:
             if self.error is not None:
                 raise self.error
@@ -4071,7 +4073,13 @@ class WarmingRunner(FakeRunner):
         self.warmed: list[SessionKey] = []
         self.discarded: list[WarmSession] = []
 
-    async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+    async def warm(
+        self,
+        key: SessionKey,
+        *,
+        timeout_seconds: float,
+        native_tools: Any = None,
+    ) -> WarmSession:
         del timeout_seconds
         self.warmed.append(key)
         return WarmSession(
@@ -4080,6 +4088,7 @@ class WarmingRunner(FakeRunner):
             transport=None,
             session_id="session-1",
             created_at=asyncio.get_running_loop().time(),
+            native_binding=native_tools,
         )
 
     async def discard(self, session: WarmSession) -> None:
@@ -4845,7 +4854,7 @@ async def test_native_tool_calls_reuse_a_catalog_matched_warm_session(tmp_path: 
         native_tool_calls=True,
         max_concurrency=1,
         warm_sessions=1,
-        max_tracked_sessions=1,
+        max_tracked_sessions=2,
         telemetry=False,
     )
     app = create_app(
@@ -4887,11 +4896,13 @@ async def test_native_tool_calls_reuse_a_catalog_matched_warm_session(tmp_path: 
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("consumed", [False, True])
 async def test_native_tool_calls_reject_a_warm_session_without_its_binding(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    consumed: bool,
 ) -> None:
-    runner = FakeRunner([RunComplete(Usage())])
+    runner = WarmingRunner()
     app = create_app(
         _native_settings(tmp_path),
         runner_factory=cast("RunnerFactory", lambda: runner),
@@ -4902,6 +4913,7 @@ async def test_native_tool_calls_reject_a_warm_session_without_its_binding(
         transport=None,
         session_id="invalid-native-warm",
         created_at=asyncio.get_running_loop().time(),
+        consumed=consumed,
     )
     monkeypatch.setattr(
         app.state.pool,
@@ -4913,6 +4925,8 @@ async def test_native_tool_calls_reject_a_warm_session_without_its_binding(
         async with _client(app) as client:
             await client.post("/v1/chat/completions", json=_weather_payload())
 
+    await app.state.reaper.drain()
+    assert runner.discarded == ([] if consumed else [warm])
     assert len(app.state.native_tools) == 0
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4833,6 +4833,129 @@ async def test_native_tool_calls_publish_the_request_tools_for_the_turn(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_native_tool_calls_reuse_a_catalog_matched_warm_session(tmp_path: Path) -> None:
+    marker = (
+        f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Gdansk"}}}}{TOOL_CALL_CLOSE}'
+    )
+    runner = CatalogWatchingRunner([TextDelta(marker), RunComplete(Usage())], registry=None)
+    settings = Settings(
+        droid_path="droid",
+        workdir=tmp_path,
+        timeout_seconds=30.0,
+        native_tool_calls=True,
+        max_concurrency=1,
+        warm_sessions=1,
+        max_tracked_sessions=1,
+        telemetry=False,
+    )
+    app = create_app(
+        settings,
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    runner.registry = app.state.native_tools
+    catalog = app.state.native_tools.catalog_identity(
+        (
+            {
+                "name": "weather",
+                "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}},
+                "description": "Read the weather.",
+            },
+        )
+    )
+    binding = app.state.native_tools.open_catalog(catalog)
+    app.state.native_tools.pin(binding.token)
+    key = SessionKey(model_id=None, reasoning_effort=None)
+    app.state.pool.note(key, catalog)
+    warm = WarmSession(
+        key=key,
+        client=cast("Any", object()),
+        transport=None,
+        session_id="warm-native",
+        created_at=asyncio.get_running_loop().time(),
+        native_binding=binding,
+    )
+    app.state.pool.offer(warm)
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
+
+    assert response.status_code == 200
+    assert runner.requests[0].warm_session is warm
+    assert runner.requests[0].native_tools is binding
+    assert runner.catalog_in_flight == catalog.tools
+    assert len(app.state.native_tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_native_tool_calls_reject_a_warm_session_without_its_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    app = create_app(
+        _native_settings(tmp_path),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort=None),
+        client=cast("Any", object()),
+        transport=None,
+        session_id="invalid-native-warm",
+        created_at=asyncio.get_running_loop().time(),
+    )
+    monkeypatch.setattr(
+        app.state.pool,
+        "acquire",
+        cast("Any", lambda _key, _catalog: warm),
+    )
+
+    with pytest.raises(RuntimeError, match="no catalog binding"):
+        async with _client(app) as client:
+            await client.post("/v1/chat/completions", json=_weather_payload())
+
+    assert len(app.state.native_tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_native_catalog_setup_releases_a_continuation_lease_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    settings = Settings(
+        droid_path="droid",
+        workdir=tmp_path,
+        timeout_seconds=30.0,
+        native_tool_calls=True,
+        session_continuity=True,
+        telemetry=False,
+    )
+    app = create_app(
+        settings,
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    key = SessionKey(model_id=None, reasoning_effort=None)
+    app.state.sessions.remember("session-1", key)
+
+    def fail_open(_catalog: Any) -> Any:
+        raise RuntimeError("catalog capacity")
+
+    monkeypatch.setattr(app.state.native_tools, "open_catalog", fail_open)
+
+    with pytest.raises(RuntimeError, match="catalog capacity"):
+        async with _client(app) as client:
+            await client.post(
+                "/v1/chat/completions",
+                json=_weather_payload(factory_droid_session_id="session-1"),
+            )
+
+    lease = app.state.sessions.acquire("session-1")
+    assert lease is not None
+    lease.release()
+    assert len(app.state.native_tools) == 0
+
+
+@pytest.mark.asyncio
 async def test_native_tool_calls_serve_the_catalog_over_the_mcp_endpoint(tmp_path: Path) -> None:
     app = create_app(
         _native_settings(tmp_path),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,8 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_WARM_SESSION_TTL_SECONDS",
     "FACTORY_DROID_OPENAI_DETACHED_CLEANUP",
     "FACTORY_DROID_OPENAI_REPAIR_LOST_PREFIX",
+    "FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS",
+    "FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL",
     "FACTORY_DROID_OPENAI_TELEMETRY",
     "FACTORY_DROID_OPENAI_TRACE_PAYLOADS",
     "FACTORY_DROID_OPENAI_TRACE_FILE",
@@ -180,6 +182,35 @@ def test_warm_session_count_tracks_max_concurrency_unless_set(
 
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WARM_SESSIONS", "5")
     assert Settings.from_env().warm_session_count() == 5
+
+
+def test_settings_reserve_native_catalog_capacity_for_warm_sessions(tmp_path: Path) -> None:
+    with pytest.raises(
+        ValueError,
+        match="max_tracked_sessions must be greater than warm sessions",
+    ):
+        Settings(
+            workdir=tmp_path,
+            native_tool_calls=True,
+            warm_sessions=1,
+            max_tracked_sessions=1,
+        )
+
+    enabled = Settings(
+        workdir=tmp_path,
+        native_tool_calls=True,
+        warm_sessions=1,
+        max_tracked_sessions=2,
+    )
+    assert enabled.native_tool_calls is True
+
+    disabled_pool = Settings(
+        workdir=tmp_path,
+        native_tool_calls=True,
+        warm_sessions=0,
+        max_tracked_sessions=1,
+    )
+    assert disabled_pool.warm_session_count() == 0
 
 
 def test_settings_from_env_reads_pool_overrides(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -184,23 +184,26 @@ def test_warm_session_count_tracks_max_concurrency_unless_set(
     assert Settings.from_env().warm_session_count() == 5
 
 
-def test_settings_reserve_native_catalog_capacity_for_warm_sessions(tmp_path: Path) -> None:
+def test_settings_reserve_native_catalog_capacity_for_warm_and_in_flight(tmp_path: Path) -> None:
+    # One warm session plus two admitted requests need three catalog slots.
     with pytest.raises(
         ValueError,
-        match="max_tracked_sessions must be greater than warm sessions",
+        match=r"at least warm sessions plus max_concurrency \(3\)",
     ):
         Settings(
             workdir=tmp_path,
             native_tool_calls=True,
             warm_sessions=1,
-            max_tracked_sessions=1,
+            max_concurrency=2,
+            max_tracked_sessions=2,
         )
 
     enabled = Settings(
         workdir=tmp_path,
         native_tool_calls=True,
         warm_sessions=1,
-        max_tracked_sessions=2,
+        max_concurrency=2,
+        max_tracked_sessions=3,
     )
     assert enabled.native_tool_calls is True
 
@@ -208,9 +211,18 @@ def test_settings_reserve_native_catalog_capacity_for_warm_sessions(tmp_path: Pa
         workdir=tmp_path,
         native_tool_calls=True,
         warm_sessions=0,
+        max_concurrency=1,
         max_tracked_sessions=1,
     )
     assert disabled_pool.warm_session_count() == 0
+
+    text_only = Settings(
+        workdir=tmp_path,
+        warm_sessions=1,
+        max_concurrency=2,
+        max_tracked_sessions=1,
+    )
+    assert text_only.native_tool_calls is False
 
 
 def test_settings_from_env_reads_pool_overrides(

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -6,10 +6,12 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
+import factory_droid_openai.mcp_tools as mcp_tools
 from factory_droid_openai.mcp_tools import (
     MCP_PROTOCOL_VERSION,
     MCP_ROUTE_PREFIX,
     MCP_SERVER_NAME,
+    NativeToolCatalog,
     NativeToolRegistry,
     build_router,
     handle_rpc,
@@ -78,6 +80,8 @@ def test_registry_forgets_a_closed_catalog() -> None:
     registry = _registry()
     binding = registry.open(_catalog())
 
+    registry.pin("missing")
+    registry.unpin("missing")
     registry.close(binding.token)
     registry.close(binding.token)
 
@@ -105,6 +109,88 @@ def test_registry_copies_the_published_tools() -> None:
     catalog = registry.catalog(binding.token)
     assert catalog is not None
     assert catalog[0]["name"] == "get_weather"
+
+
+def test_catalog_identity_includes_order_and_every_descriptor_field() -> None:
+    registry = _registry()
+    first = registry.catalog_identity(
+        (
+            {"name": "a", "description": "one", "inputSchema": {"type": "object"}},
+            {"name": "b", "inputSchema": {"type": "string"}},
+        )
+    )
+    same = registry.catalog_identity(
+        (
+            {"name": "a", "description": "one", "inputSchema": {"type": "object"}},
+            {"name": "b", "inputSchema": {"type": "string"}},
+        )
+    )
+    changed = registry.catalog_identity(
+        (
+            {"name": "b", "inputSchema": {"type": "string"}},
+            {"name": "a", "description": "two", "inputSchema": {"type": "object"}},
+        )
+    )
+
+    assert isinstance(first, NativeToolCatalog)
+    assert first == same
+    assert first.fingerprint == same.fingerprint
+    assert first != changed
+    assert first.fingerprint != changed.fingerprint
+    assert first.names == frozenset({"a", "b"})
+
+
+def test_catalog_tools_are_fresh_copies() -> None:
+    catalog = _registry().catalog_identity(_catalog())
+
+    first = catalog.tools
+    first[0]["name"] = "mutated"
+
+    assert catalog.tools[0]["name"] == "get_weather"
+
+
+def test_catalog_rejects_malformed_serialized_tools() -> None:
+    catalog = NativeToolCatalog(serialized="{}", fingerprint="", names=frozenset())
+
+    with pytest.raises(RuntimeError, match="serialization is malformed"):
+        _ = catalog.tools
+
+
+def test_catalog_identity_rejects_malformed_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = cast("Any", mcp_tools)
+    monkeypatch.setattr(module.__dict__["json"], "loads", lambda _serialized: {})
+
+    with pytest.raises(RuntimeError, match="serialization is malformed"):
+        _registry().catalog_identity(())
+
+
+def test_pinned_catalogs_survive_eviction_until_unpinned() -> None:
+    registry = _registry(max_sessions=2)
+    first = registry.open(_catalog())
+    second = registry.open(())
+    registry.pin(first.token)
+
+    third = registry.open(({"name": "third", "inputSchema": {}},))
+
+    assert registry.catalog(first.token) == _catalog()
+    assert registry.catalog(second.token) is None
+    assert registry.catalog(third.token) is not None
+
+    registry.unpin(first.token)
+    fourth = registry.open(({"name": "fourth", "inputSchema": {}},))
+    assert registry.catalog(first.token) is None
+    assert registry.catalog(fourth.token) is not None
+
+
+def test_registry_rejects_opening_when_all_catalogs_are_pinned() -> None:
+    registry = _registry(max_sessions=1)
+    first = registry.open(_catalog())
+    registry.pin(first.token)
+
+    with pytest.raises(RuntimeError, match="capacity is exhausted"):
+        registry.open(())
 
 
 def test_openai_tools_become_mcp_descriptors() -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -11,6 +11,7 @@ from factory_droid_openai.mcp_tools import (
     MCP_PROTOCOL_VERSION,
     MCP_ROUTE_PREFIX,
     MCP_SERVER_NAME,
+    NativeCatalogUnavailableError,
     NativeToolCatalog,
     NativeToolRegistry,
     build_router,
@@ -81,7 +82,6 @@ def test_registry_forgets_a_closed_catalog() -> None:
     binding = registry.open(_catalog())
 
     registry.pin("missing")
-    registry.unpin("missing")
     registry.close(binding.token)
     registry.close(binding.token)
 
@@ -134,10 +134,22 @@ def test_catalog_identity_includes_order_and_every_descriptor_field() -> None:
 
     assert isinstance(first, NativeToolCatalog)
     assert first == same
-    assert first.fingerprint == same.fingerprint
+    assert hash(first) == hash(same)
     assert first != changed
-    assert first.fingerprint != changed.fingerprint
     assert first.names == frozenset({"a", "b"})
+
+
+def test_catalog_serves_the_tools_in_the_order_the_client_sent_them() -> None:
+    """The serialization is what the model reads, so it must not be re-keyed."""
+    registry = _registry()
+    schema = {"type": "object", "properties": {"zone": {"type": "string"}, "city": {}}}
+
+    binding = registry.open(({"inputSchema": schema, "name": "get_weather"},))
+
+    served = registry.catalog(binding.token)
+    assert served is not None
+    assert list(served[0]) == ["inputSchema", "name"]
+    assert list(served[0]["inputSchema"]["properties"]) == ["zone", "city"]
 
 
 def test_catalog_tools_are_fresh_copies() -> None:
@@ -150,9 +162,9 @@ def test_catalog_tools_are_fresh_copies() -> None:
 
 
 def test_catalog_rejects_malformed_serialized_tools() -> None:
-    catalog = NativeToolCatalog(serialized="{}", fingerprint="", names=frozenset())
+    catalog = NativeToolCatalog(serialized="{}", names=frozenset())
 
-    with pytest.raises(RuntimeError, match="serialization is malformed"):
+    with pytest.raises(NativeCatalogUnavailableError, match="serialization is malformed"):
         _ = catalog.tools
 
 
@@ -162,11 +174,11 @@ def test_catalog_identity_rejects_malformed_serialization(
     module = cast("Any", mcp_tools)
     monkeypatch.setattr(module.__dict__["json"], "loads", lambda _serialized: {})
 
-    with pytest.raises(RuntimeError, match="serialization is malformed"):
+    with pytest.raises(NativeCatalogUnavailableError, match="serialization is malformed"):
         _registry().catalog_identity(())
 
 
-def test_pinned_catalogs_survive_eviction_until_unpinned() -> None:
+def test_pinned_catalogs_survive_eviction_until_closed() -> None:
     registry = _registry(max_sessions=2)
     first = registry.open(_catalog())
     second = registry.open(())
@@ -178,7 +190,7 @@ def test_pinned_catalogs_survive_eviction_until_unpinned() -> None:
     assert registry.catalog(second.token) is None
     assert registry.catalog(third.token) is not None
 
-    registry.unpin(first.token)
+    registry.close(first.token)
     fourth = registry.open(({"name": "fourth", "inputSchema": {}},))
     assert registry.catalog(first.token) is None
     assert registry.catalog(fourth.token) is not None
@@ -189,7 +201,7 @@ def test_registry_rejects_opening_when_all_catalogs_are_pinned() -> None:
     first = registry.open(_catalog())
     registry.pin(first.token)
 
-    with pytest.raises(RuntimeError, match="capacity is exhausted"):
+    with pytest.raises(NativeCatalogUnavailableError, match="capacity is exhausted"):
         registry.open(())
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -298,6 +298,41 @@ async def test_pool_misses_when_native_catalog_changes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pool_keeps_a_text_session_while_native_catalogs_rotate() -> None:
+    """A rotating catalog must not push a live text key to a target of zero."""
+    log: list[str] = []
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    pool = _pool(FakeRunner(log=log), size=3, max_keys=2, native_registry=registry)
+    warmed = asyncio.get_running_loop().time()
+    pool.note(KEY)
+    pool.offer(_session(KEY, created_at=warmed))
+    pool.note(OTHER_KEY)
+    pool.offer(_session(OTHER_KEY, created_at=warmed))
+    catalogs = [_native_catalog(registry, name) for name in ("first", "second")]
+    for catalog in catalogs:
+        pool.note(KEY, catalog)
+        pool.offer(
+            _session(
+                KEY,
+                created_at=warmed,
+                native_binding=registry.open_catalog(catalog),
+            )
+        )
+
+    # Four demands over a pool of three: the text half still funds both keys,
+    # and only the rotated-away catalog loses its session.
+    pool._rebalance()
+    await asyncio.sleep(0)
+
+    assert pool.acquire(KEY) is not None
+    assert pool.acquire(OTHER_KEY) is not None
+    assert pool.acquire(KEY, catalogs[1]) is not None
+    assert pool.acquire(KEY, catalogs[0]) is None
+    assert log == ["discard:model-a"]
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
 async def test_pool_drops_stale_native_demand() -> None:
     log: list[str] = []
     registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
@@ -403,8 +438,14 @@ async def test_pool_drops_a_key_after_session_init_timeout() -> None:
             super().__init__()
             self.attempts = 0
 
-        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
-            del key, timeout_seconds
+        async def warm(
+            self,
+            key: SessionKey,
+            *,
+            timeout_seconds: float,
+            native_tools: NativeToolBinding | None = None,
+        ) -> WarmSession:
+            del key, timeout_seconds, native_tools
             self.attempts += 1
             raise RunnerError(
                 "Factory Droid session initialization timed out after 0.1 seconds.",

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -5,8 +5,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
+from factory_droid_openai.mcp_tools import NativeToolBinding, NativeToolRegistry
 from factory_droid_openai.metrics import BridgeMetrics
-from factory_droid_openai.pool import BackgroundReaper, PoolMetrics, WarmSessionPool
+from factory_droid_openai.pool import (
+    BackgroundReaper,
+    PoolMetrics,
+    WarmSessionPool,
+    _WarmDemand,
+)
 from factory_droid_openai.runner import RunnerError, SessionKey, WarmSession
 
 if TYPE_CHECKING:
@@ -31,14 +37,26 @@ class FakeRunner:
         self.fail = fail
         self.log = log if log is not None else []
         self.warmed = 0
+        self.native_bindings: list[NativeToolBinding | None] = []
 
-    async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+    async def warm(
+        self,
+        key: SessionKey,
+        *,
+        timeout_seconds: float,
+        native_tools: NativeToolBinding | None = None,
+    ) -> WarmSession:
         del timeout_seconds
         if self.fail:
             raise RuntimeError("warm failed")
         self.warmed += 1
+        self.native_bindings.append(native_tools)
         self.log.append(f"warm:{key.model_id}")
-        return _session(key, created_at=asyncio.get_running_loop().time())
+        return _session(
+            key,
+            created_at=asyncio.get_running_loop().time(),
+            native_binding=native_tools,
+        )
 
     async def discard(self, session: WarmSession) -> None:
         self.log.append(f"discard:{session.key.model_id}")
@@ -49,6 +67,7 @@ def _session(
     *,
     created_at: float = 0.0,
     reaped: bool = False,
+    native_binding: NativeToolBinding | None = None,
 ) -> WarmSession:
     return WarmSession(
         key=key,
@@ -56,6 +75,7 @@ def _session(
         transport=cast("Any", FakeTransport(reaped=reaped)),
         session_id="session-1",
         created_at=created_at,
+        native_binding=native_binding,
     )
 
 
@@ -67,6 +87,7 @@ def _pool(
     max_keys: int = 2,
     retry_seconds: float = 0.0,
     metrics: BridgeMetrics | None = None,
+    native_registry: NativeToolRegistry | None = None,
 ) -> WarmSessionPool:
     return WarmSessionPool(
         runner_factory=cast("RunnerFactory", lambda: runner),
@@ -77,7 +98,12 @@ def _pool(
         max_keys=max_keys,
         retry_seconds=retry_seconds,
         metrics=metrics,
+        native_registry=native_registry,
     )
+
+
+def _native_catalog(registry: NativeToolRegistry, name: str = "weather") -> Any:
+    return registry.catalog_identity(({"name": name, "inputSchema": {"type": "object"}},))
 
 
 @pytest.mark.asyncio
@@ -218,6 +244,146 @@ async def test_pool_discards_sessions_offered_when_full_or_unwanted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pool_warms_and_reuses_an_exact_native_catalog() -> None:
+    log: list[str] = []
+    reaper = BackgroundReaper()
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    runner = FakeRunner(log=log)
+    pool = WarmSessionPool(
+        runner_factory=cast("RunnerFactory", lambda: runner),
+        reaper=reaper,
+        size=1,
+        warm_timeout_seconds=5.0,
+        native_registry=registry,
+    )
+    catalog = _native_catalog(registry)
+    pool.start()
+    pool.note(KEY, catalog)
+    await asyncio.sleep(0.05)
+
+    session = pool.acquire(KEY, catalog)
+
+    assert session is not None
+    assert session.native_binding is not None
+    assert session.native_binding.catalog == catalog
+    assert runner.native_bindings == [session.native_binding]
+    assert len(registry) == 1
+    await pool.aclose()
+    await reaper.drain()
+    assert len(registry) == 1
+    registry.close(session.native_binding.token)
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
+async def test_pool_misses_when_native_catalog_changes() -> None:
+    reaper = BackgroundReaper()
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    pool = WarmSessionPool(
+        runner_factory=cast("RunnerFactory", lambda: FakeRunner()),
+        reaper=reaper,
+        size=1,
+        warm_timeout_seconds=5.0,
+        native_registry=registry,
+    )
+    first_catalog = _native_catalog(registry, "first")
+    second_catalog = _native_catalog(registry, "second")
+    binding = registry.open_catalog(first_catalog)
+    pool.note(KEY, first_catalog)
+    pool.offer(_session(created_at=asyncio.get_running_loop().time(), native_binding=binding))
+
+    assert pool.acquire(KEY, second_catalog) is None
+    await pool.aclose()
+    await reaper.drain()
+
+
+@pytest.mark.asyncio
+async def test_pool_drops_stale_native_demand() -> None:
+    log: list[str] = []
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    pool = _pool(FakeRunner(log=log), max_keys=1, native_registry=registry)
+    first_catalog = _native_catalog(registry, "first")
+    second_catalog = _native_catalog(registry, "second")
+    first_binding = registry.open_catalog(first_catalog)
+    pool.note(KEY, first_catalog)
+    pool.offer(_session(created_at=asyncio.get_running_loop().time(), native_binding=first_binding))
+
+    pool.note(OTHER_KEY, second_catalog)
+    await asyncio.sleep(0)
+
+    assert log == ["discard:model-a"]
+    assert len(registry) == 0
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_reports_missing_native_registry() -> None:
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    pool = _pool(FakeRunner(), native_registry=None)
+    catalog = _native_catalog(registry)
+
+    result = await pool._warm(_WarmDemand(KEY, catalog))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pool_closes_a_native_catalog_after_warm_failure() -> None:
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    runner = FakeRunner(fail=True)
+    pool = _pool(runner, native_registry=registry)
+    catalog = _native_catalog(registry)
+
+    pool.start()
+    pool.note(KEY, catalog)
+    await asyncio.sleep(0.05)
+
+    assert len(registry) == 0
+    assert pool.acquire(KEY, catalog) is None
+    await pool.aclose()
+
+
+def test_pool_drop_wrapper_removes_plain_demand() -> None:
+    pool = _pool(FakeRunner())
+
+    pool._drop(KEY)
+
+    assert pool.acquire(KEY) is None
+
+
+@pytest.mark.asyncio
+async def test_pool_closes_a_native_catalog_when_warmup_is_cancelled() -> None:
+    class SlowNativeRunner(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.started = asyncio.Event()
+
+        async def warm(
+            self,
+            key: SessionKey,
+            *,
+            timeout_seconds: float,
+            native_tools: NativeToolBinding | None = None,
+        ) -> WarmSession:
+            del key, timeout_seconds, native_tools
+            self.started.set()
+            await asyncio.sleep(30)
+            raise AssertionError("warmup should have been cancelled")
+
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    runner = SlowNativeRunner()
+    pool = _pool(runner, native_registry=registry)
+    catalog = _native_catalog(registry)
+    pool.start()
+    pool.note(KEY, catalog)
+    await runner.started.wait()
+
+    await pool.aclose()
+
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
 async def test_pool_records_warm_failures_and_keeps_running() -> None:
     metrics = BridgeMetrics()
     runner = FakeRunner(fail=True)
@@ -263,9 +429,19 @@ async def test_pool_stops_warming_a_key_droid_rejects() -> None:
             super().__init__(fail=True)
             self.attempts = 0
 
-        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+        async def warm(
+            self,
+            key: SessionKey,
+            *,
+            timeout_seconds: float,
+            native_tools: NativeToolBinding | None = None,
+        ) -> WarmSession:
             self.attempts += 1
-            return await super().warm(key, timeout_seconds=timeout_seconds)
+            return await super().warm(
+                key,
+                timeout_seconds=timeout_seconds,
+                native_tools=native_tools,
+            )
 
     runner = CountingRunner()
     pool = _pool(runner, retry_seconds=0.01)
@@ -352,8 +528,14 @@ async def test_pool_close_cancels_an_in_flight_warmup() -> None:
             super().__init__()
             self.started = asyncio.Event()
 
-        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
-            del key, timeout_seconds
+        async def warm(
+            self,
+            key: SessionKey,
+            *,
+            timeout_seconds: float,
+            native_tools: NativeToolBinding | None = None,
+        ) -> WarmSession:
+            del key, timeout_seconds, native_tools
             self.started.set()
             await asyncio.sleep(30)
             raise AssertionError("warmup should have been cancelled")
@@ -449,12 +631,22 @@ async def test_pool_refills_every_missing_session_in_one_pass() -> None:
             self.concurrent = 0
             self.peak = 0
 
-        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+        async def warm(
+            self,
+            key: SessionKey,
+            *,
+            timeout_seconds: float,
+            native_tools: NativeToolBinding | None = None,
+        ) -> WarmSession:
             self.concurrent += 1
             self.peak = max(self.peak, self.concurrent)
             try:
                 await asyncio.sleep(0.02)
-                return await super().warm(key, timeout_seconds=timeout_seconds)
+                return await super().warm(
+                    key,
+                    timeout_seconds=timeout_seconds,
+                    native_tools=native_tools,
+                )
             finally:
                 self.concurrent -= 1
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -38,6 +38,7 @@ from factory_droid_openai.mcp_tools import (
     MCP_TOOL_ID_PREFIX,
     MCP_TOOL_PREFIX,
     NativeToolBinding,
+    NativeToolRegistry,
 )
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.pool import BackgroundReaper
@@ -1473,6 +1474,28 @@ async def test_runner_warms_a_session_with_the_requested_settings(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_runner_warms_a_session_with_native_tools_enabled(tmp_path: Path) -> None:
+    client = NativeToolClient([])
+    binding = _native_binding()
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    session = await runner.warm(
+        SessionKey(model_id="claude-sonnet-4", reasoning_effort="low"),
+        timeout_seconds=1.0,
+        native_tools=binding,
+    )
+
+    assert session.native_binding is binding
+    assert client.init_kwargs["mcp_servers"] == [binding.server_config()]
+    assert client.disabled_tool_ids == {"read-cli", "exit-spec-mode", "tool-search-cli"}
+    await runner.discard(session)
+
+
+@pytest.mark.asyncio
 async def test_runner_warm_closes_the_session_when_startup_fails(tmp_path: Path) -> None:
     class FailingClient(FakeClient):
         async def initialize_session(self, **kwargs: Any) -> None:
@@ -2303,6 +2326,61 @@ async def test_runner_refuses_a_warm_session_for_a_native_turn(tmp_path: Path) -
 
     with pytest.raises(RunnerError, match="warm Droid session cannot serve"):
         async for _ in runner.run(_request(native_tools=_native_binding(), warm_session=warm)):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_runner_accepts_a_warm_session_with_the_same_native_catalog(tmp_path: Path) -> None:
+    binding = _native_binding()
+    client = NativeToolClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort="high"),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+        native_binding=binding,
+    )
+
+    events = [
+        event async for event in runner.run(_request(native_tools=binding, warm_session=warm))
+    ]
+
+    assert events == [
+        SessionStarted("session-1"),
+        RunComplete(usage=Usage()),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_a_warm_session_with_a_different_native_catalog(
+    tmp_path: Path,
+) -> None:
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    first = registry.open(({"name": "first", "inputSchema": {}},))
+    second = registry.open(({"name": "second", "inputSchema": {}},))
+    client = NativeToolClient([TurnComplete()])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+    warm = WarmSession(
+        key=SessionKey(model_id=None, reasoning_effort="high"),
+        client=cast("Any", client),
+        transport=None,
+        session_id="session-1",
+        created_at=0.0,
+        native_binding=first,
+    )
+
+    with pytest.raises(RunnerError, match="different native tool catalog"):
+        async for _ in runner.run(_request(native_tools=second, warm_session=warm)):
             pass
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2383,6 +2383,10 @@ async def test_runner_rejects_a_warm_session_with_a_different_native_catalog(
         async for _ in runner.run(_request(native_tools=second, warm_session=warm)):
             pass
 
+    assert warm.consumed is False
+    assert client.rpc_requests == []
+    assert client.closed is False
+
 
 @pytest.mark.asyncio
 async def test_runner_accepts_a_published_tool_reported_under_its_bare_name(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -34,6 +34,7 @@ from droid_sdk.schemas.enums import (
 )
 
 from factory_droid_openai import runner as runner_module
+from factory_droid_openai.droid_rpc import NativeToolUnavailableError
 from factory_droid_openai.mcp_tools import (
     MCP_TOOL_ID_PREFIX,
     MCP_TOOL_PREFIX,
@@ -1496,6 +1497,29 @@ async def test_runner_warms_a_session_with_native_tools_enabled(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+async def test_runner_verifies_the_catalog_before_a_native_session_goes_warm(
+    tmp_path: Path,
+) -> None:
+    # A session that reaches the pool unverified would serve a native turn with
+    # no tools at all, since the request path trusts a warm session.
+    client = PolicyBlockedNativeToolClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(NativeToolUnavailableError, match=r"mcpPolicy.*127.0.0.1"):
+        await runner.warm(
+            SessionKey(model_id=None, reasoning_effort=None),
+            timeout_seconds=1.0,
+            native_tools=_native_binding(),
+        )
+
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
 async def test_runner_warm_closes_the_session_when_startup_fails(tmp_path: Path) -> None:
     class FailingClient(FakeClient):
         async def initialize_session(self, **kwargs: Any) -> None:
@@ -2095,10 +2119,12 @@ class PolicyBlockedNativeToolClient(FakeClient):
 
 
 def _native_binding() -> NativeToolBinding:
-    return NativeToolBinding(
-        token="tok",
-        url="http://127.0.0.1:8787/factory/mcp/tok",
-        names=frozenset({"get_weather", "write_file", "ping"}),
+    return NativeToolRegistry(base_url="http://127.0.0.1:8787").open(
+        (
+            {"name": "get_weather", "inputSchema": {"type": "object"}},
+            {"name": "write_file", "inputSchema": {"type": "object"}},
+            {"name": "ping", "inputSchema": {"type": "object"}},
+        )
     )
 
 
@@ -2331,7 +2357,11 @@ async def test_runner_refuses_a_warm_session_for_a_native_turn(tmp_path: Path) -
 
 @pytest.mark.asyncio
 async def test_runner_accepts_a_warm_session_with_the_same_native_catalog(tmp_path: Path) -> None:
-    binding = _native_binding()
+    # Two real bindings for the same tools: the catalog decides, not the token.
+    registry = NativeToolRegistry(base_url="http://127.0.0.1:8787")
+    tools = ({"name": "get_weather", "inputSchema": {"type": "object"}},)
+    warmed = registry.open(tools)
+    requested = registry.open(tools)
     client = NativeToolClient([TurnComplete()])
     runner = DroidRunner(
         droid_path="droid",
@@ -2344,13 +2374,14 @@ async def test_runner_accepts_a_warm_session_with_the_same_native_catalog(tmp_pa
         transport=None,
         session_id="session-1",
         created_at=0.0,
-        native_binding=binding,
+        native_binding=warmed,
     )
 
     events = [
-        event async for event in runner.run(_request(native_tools=binding, warm_session=warm))
+        event async for event in runner.run(_request(native_tools=requested, warm_session=warm))
     ]
 
+    assert warmed.token != requested.token
     assert events == [
         SessionStarted("session-1"),
         RunComplete(usage=Usage()),


### PR DESCRIPTION
## Summary

- Key warm sessions by the exact native MCP catalog.
- Allocate isolated per-request catalogs and reuse matching warm sessions.
- Preserve token cleanup and session discard guarantees.
- Add runner, pool, MCP, and app coverage.

Closes #84

## Validation

- Full test suite with 100 percent coverage
- Ruff and strict mypy
- OpenAPI validation, lock check, and package build
