### PR TITLE
feat(timeout): bound session initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ error types.
 | `FACTORY_DROID_PATH` | `droid` | Droid executable path |
 | `FACTORY_DROID_OPENAI_WORKDIR` | current directory | Droid working directory |
 | `FACTORY_DROID_OPENAI_TIMEOUT_SECONDS` | `600` | Maximum request duration |
+| `FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS` | `60` | Session connect, initialize/load, and tool-safety cap; maximum `60` for `droid-sdk==0.1.2` |
 | `FACTORY_DROID_OPENAI_BODY_TIMEOUT_SECONDS` | `30` | Maximum time to receive a request body |
 | `FACTORY_DROID_OPENAI_MAX_CONCURRENCY` | `2` | Concurrent Droid subprocesses |
 | `FACTORY_DROID_OPENAI_WARM_SESSIONS` | `MAX_CONCURRENCY + 1` | Pre-started Droid sessions kept ready (`0` disables) |

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -725,6 +725,7 @@ def create_app(
             workdir=resolved_settings.workdir,
             process_grace_seconds=resolved_settings.process_grace_seconds,
             cleanup_timeout_seconds=resolved_settings.cleanup_timeout_seconds,
+            session_init_timeout_seconds=resolved_settings.session_init_timeout_seconds,
             metrics=metrics,
             worktree=resolved_settings.worktree,
             append_system_prompt_file=resolved_settings.append_system_prompt_file,

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -21,6 +21,8 @@ DEFAULT_MODEL_ALIAS = "factory-droid"
 # so the bridge stops waiting this long after one arrives. Raise it when a
 # model spreads parallel calls over slower gaps than this.
 DEFAULT_TOOL_CALL_DRAIN_SECONDS = 0.5
+DEFAULT_SESSION_INIT_TIMEOUT_SECONDS = 60.0
+MAX_SESSION_INIT_TIMEOUT_SECONDS = 60.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +33,7 @@ class Settings:
     droid_path: str = "droid"
     workdir: Path = field(default_factory=Path.cwd)
     timeout_seconds: float = 600.0
+    session_init_timeout_seconds: float = DEFAULT_SESSION_INIT_TIMEOUT_SECONDS
     body_timeout_seconds: float = 30.0
     max_concurrency: int = 2
     max_queue_size: int = 8
@@ -89,6 +92,15 @@ class Settings:
     def __post_init__(self) -> None:
         if self.max_tool_calls > MAX_PACKED_CALLS:
             raise ValueError(f"max_tool_calls must be at most {MAX_PACKED_CALLS}")
+        if not math.isfinite(self.session_init_timeout_seconds) or (
+            self.session_init_timeout_seconds <= 0
+        ):
+            raise ValueError("session_init_timeout_seconds must be greater than zero and finite")
+        if self.session_init_timeout_seconds > MAX_SESSION_INIT_TIMEOUT_SECONDS:
+            raise ValueError(
+                "session_init_timeout_seconds must be at most "
+                f"{MAX_SESSION_INIT_TIMEOUT_SECONDS:g} seconds"
+            )
         # The warm pool keys sessions by this value, so it has to match the
         # normalized effort the request path sends to Droid, and a bad value
         # has to fail at construction instead of on every request.
@@ -122,6 +134,15 @@ class Settings:
             "FACTORY_DROID_OPENAI_TIMEOUT_SECONDS",
             default=600.0,
         )
