### PR TITLE
test(matrix): cover native session continuity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,12 @@ To verify explicit session continuity as well, start the bridge with
 `--test-session-continuity` to the matrix command. That phase creates a session
 with one model and confirms that continuing its ID with different settings is
 rejected instead of silently running under a stale model or reasoning effort.
+Use `--test-native-session-continuity` to create a real native tool call, append
+the returned assistant call and client result, and continue the same session.
+Run this against affected models in both transports. Keep a client-side
+iteration cap; repeated calls remain legal model behavior and must not be
+deduplicated by the bridge. The matrix recognizes a repeat by tool name and
+argument values, because every request gets its own call IDs.
 
 ```bash
 uv run python scripts/e2e_matrix.py report traces/run-a.jsonl

--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,15 @@ the session; changing either returns HTTP `400`. Start a new session and resend
 the transcript when switching settings. Restarting the bridge clears the set
 of continuable sessions.
 
+Native tool calls have the same empty-history limitation in stateless mode:
+`tool_result_followup` may repeat a call that the transcript already answers.
+Do not deduplicate or suppress such calls, because retries and multi-step
+workflows are valid OpenAI behavior. For native tool loops, enable continuity,
+return the assistant tool call and client result with the bridge-issued session
+ID, and cap client iterations. The session-aware matrix check exercises this
+path with `--test-native-session-continuity`; a repeat remains model behavior,
+not a bridge-side duplicate-call decision.
+
 The same guard applies to the Factory session extension endpoints. They are
 available only when continuity is enabled and only for IDs created by the
 current bridge process:

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -394,6 +394,27 @@ def _label_argument(value: str) -> str:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
+_NATIVE_CONTINUATION_PROMPT = "What is the weather in Gdansk? Use the tool."
+
+
+def native_continuation_scenarios(*, streaming: bool = True) -> list[Scenario]:
+    """Continue a real tool turn and require an answer from its result."""
+    scenario = Scenario(
+        name="native_tool_continuation",
+        body={
+            "messages": [
+                {"role": "user", "content": _NATIVE_CONTINUATION_PROMPT},
+            ],
+            "tools": [_WEATHER_TOOL],
+            "tool_choice": "required",
+            "parallel_tool_calls": False,
+        },
+        expect_finish=("stop",),
+        expect_content=True,
+    )
+    return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
+
+
 @dataclass(frozen=True, slots=True)
 class Observation:
     """What one request produced, before it is judged."""
@@ -404,6 +425,7 @@ class Observation:
     content_semantic_error: str | None = None
     finish_reason: str | None = None
     tool_calls: int = 0
+    tool_call_payloads: tuple[dict[str, Any], ...] = ()
     content_chars: int = 0
     request_id: str | None = None
     session_id: str | None = None
@@ -562,6 +584,7 @@ def _completion_observation(
     choice = choices[0] if isinstance(choices, list) and choices else {}
     message = choice.get("message", {}) if isinstance(choice, dict) else {}
     tool_calls = message.get("tool_calls") or []
+    tool_call_payloads = tuple(call for call in tool_calls if isinstance(call, dict))
     content = message.get("content") or ""
     error_type, error_message = _error_fields(body)
     semantic_error = _content_semantic_error(content) if isinstance(content, str) else None
@@ -573,6 +596,7 @@ def _completion_observation(
         content_semantic_error=semantic_error,
         finish_reason=choice.get("finish_reason") if isinstance(choice, dict) else None,
         tool_calls=len(tool_calls) if isinstance(tool_calls, list) else 0,
+        tool_call_payloads=tool_call_payloads,
         content_chars=len(content) if isinstance(content, str) else 0,
         request_id=headers.get("x-request-id"),
         session_id=session_id if isinstance(session_id, str) else None,
@@ -591,6 +615,7 @@ def _stream_observation(
     tool_calls = 0
     content_chars = 0
     content_parts: list[str] = []
+    streamed_tool_calls: dict[int, dict[str, Any]] = {}
     error_type: str | None = None
     error_message = ""
     stream_done = False
@@ -627,6 +652,31 @@ def _stream_observation(
             if calls:
                 tool_calls += len(calls)
                 ttft_ms = elapsed_ms if ttft_ms is None else ttft_ms
+                for fallback_index, call in enumerate(calls):
+                    if not isinstance(call, dict):
+                        continue
+                    index = call.get("index", fallback_index)
+                    if not isinstance(index, int) or isinstance(index, bool):
+                        index = fallback_index
+                    current = streamed_tool_calls.setdefault(
+                        index,
+                        {
+                            "id": "",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        },
+                    )
+                    if isinstance(call.get("id"), str):
+                        current["id"] = call["id"]
+                    if isinstance(call.get("type"), str):
+                        current["type"] = call["type"]
+                    function = call.get("function")
+                    if isinstance(function, dict):
+                        current_function = current["function"]
+                        if isinstance(function.get("name"), str):
+                            current_function["name"] = function["name"]
+                        if isinstance(function.get("arguments"), str):
+                            current_function["arguments"] += function["arguments"]
             finish_reason = choice.get("finish_reason") or finish_reason
     return Observation(
         status=status,
@@ -635,6 +685,9 @@ def _stream_observation(
         content_semantic_error=_content_semantic_error("".join(content_parts)),
         finish_reason=finish_reason,
         tool_calls=tool_calls,
+        tool_call_payloads=tuple(
+            streamed_tool_calls[index] for index in sorted(streamed_tool_calls)
+        ),
         content_chars=content_chars,
         request_id=headers.get("x-request-id"),
         session_id=session_id,
@@ -926,6 +979,133 @@ async def run_continuation_switch_matrix(
     return rows
 
 
+def _canonical_arguments(arguments: Any) -> str:
+    """Render tool call arguments so equal values compare equal."""
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return arguments.strip()
+    return json.dumps(arguments, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _tool_call_signatures(payloads: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    """What tool calls ask for, without the id the bridge mints per request.
+
+    A continuation gets fresh call ids, so comparing whole payloads would never
+    report a repeated call, which is the behavior this scenario is looking for.
+    """
+    signatures: list[tuple[str, str]] = []
+    for call in payloads:
+        function = call.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = str(function.get("name", ""))
+        signatures.append((name, _canonical_arguments(function.get("arguments"))))
+    return signatures
+
+
+async def run_native_continuation_matrix(
+    bridge: Bridge,
+    models: list[str],
+    plan: list[Scenario],
+    *,
+    on_row: RowCallback = None,
+    label: str | None = None,
+) -> list[dict[str, Any]]:
+    """Run a real native tool call, then continue it with its result."""
+    rows: list[dict[str, Any]] = []
+    for model in models:
+        for scenario in plan:
+            prime_scenario = _required_weather_scenario("native_continuation_prime")
+            prime_scenario = replace(
+                prime_scenario,
+                body={
+                    **prime_scenario.body,
+                    "parallel_tool_calls": False,
+                },
+                stream=scenario.stream,
+            )
+            prime = await bridge.run(model, prime_scenario)
+            prime_verdict, prime_detail = classify(prime_scenario, prime)
+            followup: Scenario | None = None
+            if prime_verdict == SUCCESS and prime.session_id is not None:
+                if len(prime.tool_call_payloads) != 1:
+                    observation = Observation(
+                        status=0,
+                        transport_error="native prime did not return exactly one tool call",
+                    )
+                else:
+                    call = prime.tool_call_payloads[0]
+                    call_id = call.get("id")
+                    function = call.get("function")
+                    if not isinstance(call_id, str) or not isinstance(function, dict):
+                        observation = Observation(
+                            status=0,
+                            transport_error="native prime returned a tool call without an id",
+                        )
+                    else:
+                        followup = replace(
+                            scenario,
+                            body={
+                                "messages": [
+                                    {
+                                        "role": "user",
+                                        "content": _NATIVE_CONTINUATION_PROMPT,
+                                    },
+                                    {
+                                        "role": "assistant",
+                                        "content": None,
+                                        "tool_calls": list(prime.tool_call_payloads),
+                                    },
+                                    {
+                                        "role": "tool",
+                                        "tool_call_id": call_id,
+                                        "content": '{"temperature_c":20}',
+                                    },
+                                ],
+                                "tools": [_WEATHER_TOOL],
+                                "parallel_tool_calls": False,
+                                "factory_droid_session_id": prime.session_id,
+                            },
+                        )
+                        observation = await bridge.run(model, followup)
+            elif prime_verdict != SUCCESS:
+                observation = Observation(
+                    status=prime.status,
+                    error_type=prime.error_type,
+                    error_message=prime.error_message,
+                    duration_ms=prime.duration_ms,
+                    stream_done=prime.stream_done,
+                    transport_error=(f"native continuation prime failed: {prime_detail}"),
+                )
+            else:
+                observation = Observation(
+                    status=0,
+                    transport_error="native continuation prime returned no session id",
+                )
+
+            record = row(model, scenario, observation, label=label)
+            record.update(
+                {
+                    "continuation_prime_status": prime.status,
+                    "continuation_prime_verdict": prime_verdict,
+                    "continuation_prime_detail": prime_detail,
+                    "continuation_prime_session_id": prime.session_id,
+                }
+            )
+            primed_calls = _tool_call_signatures(prime.tool_call_payloads)
+            if (
+                followup is not None
+                and primed_calls
+                and _tool_call_signatures(observation.tool_call_payloads) == primed_calls
+            ):
+                record["verdict"] = MODEL_BEHAVIOR
+                record["detail"] = "native continuation repeated the prime tool call"
+            _record(rows, record, on_row)
+    return rows
+
+
 def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate verdicts, blocking failures and latency for a run."""
     counts = dict.fromkeys(VERDICTS, 0)
@@ -1188,6 +1368,7 @@ class RunOptions:
     streaming: bool = True
     switch_settle_seconds: float = 5.0
     test_session_continuity: bool = False
+    test_native_session_continuity: bool = False
     out: Path | None = None
     label: str | None = None
 
@@ -1222,10 +1403,16 @@ async def _run_with_output(
             if options.test_session_continuity
             else []
         )
+        native_continuation_plan = (
+            native_continuation_scenarios(streaming=options.streaming)
+            if options.test_native_session_continuity
+            else []
+        )
         print(
             f"{len(models)} models x {len(plan)} scenarios + "
             f"{len(switch_plan)} warm switches + "
-            f"{len(continuation_plan)} continuation switches -> {out}",
+            f"{len(continuation_plan)} continuation switches + "
+            f"{len(native_continuation_plan)} native continuations -> {out}",
             file=sys.stderr,
         )
 
@@ -1260,6 +1447,15 @@ async def _run_with_output(
                 label=label,
             )
         )
+        rows.extend(
+            await run_native_continuation_matrix(
+                bridge,
+                models,
+                native_continuation_plan,
+                on_row=write,
+                label=label,
+            )
+        )
     print(render_report(rows))
     return 1 if summarize(rows)["blocking"] else 0
 
@@ -1275,6 +1471,7 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--no-stream", action="store_true")
     run_parser.add_argument("--switch-settle-seconds", type=float, default=5.0)
     run_parser.add_argument("--test-session-continuity", action="store_true")
+    run_parser.add_argument("--test-native-session-continuity", action="store_true")
     run_parser.add_argument("--out", type=Path, default=None)
     run_parser.add_argument("--label", type=_label_argument, default=None)
 
@@ -1307,6 +1504,7 @@ def main(argv: list[str] | None = None) -> int:
             streaming=not args.no_stream,
             switch_settle_seconds=args.switch_settle_seconds,
             test_session_continuity=args.test_session_continuity,
+            test_native_session_continuity=args.test_native_session_continuity,
             out=args.out,
             label=args.label,
         )

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -401,14 +401,7 @@ def native_continuation_scenarios(*, streaming: bool = True) -> list[Scenario]:
     """Continue a real tool turn and require an answer from its result."""
     scenario = Scenario(
         name="native_tool_continuation",
-        body={
-            "messages": [
-                {"role": "user", "content": _NATIVE_CONTINUATION_PROMPT},
-            ],
-            "tools": [_WEATHER_TOOL],
-            "tool_choice": "required",
-            "parallel_tool_calls": False,
-        },
+        body={},
         expect_finish=("stop",),
         expect_content=True,
     )
@@ -1070,7 +1063,7 @@ async def run_native_continuation_matrix(
                             },
                         )
                         observation = await bridge.run(model, followup)
-            elif prime_verdict != SUCCESS:
+            elif prime_verdict == BRIDGE_DEFECT:
                 observation = Observation(
                     status=prime.status,
                     error_type=prime.error_type,
@@ -1079,6 +1072,8 @@ async def run_native_continuation_matrix(
                     stream_done=prime.stream_done,
                     transport_error=(f"native continuation prime failed: {prime_detail}"),
                 )
+            elif prime_verdict != SUCCESS:
+                observation = prime
             else:
                 observation = Observation(
                     status=0,
@@ -1094,6 +1089,9 @@ async def run_native_continuation_matrix(
                     "continuation_prime_session_id": prime.session_id,
                 }
             )
+            if prime_verdict not in {SUCCESS, BRIDGE_DEFECT}:
+                record["verdict"] = prime_verdict
+                record["detail"] = f"native continuation prime failed: {prime_detail}"
             primed_calls = _tool_call_signatures(prime.tool_call_payloads)
             if (
                 followup is not None

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -58,6 +58,7 @@ def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleT
     plan = e2e.scenarios()
     switch_plan = e2e.switch_scenarios()
     continuation_plan = e2e.continuation_switch_scenarios()
+    native_plan = e2e.native_continuation_scenarios()
 
     streamed = {scenario.name for scenario in plan if scenario.stream}
     hostile = [scenario for scenario in plan if not scenario.per_model]
@@ -71,6 +72,7 @@ def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleT
     assert len(e2e.switch_scenarios(streaming=False)) == 1
     assert {scenario.stream for scenario in continuation_plan} == {False, True}
     assert len(e2e.continuation_switch_scenarios(streaming=False)) == 1
+    assert all(scenario.body == {} for scenario in native_plan)
 
 
 @pytest.mark.parametrize(
@@ -1042,6 +1044,70 @@ def test_tool_call_signatures_ignore_ids_and_unparsable_arguments(e2e: ModuleTyp
     assert e2e._tool_call_signatures(
         [{"function": {"name": "weather", "arguments": " oops "}}]
     ) == [("weather", "oops")]
+
+
+@pytest.mark.asyncio
+async def test_native_continuation_keeps_a_model_behavior_prime_non_blocking(
+    e2e: ModuleType,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "No tool call"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        rows = await e2e.run_native_continuation_matrix(
+            bridge,
+            ["m1"],
+            e2e.native_continuation_scenarios(streaming=False),
+        )
+
+    assert rows[0]["continuation_prime_verdict"] == e2e.MODEL_BEHAVIOR
+    assert rows[0]["verdict"] == e2e.MODEL_BEHAVIOR
+    assert e2e.summarize(rows)["blocking"] == []
+
+
+@pytest.mark.asyncio
+async def test_native_continuation_keeps_bridge_defect_prime_blocking(
+    e2e: ModuleType,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            502,
+            json={
+                "error": {
+                    "type": "factory_protocol_error",
+                    "message": "tool call payload never closed",
+                }
+            },
+        )
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        rows = await e2e.run_native_continuation_matrix(
+            bridge,
+            ["m1"],
+            e2e.native_continuation_scenarios(streaming=False),
+        )
+
+    assert rows[0]["continuation_prime_verdict"] == e2e.BRIDGE_DEFECT
+    assert rows[0]["verdict"] == e2e.BRIDGE_DEFECT
+    assert rows[0]["detail"] == (
+        "transport error: native continuation prime failed: "
+        "unexpected status 502 (factory_protocol_error)"
+    )
+    assert e2e.summarize(rows)["blocking"] == rows
 
 
 @pytest.mark.parametrize(

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -407,6 +407,7 @@ async def test_bridge_reads_a_json_completion(e2e: ModuleType) -> None:
     assert observation.status == 200
     assert observation.finish_reason == "tool_calls"
     assert observation.tool_calls == 1
+    assert observation.tool_call_payloads == ({"id": "call_1"},)
     assert observation.content_chars == 5
     assert observation.request_id == "req-1"
     assert observation.session_id == "session-json"
@@ -455,6 +456,13 @@ async def test_bridge_reads_a_streamed_completion(e2e: ModuleType) -> None:
     assert observation.stream_done is True
     assert observation.finish_reason == "tool_calls"
     assert observation.tool_calls == 1
+    assert observation.tool_call_payloads == (
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "", "arguments": ""},
+        },
+    )
     assert observation.content_chars == 2
     assert observation.ttft_ms is not None
     assert observation.session_id == "session-stream"
@@ -867,6 +875,173 @@ async def test_continuation_switch_matrix_skips_an_opted_out_plan(e2e: ModuleTyp
 
     assert rows == []
     assert seen == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_native_continuation_matrix_uses_the_real_tool_call(
+    e2e: ModuleType,
+    stream: bool,
+) -> None:
+    seen: list[dict[str, Any]] = []
+
+    def response(body: dict[str, Any]) -> httpx.Response:
+        if stream:
+            chunks = [
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": body["delta"],
+                            "finish_reason": body["finish_reason"],
+                        }
+                    ]
+                }
+            ]
+            payload = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+            return httpx.Response(
+                200,
+                text=payload + "data: [DONE]\n\n",
+                headers={"content-type": "text/event-stream"},
+            )
+        return httpx.Response(200, json=body["json"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        seen.append(body)
+        if "factory_droid_session_id" not in body:
+            call = {
+                "id": "call_weather",
+                "type": "function",
+                "function": {"name": "weather", "arguments": '{"city":"Gdansk"}'},
+            }
+            if stream:
+                return response(
+                    {
+                        "delta": {
+                            "factory_droid_session_id": "session-native",
+                            "tool_calls": [dict(call, index=0)],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                )
+            return response(
+                {
+                    "json": {
+                        "factory_droid_session_id": "session-native",
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [call],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                }
+            )
+        assert body["messages"][-1] == {
+            "role": "tool",
+            "tool_call_id": "call_weather",
+            "content": '{"temperature_c":20}',
+        }
+        if stream:
+            return response({"delta": {"content": "stop"}, "finish_reason": "stop"})
+        return response(
+            {
+                "json": {
+                    "choices": [
+                        {
+                            "message": {"role": "assistant", "content": "stop"},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            }
+        )
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        plan = [
+            scenario
+            for scenario in e2e.native_continuation_scenarios(streaming=True)
+            if scenario.stream is stream
+        ]
+        rows = await e2e.run_native_continuation_matrix(
+            bridge,
+            ["m1"],
+            plan,
+        )
+
+    assert len(rows) == 1
+    assert rows[0]["verdict"] == e2e.SUCCESS
+    assert len(seen) == 2
+    assert seen[1]["factory_droid_session_id"] == "session-native"
+
+
+@pytest.mark.asyncio
+async def test_native_continuation_matrix_flags_a_repeated_call_under_a_new_id(
+    e2e: ModuleType,
+) -> None:
+    """The bridge mints a fresh call id, so ids cannot be part of the compare."""
+    calls = iter(("call_prime", "call_repeat"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(
+            200,
+            json={
+                "factory_droid_session_id": "session-native",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": next(calls),
+                                    "type": "function",
+                                    "function": {
+                                        "name": "weather",
+                                        # Same request, spelled with different
+                                        # whitespace and key order.
+                                        "arguments": '{"city": "Gdansk"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        )
+
+    bridge = _bridge(e2e, handler)
+    async with bridge.client:
+        plan = e2e.native_continuation_scenarios(streaming=False)
+        rows = await e2e.run_native_continuation_matrix(bridge, ["m1"], plan, label="native")
+
+    assert len(rows) == 1
+    assert rows[0]["verdict"] == e2e.MODEL_BEHAVIOR
+    assert rows[0]["detail"] == "native continuation repeated the prime tool call"
+    assert rows[0]["label"] == "native"
+    assert e2e.artifact_label(rows) == "native"
+
+
+def test_tool_call_signatures_ignore_ids_and_unparsable_arguments(e2e: ModuleType) -> None:
+    same = e2e._tool_call_signatures(
+        [{"id": "call_1", "function": {"name": "weather", "arguments": '{"city":"Gdansk"}'}}]
+    )
+
+    assert same == e2e._tool_call_signatures(
+        [{"id": "call_2", "function": {"name": "weather", "arguments": '{ "city" : "Gdansk" }'}}]
+    )
+    assert e2e._tool_call_signatures([{"id": "call_3", "function": "not an object"}]) == []
+    assert e2e._tool_call_signatures(
+        [{"function": {"name": "weather", "arguments": " oops "}}]
+    ) == [("weather", "oops")]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add matrix coverage for continuation behavior with native tool sessions.
- Record the native session continuity case and document its current limitation.
- Keep the scenario available for replay and future SDK support.

Refs #85

## Validation

- Full test suite with 100 percent coverage
- Ruff and strict mypy
- OpenAPI validation, lock check, and package build