+        session_init_timeout_seconds = _positive_float(
+            "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS",
+            default=DEFAULT_SESSION_INIT_TIMEOUT_SECONDS,
+        )
+        if session_init_timeout_seconds > MAX_SESSION_INIT_TIMEOUT_SECONDS:
+            raise ValueError(
+                "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS must be at most "
+                f"{MAX_SESSION_INIT_TIMEOUT_SECONDS:g} seconds for droid-sdk==0.1.2"
+            )
         body_timeout_seconds = _positive_float(
             "FACTORY_DROID_OPENAI_BODY_TIMEOUT_SECONDS",
             default=30.0,
@@ -296,6 +317,7 @@ class Settings:
             droid_path=os.getenv("FACTORY_DROID_PATH", "droid"),
             workdir=workdir.resolve(),
             timeout_seconds=timeout_seconds,
+            session_init_timeout_seconds=session_init_timeout_seconds,
             body_timeout_seconds=body_timeout_seconds,
             max_concurrency=max_concurrency,
             max_queue_size=max_queue_size,

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -22,6 +22,9 @@ DEFAULT_MODEL_ALIAS = "factory-droid"
 # model spreads parallel calls over slower gaps than this.
 DEFAULT_TOOL_CALL_DRAIN_SECONDS = 0.5
 DEFAULT_SESSION_INIT_TIMEOUT_SECONDS = 60.0
+# droid-sdk pins its own SESSION_INIT_TIMEOUT at 60 s, so a larger cap here
+# could never take effect. Revisit both values when the pinned droid-sdk
+# version in pyproject.toml changes.
 MAX_SESSION_INIT_TIMEOUT_SECONDS = 60.0
 
 

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, TypeVar
+from typing import Any, NoReturn, Protocol, TypeVar
 
 from droid_sdk import (
     AssistantTextDelta,
@@ -417,10 +417,6 @@ class DroidRunner:
                 return await operation()
         except (TimeoutError, DroidTimeoutError) as exc:
             raise self._session_init_timeout_error(started) from exc
-        except asyncio.CancelledError as exc:
-            if asyncio.get_running_loop().time() < phase_deadline:
-                raise
-            raise self._session_init_timeout_error(started) from exc
 
     def _session_init_timeout_error(self, started: float) -> RunnerError:
         elapsed = asyncio.get_running_loop().time() - started
@@ -434,6 +430,16 @@ class DroidRunner:
             status_code=504,
             error_type="factory_droid_timeout",
         )
+
+    def _handle_session_init_cancellation(
+        self,
+        started: float,
+        request_timeout: asyncio.Timeout,
+        exc: asyncio.CancelledError,
+    ) -> NoReturn:
+        if not request_timeout.expired():
+            raise exc
+        raise self._session_init_timeout_error(started) from exc
 
     async def discard(self, session: WarmSession) -> None:
         """Tear down a warm session that will not serve a turn."""
@@ -513,7 +519,7 @@ class DroidRunner:
         usage = Usage()
 
         try:
-            async with asyncio.timeout_at(deadline):
+            async with asyncio.timeout_at(deadline) as request_timeout:
                 if warm is None:
 
                     async def initialize() -> None:
@@ -563,7 +569,10 @@ class DroidRunner:
                             ),
                         )
 
-                    await self._run_session_init(deadline, initialize)
+                    try:
+                        await self._run_session_init(deadline, initialize)
+                    except asyncio.CancelledError as exc:
+                        self._handle_session_init_cancellation(started, request_timeout, exc)
                 else:
                     await self._retune(warm, request.session_key())
                 session_timeline = current_timeline()
@@ -893,19 +902,21 @@ class DroidRunner:
         client.set_ask_user_handler(
             lambda _params: {"cancelled": True, "answers": []},
         )
-        started = asyncio.get_running_loop().time()
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        deadline = started + timeout_seconds
         try:
-            async with asyncio.timeout(timeout_seconds):
+            async with asyncio.timeout_at(deadline) as request_timeout:
 
                 async def initialize() -> None:
                     await client.connect()
                     if init_operation is not None:
                         await init_operation(client)
 
-                await self._run_session_init(
-                    asyncio.get_running_loop().time() + timeout_seconds,
-                    initialize,
-                )
+                try:
+                    await self._run_session_init(deadline, initialize)
+                except asyncio.CancelledError as exc:
+                    self._handle_session_init_cancellation(started, request_timeout, exc)
                 return await operation(client)
         except (TimeoutError, DroidTimeoutError) as exc:
             raise RunnerError(

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NoReturn, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 from droid_sdk import (
     AssistantTextDelta,
@@ -408,6 +408,8 @@ class DroidRunner:
         self,
         deadline: float,
         operation: Callable[[], Awaitable[OperationResult]],
+        *,
+        request_timeout: asyncio.Timeout | None = None,
     ) -> OperationResult:
         """Run session setup under its own deadline inside the request budget."""
         started = asyncio.get_running_loop().time()
@@ -416,6 +418,14 @@ class DroidRunner:
             async with asyncio.timeout_at(phase_deadline):
                 return await operation()
         except (TimeoutError, DroidTimeoutError) as exc:
+            raise self._session_init_timeout_error(started) from exc
+        except asyncio.CancelledError as exc:
+            # A request deadline that lands on the same instant as the phase
+            # deadline cancels this scope before the phase timer converts it,
+            # and the phase still names where the budget went. A cancel from
+            # anywhere else, such as a client disconnect, has to stay one.
+            if request_timeout is None or not request_timeout.expired():
+                raise
             raise self._session_init_timeout_error(started) from exc
 
     def _session_init_timeout_error(self, started: float) -> RunnerError:
@@ -430,16 +440,6 @@ class DroidRunner:
             status_code=504,
             error_type="factory_droid_timeout",
         )
-
-    def _handle_session_init_cancellation(
-        self,
-        started: float,
-        request_timeout: asyncio.Timeout,
-        exc: asyncio.CancelledError,
-    ) -> NoReturn:
-        if not request_timeout.expired():
-            raise exc
-        raise self._session_init_timeout_error(started) from exc
 
     async def discard(self, session: WarmSession) -> None:
         """Tear down a warm session that will not serve a turn."""
@@ -569,10 +569,11 @@ class DroidRunner:
                             ),
                         )
 
-                    try:
-                        await self._run_session_init(deadline, initialize)
-                    except asyncio.CancelledError as exc:
-                        self._handle_session_init_cancellation(started, request_timeout, exc)
+                    await self._run_session_init(
+                        deadline,
+                        initialize,
+                        request_timeout=request_timeout,
+                    )
                 else:
                     await self._retune(warm, request.session_key())
                 session_timeline = current_timeline()
@@ -913,10 +914,11 @@ class DroidRunner:
                     if init_operation is not None:
                         await init_operation(client)
 
-                try:
-                    await self._run_session_init(deadline, initialize)
-                except asyncio.CancelledError as exc:
-                    self._handle_session_init_cancellation(started, request_timeout, exc)
+                await self._run_session_init(
+                    deadline,
+                    initialize,
+                    request_timeout=request_timeout,
+                )
                 return await operation(client)
         except (TimeoutError, DroidTimeoutError) as exc:
             raise RunnerError(

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -33,7 +33,10 @@ from droid_sdk.schemas.enums import (
     ReasoningEffort,
 )
 
-from factory_droid_openai.config import DEFAULT_MODEL_ALIAS
+from factory_droid_openai.config import (
+    DEFAULT_MODEL_ALIAS,
+    DEFAULT_SESSION_INIT_TIMEOUT_SECONDS,
+)
 from factory_droid_openai.dialects import TOOL_CALL_CLOSE, TOOL_CALL_OPEN
 from factory_droid_openai.droid_rpc import (
     CompactionResult,
@@ -338,6 +341,7 @@ class DroidRunner:
         client_factory: ClientFactory | None = None,
         process_grace_seconds: float = 2.0,
         cleanup_timeout_seconds: float = 4.0,
+        session_init_timeout_seconds: float = DEFAULT_SESSION_INIT_TIMEOUT_SECONDS,
         metrics: RunnerMetrics | None = None,
         worktree: str | None = None,
         append_system_prompt_file: Path | None = None,
@@ -349,6 +353,7 @@ class DroidRunner:
         self._client_factory = client_factory
         self._process_grace_seconds = process_grace_seconds
         self._cleanup_timeout_seconds = cleanup_timeout_seconds
+        self._session_init_timeout_seconds = session_init_timeout_seconds
         self._metrics = metrics
         self._rpc = rpc_extension or DroidRpcExtension()
         self._reaper = reaper
@@ -366,7 +371,8 @@ class DroidRunner:
         )
         started = time.perf_counter()
         try:
-            async with asyncio.timeout(timeout_seconds):
+
+            async def initialize() -> None:
                 await client.connect()
                 await client.initialize_session(
                     machine_id="factory-droid-openai",
@@ -380,6 +386,11 @@ class DroidRunner:
                     enabled_tool_ids=[],
                 )
                 await self._rpc.disable_native_tools(client)
+
+            await self._run_session_init(
+                asyncio.get_running_loop().time() + timeout_seconds,
+                initialize,
+            )
         except BaseException:
             await self.discard(WarmSession(key, client, transport, None, started))
             raise
@@ -391,6 +402,37 @@ class DroidRunner:
             transport=transport,
             session_id=client.session_id,
             created_at=asyncio.get_running_loop().time(),
+        )
+
+    async def _run_session_init(
+        self,
+        deadline: float,
+        operation: Callable[[], Awaitable[OperationResult]],
+    ) -> OperationResult:
+        """Run session setup under its own deadline inside the request budget."""
+        started = asyncio.get_running_loop().time()
+        phase_deadline = min(deadline, started + self._session_init_timeout_seconds)
+        try:
+            async with asyncio.timeout_at(phase_deadline):
+                return await operation()
+        except (TimeoutError, DroidTimeoutError) as exc:
+            raise self._session_init_timeout_error(started) from exc
+        except asyncio.CancelledError as exc:
+            if asyncio.get_running_loop().time() < phase_deadline:
+                raise
+            raise self._session_init_timeout_error(started) from exc
+
+    def _session_init_timeout_error(self, started: float) -> RunnerError:
+        elapsed = asyncio.get_running_loop().time() - started
+        log_warning(
+            "droid.timeout",
+            phase="session_init",
+            elapsed_s=round(elapsed, 1),
+        )
+        return RunnerError(
+            f"Factory Droid session initialization timed out after {elapsed:.1f} seconds.",
+            status_code=504,
+            error_type="factory_droid_timeout",
         )
 
     async def discard(self, session: WarmSession) -> None:
@@ -473,50 +515,55 @@ class DroidRunner:
         try:
             async with asyncio.timeout_at(deadline):
                 if warm is None:
-                    startup_started = time.perf_counter()
-                    try:
-                        await client.connect()
-                    finally:
-                        startup_seconds = time.perf_counter() - startup_started
-                        if self._metrics is not None:
-                            self._metrics.observe_droid_startup(startup_seconds)
-                        timeline = current_timeline()
-                        startup_ms = (
-                            timeline.observe("droid_startup_ms", startup_seconds)
-                            if timeline is not None
-                            else None
+
+                    async def initialize() -> None:
+                        nonlocal initialized
+                        startup_started = time.perf_counter()
+                        try:
+                            await client.connect()
+                        finally:
+                            startup_seconds = time.perf_counter() - startup_started
+                            if self._metrics is not None:
+                                self._metrics.observe_droid_startup(startup_seconds)
+                            timeline = current_timeline()
+                            startup_ms = (
+                                timeline.observe("droid_startup_ms", startup_seconds)
+                                if timeline is not None
+                                else None
+                            )
+                            log_debug(
+                                "droid.connected",
+                                droid=self._droid_path,
+                                droid_startup_ms=startup_ms,
+                            )
+                        if request.session_id is not None:
+                            # Continuation: reuse the stored Droid session so only
+                            # the new turn is sent instead of the full transcript.
+                            await client.load_session(
+                                session_id=request.session_id,
+                                mcp_servers=mcp_servers,
+                            )
+                        else:
+                            await client.initialize_session(
+                                machine_id="factory-droid-openai",
+                                cwd=str(self._workdir),
+                                mcp_servers=mcp_servers,
+                                model_id=_resolve_model_id(request.model, request.model_alias),
+                                reasoning_effort=reasoning_effort,
+                                interaction_mode=DroidInteractionMode.Auto,
+                                autonomy_level=AutonomyLevel.Off,
+                                skip_permissions_unsafe=False,
+                                enabled_tool_ids=[],
+                            )
+                        initialized = True
+                        await self._rpc.disable_native_tools(
+                            client,
+                            keep_tool_prefix=(
+                                None if request.native_tools is None else MCP_TOOL_ID_PREFIX
+                            ),
                         )
-                        log_debug(
-                            "droid.connected",
-                            droid=self._droid_path,
-                            droid_startup_ms=startup_ms,
-                        )
-                    if request.session_id is not None:
-                        # Continuation: reuse the stored Droid session so only
-                        # the new turn is sent instead of the whole transcript.
-                        await client.load_session(
-                            session_id=request.session_id,
-                            mcp_servers=mcp_servers,
-                        )
-                    else:
-                        await client.initialize_session(
-                            machine_id="factory-droid-openai",
-                            cwd=str(self._workdir),
-                            mcp_servers=mcp_servers,
-                            model_id=_resolve_model_id(request.model, request.model_alias),
-                            reasoning_effort=reasoning_effort,
-                            interaction_mode=DroidInteractionMode.Auto,
-                            autonomy_level=AutonomyLevel.Off,
-                            skip_permissions_unsafe=False,
-                            enabled_tool_ids=[],
-                        )
-                    initialized = True
-                    await self._rpc.disable_native_tools(
-                        client,
-                        keep_tool_prefix=(
-                            None if request.native_tools is None else MCP_TOOL_ID_PREFIX
-                        ),
-                    )
+
+                    await self._run_session_init(deadline, initialize)
                 else:
                     await self._retune(warm, request.session_key())
                 session_timeline = current_timeline()
@@ -696,7 +743,9 @@ class DroidRunner:
                     raise
 
     async def list_models(self, *, timeout_seconds: float) -> tuple[DroidModel, ...]:
-        async def operation(client: DroidClient) -> tuple[DroidModel, ...]:
+        models: list[Any] = []
+
+        async def initialize(client: DroidClient) -> None:
             result = await client.initialize_session(
                 machine_id="factory-droid-openai-models",
                 cwd=str(self._workdir),
@@ -706,7 +755,10 @@ class DroidRunner:
                 skip_permissions_unsafe=False,
                 enabled_tool_ids=[],
             )
-            models = result.available_models or []
+
+            models.extend(result.available_models or [])
+
+        async def operation(client: DroidClient) -> tuple[DroidModel, ...]:
             await self._rpc.close_session(client, reason="clear")
             return tuple(
                 DroidModel(
@@ -726,6 +778,7 @@ class DroidRunner:
         return await self._session_operation(
             operation,
             timeout_seconds=timeout_seconds,
+            init_operation=initialize,
         )
 
     async def get_context(
@@ -813,18 +866,18 @@ class DroidRunner:
         timeout_seconds: float,
         disable_tools: bool = True,
     ) -> OperationResult:
-        async def loaded(client: DroidClient) -> OperationResult:
+        async def initialize(client: DroidClient) -> None:
             await client.load_session(session_id=session_id, mcp_servers=[])
             # Metadata-only operations never run a model turn, so they neither
             # need the tool guard nor should they rewrite session settings.
             if disable_tools:
                 await self._rpc.disable_native_tools(client)
-            return await operation(client)
 
         return await self._session_operation(
-            loaded,
+            operation,
             timeout_seconds=timeout_seconds,
             session_id=session_id,
+            init_operation=initialize,
         )
 
     async def _session_operation(
@@ -833,6 +886,7 @@ class DroidRunner:
         *,
         timeout_seconds: float,
         session_id: str | None = None,
+        init_operation: Callable[[DroidClient], Awaitable[None]] | None = None,
     ) -> OperationResult:
         client, transport = self._new_client()
         client.set_permission_handler(lambda _params: "cancel")
@@ -842,7 +896,16 @@ class DroidRunner:
         started = asyncio.get_running_loop().time()
         try:
             async with asyncio.timeout(timeout_seconds):
-                await client.connect()
+
+                async def initialize() -> None:
+                    await client.connect()
+                    if init_operation is not None:
+                        await init_operation(client)
+
+                await self._run_session_init(
+                    asyncio.get_running_loop().time() + timeout_seconds,
+                    initialize,
+                )
                 return await operation(client)
         except (TimeoutError, DroidTimeoutError) as exc:
             raise RunnerError(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_PATH",
     "FACTORY_DROID_OPENAI_WORKDIR",
     "FACTORY_DROID_OPENAI_TIMEOUT_SECONDS",
+    "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS",
     "FACTORY_DROID_OPENAI_BODY_TIMEOUT_SECONDS",
     "FACTORY_DROID_OPENAI_MAX_CONCURRENCY",
     "FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE",
@@ -140,6 +141,23 @@ def test_settings_normalize_reasoning_effort_on_construction() -> None:
         Settings(reasoning_effort="extreme")
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (0.0, "greater than zero"),
+        (float("inf"), "greater than zero"),
+        (61.0, "at most 60"),
+    ],
+)
+def test_settings_rejects_invalid_session_init_timeout(
+    tmp_path: Path,
+    value: float,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        Settings(workdir=tmp_path, session_init_timeout_seconds=value)
+
+
 def test_warm_session_count_tracks_max_concurrency_unless_set(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -221,6 +239,7 @@ def test_settings_from_env_reads_all_overrides(
     monkeypatch.setenv("FACTORY_DROID_PATH", "/usr/local/bin/droid")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_WORKDIR", str(workdir))
     monkeypatch.setenv("FACTORY_DROID_OPENAI_TIMEOUT_SECONDS", "45.5")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS", "12.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_BODY_TIMEOUT_SECONDS", "12.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_CONCURRENCY", "3")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE", "12")
@@ -250,6 +269,7 @@ def test_settings_from_env_reads_all_overrides(
         droid_path="/usr/local/bin/droid",
         workdir=workdir,
         timeout_seconds=45.5,
+        session_init_timeout_seconds=12.5,
         body_timeout_seconds=12.5,
         max_concurrency=3,
         max_queue_size=12,
@@ -278,6 +298,26 @@ def test_settings_from_env_reads_all_overrides(
         ("FACTORY_DROID_OPENAI_TIMEOUT_SECONDS", "invalid", "must be a number"),
         ("FACTORY_DROID_OPENAI_TIMEOUT_SECONDS", "0", "must be greater than zero"),
         ("FACTORY_DROID_OPENAI_TIMEOUT_SECONDS", "inf", "must be greater than zero"),
+        (
+            "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS",
+            "invalid",
+            "must be a number",
+        ),
+        (
+            "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS",
+            "0",
+            "must be greater than zero",
+        ),
+        (
+            "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS",
+            "nan",
+            "must be greater than zero",
+        ),
+        (
+            "FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS",
+            "61",
+            "must be at most 60",
+        ),
         ("FACTORY_DROID_OPENAI_BODY_TIMEOUT_SECONDS", "nan", "must be greater than zero"),
         ("FACTORY_DROID_OPENAI_MAX_CONCURRENCY", "invalid", "must be an integer"),
         ("FACTORY_DROID_OPENAI_MAX_CONCURRENCY", "0", "must be greater than zero"),

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -7,7 +7,7 @@ import pytest
 
 from factory_droid_openai.metrics import BridgeMetrics
 from factory_droid_openai.pool import BackgroundReaper, PoolMetrics, WarmSessionPool
-from factory_droid_openai.runner import SessionKey, WarmSession
+from factory_droid_openai.runner import RunnerError, SessionKey, WarmSession
 
 if TYPE_CHECKING:
     from factory_droid_openai.pool import RunnerFactory
@@ -227,6 +227,32 @@ async def test_pool_records_warm_failures_and_keeps_running() -> None:
     await asyncio.sleep(0.05)
 
     assert "factory_droid_openai_warm_session_failures_total 1" in metrics.render()
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_drops_a_key_after_session_init_timeout() -> None:
+    class InitTimeoutRunner(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attempts = 0
+
+        async def warm(self, key: SessionKey, *, timeout_seconds: float) -> WarmSession:
+            del key, timeout_seconds
+            self.attempts += 1
+            raise RunnerError(
+                "Factory Droid session initialization timed out after 0.1 seconds.",
+                status_code=504,
+                error_type="factory_droid_timeout",
+            )
+
+    runner = InitTimeoutRunner()
+    pool = _pool(runner, retry_seconds=0.01)
+    pool.start(initial_key=KEY)
+    await asyncio.sleep(0.05)
+
+    assert runner.attempts == 1
+    assert pool.acquire(KEY) is None
     await pool.aclose()
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -502,6 +502,83 @@ async def test_runner_times_out(tmp_path: Path) -> None:
     assert client.closed is True
 
 
+@pytest.mark.asyncio
+async def test_runner_caps_session_initialization_and_closes_a_hanging_client(
+    tmp_path: Path,
+) -> None:
+    class HangingInitClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> None:
+            del kwargs
+            await asyncio.Event().wait()
+
+    client = HangingInitClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+        session_init_timeout_seconds=0.01,
+    )
+
+    with pytest.raises(RunnerError, match="session initialization timed out") as error:
+        await _collect(runner, _request(timeout_seconds=1.0))
+
+    assert error.value.status_code == 504
+    assert error.value.error_type == "factory_droid_timeout"
+    assert client.closed is True
+    assert client.interrupted is False
+
+
+@pytest.mark.asyncio
+async def test_runner_caps_continuation_load_session(tmp_path: Path) -> None:
+    class HangingLoadClient(FakeClient):
+        async def load_session(
+            self,
+            *,
+            session_id: str,
+            mcp_servers: list[dict[str, Any]] | None = None,
+        ) -> None:
+            del session_id, mcp_servers
+            await asyncio.Event().wait()
+
+    client = HangingLoadClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+        session_init_timeout_seconds=0.01,
+    )
+
+    with pytest.raises(RunnerError, match="session initialization timed out") as error:
+        await _collect(runner, _request(timeout_seconds=1.0, session_id="session-1"))
+
+    assert error.value.status_code == 504
+    assert error.value.error_type == "factory_droid_timeout"
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_request_deadline_wins_over_session_init_cap(tmp_path: Path) -> None:
+    class HangingInitClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> None:
+            del kwargs
+            await asyncio.Event().wait()
+
+    client = HangingInitClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+        session_init_timeout_seconds=1.0,
+    )
+    deadline = asyncio.get_running_loop().time() + 0.01
+
+    with pytest.raises(RunnerError, match="session initialization timed out") as error:
+        await _collect(runner, _request(timeout_seconds=1.0, deadline=deadline))
+
+    assert error.value.status_code == 504
+    assert client.closed is True
+
+
 class SdkTimeoutClient(FakeClient):
     async def connect(self) -> None:
         raise DroidTimeoutError("SDK request timed out")
@@ -1152,6 +1229,31 @@ async def test_runner_discovers_models_from_session_initialization(
 
 
 @pytest.mark.asyncio
+async def test_model_discovery_uses_the_session_init_timeout(
+    tmp_path: Path,
+) -> None:
+    class HangingModelClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> Any:
+            del kwargs
+            await asyncio.Event().wait()
+
+    client = HangingModelClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+        session_init_timeout_seconds=0.01,
+    )
+
+    with pytest.raises(RunnerError, match="session initialization timed out") as error:
+        await runner.list_models(timeout_seconds=1.0)
+
+    assert error.value.status_code == 504
+    assert error.value.error_type == "factory_droid_timeout"
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
 async def test_runner_exposes_guarded_session_rpc_operations(tmp_path: Path) -> None:
     class SessionOperationClient(FakeClient):
         async def send_request(
@@ -1287,6 +1389,29 @@ async def test_session_operations_time_out_on_a_slow_droid(tmp_path: Path) -> No
     with pytest.raises(RunnerError, match="timed out"):
         await runner.close_session("session", timeout_seconds=0.01)
 
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_session_operation_without_initialization_maps_outer_timeout(
+    tmp_path: Path,
+) -> None:
+    client = FakeClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    async def operation(_client: DroidClient) -> str:
+        await asyncio.sleep(1)
+        return "done"
+
+    with pytest.raises(RunnerError, match="Factory Droid timed out after") as error:
+        await runner._session_operation(operation, timeout_seconds=0.01)
+
+    assert error.value.status_code == 504
+    assert error.value.error_type == "factory_droid_timeout"
     assert client.closed is True
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -529,6 +529,36 @@ async def test_runner_caps_session_initialization_and_closes_a_hanging_client(
 
 
 @pytest.mark.asyncio
+async def test_runner_preserves_external_cancellation_during_session_init(
+    tmp_path: Path,
+) -> None:
+    class CancelledInitClient(FakeClient):
+        async def initialize_session(self, **kwargs: Any) -> None:
+            del kwargs
+            loop = asyncio.get_running_loop()
+            end = loop.time() + 0.03
+            while loop.time() < end:
+                pass
+            task = asyncio.current_task()
+            assert task is not None
+            task.cancel()
+            await asyncio.sleep(0)
+
+    client = CancelledInitClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+        session_init_timeout_seconds=0.01,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await _collect(runner, _request(timeout_seconds=1.0))
+
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
 async def test_runner_caps_continuation_load_session(tmp_path: Path) -> None:
     class HangingLoadClient(FakeClient):
         async def load_session(
@@ -1386,9 +1416,10 @@ async def test_session_operations_time_out_on_a_slow_droid(tmp_path: Path) -> No
         client_factory=cast("Any", lambda _path, _cwd: client),
     )
 
-    with pytest.raises(RunnerError, match="timed out"):
+    with pytest.raises(RunnerError, match="session initialization timed out") as error:
         await runner.close_session("session", timeout_seconds=0.01)
 
+    assert error.value.error_type == "factory_droid_timeout"
     assert client.closed is True
 
 


### PR DESCRIPTION
## Summary

- Add a validated session initialization timeout configuration.
- Bound connect, initialize, native-tool setup, warm sessions, discovery, and guarded operations.
- Map timeout phases to the documented 504 error response.
- Cover timeout cleanup and phase-specific diagnostics.

Closes #86

## Validation

- Full test suite with 100 percent coverage
- Ruff and strict mypy
- OpenAPI validation, lock check, and package build
