### PR TITLE
feat(matrix): label e2e artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,8 @@ export FACTORY_HOME_OVERRIDE="$PWD/traces/profile"
 env -u FACTORY_APPEND_SYSTEM_PROMPT uv run factory-droid-openai --port 8798 &
 FACTORY_DROID_OPENAI_NATIVE_TOOL_CALLS=true \
   env -u FACTORY_APPEND_SYSTEM_PROMPT uv run factory-droid-openai --port 8799 &
-uv run python scripts/e2e_matrix.py run --base-url http://127.0.0.1:8798 --out traces/text.jsonl
-uv run python scripts/e2e_matrix.py run --base-url http://127.0.0.1:8799 --out traces/native.jsonl
+uv run python scripts/e2e_matrix.py run --label text --base-url http://127.0.0.1:8798 --out traces/text.jsonl
+uv run python scripts/e2e_matrix.py run --label native --base-url http://127.0.0.1:8799 --out traces/native.jsonl
 uv run python scripts/e2e_matrix.py compare traces/text.jsonl traces/native.jsonl
 ```
 

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -4,7 +4,7 @@ Runs a fixed scenario set against every model the bridge lists, classifies each
 result, and writes one JSONL row per request. Results stay out of the
 repository: they carry model output and account-specific denials.
 
-    uv run python scripts/e2e_matrix.py run --out traces/run-a.jsonl
+    uv run python scripts/e2e_matrix.py run --label text --out traces/run-a.jsonl
     uv run python scripts/e2e_matrix.py report traces/run-a.jsonl
     uv run python scripts/e2e_matrix.py compare traces/run-a.jsonl traces/run-b.jsonl
 
@@ -23,7 +23,9 @@ import re
 import statistics
 import sys
 import time
-from collections.abc import Callable
+import unicodedata
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -33,7 +35,18 @@ import httpx
 
 from factory_droid_openai.dialects import strip_code_fence
 
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:
+    _msvcrt = None
+
 DEFAULT_BASE_URL = "http://127.0.0.1:8787"
+_MAX_LABEL_LENGTH = 128
 RowCallback = Callable[[dict[str, Any]], None] | None
 _WEATHER_TOOL: dict[str, Any] = {
     "type": "function",
@@ -346,6 +359,27 @@ def continuation_switch_scenarios(*, streaming: bool = True) -> list[Scenario]:
         expect_error_contains="session settings do not match",
     )
     return [scenario, replace(scenario, stream=True)] if streaming else [scenario]
+
+
+def normalize_label(value: str) -> str:
+    """Trim and validate a label that identifies one matrix artifact."""
+    label = value.strip()
+    if not label:
+        raise ValueError("matrix label must not be empty")
+    if any(char in "\n\r\u2028\u2029" for char in label):
+        raise ValueError("matrix label must not contain newlines or line separators")
+    if any(unicodedata.category(char) == "Cc" for char in label):
+        raise ValueError("matrix label must not contain control characters")
+    if len(label) > _MAX_LABEL_LENGTH:
+        raise ValueError(f"matrix label must be at most {_MAX_LABEL_LENGTH} characters")
+    return label
+
+
+def _label_argument(value: str) -> str:
+    try:
+        return normalize_label(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 @dataclass(frozen=True, slots=True)
@@ -704,10 +738,16 @@ class Bridge:
         )
 
 
-def row(model: str, scenario: Scenario, observation: Observation) -> dict[str, Any]:
+def row(
+    model: str,
+    scenario: Scenario,
+    observation: Observation,
+    *,
+    label: str | None = None,
+) -> dict[str, Any]:
     """One JSONL record: the request, what came back, and the verdict."""
     verdict, detail = classify(scenario, observation)
-    return {
+    record: dict[str, Any] = {
         "ts": datetime.now(UTC).isoformat(),
         "model": model,
         "scenario": scenario.name,
@@ -726,6 +766,9 @@ def row(model: str, scenario: Scenario, observation: Observation) -> dict[str, A
         "verdict": verdict,
         "detail": detail,
     }
+    if label is not None:
+        record["label"] = normalize_label(label)
+    return record
 
 
 def _transition_row(
@@ -734,8 +777,10 @@ def _transition_row(
     scenario: Scenario,
     observation: Observation,
     prime: Observation,
+    *,
+    label: str | None = None,
 ) -> dict[str, Any]:
-    record = row(target, scenario, observation)
+    record = row(target, scenario, observation, label=label)
     prime_verdict, prime_detail = classify(_SWITCH_PRIME, prime)
     record.update(
         {
@@ -775,6 +820,7 @@ async def run_matrix(
     *,
     concurrency: int,
     on_row: RowCallback = None,
+    label: str | None = None,
 ) -> list[dict[str, Any]]:
     """Run every applicable (model, scenario) pair and return the rows."""
     jobs: list[tuple[str, Scenario]] = []
@@ -789,7 +835,7 @@ async def run_matrix(
     async def execute(model: str, scenario: Scenario) -> None:
         async with semaphore:
             observation = await bridge.run(model, scenario)
-        record = row(model, scenario, observation)
+        record = row(model, scenario, observation, label=label)
         _record(rows, record, on_row)
 
     await asyncio.gather(*(execute(model, scenario) for model, scenario in jobs))
@@ -803,6 +849,7 @@ async def run_switch_matrix(
     *,
     settle_seconds: float,
     on_row: RowCallback = None,
+    label: str | None = None,
 ) -> list[dict[str, Any]]:
     """Run ordered model transitions against one bridge warm pool."""
     rows: list[dict[str, Any]] = []
@@ -811,7 +858,14 @@ async def run_switch_matrix(
             prime = await bridge.run(source, _SWITCH_PRIME)
             await asyncio.sleep(max(0.0, settle_seconds))
             observation = await bridge.run(target, scenario)
-            record = _transition_row(source, target, scenario, observation, prime)
+            record = _transition_row(
+                source,
+                target,
+                scenario,
+                observation,
+                prime,
+                label=label,
+            )
             _record(rows, record, on_row)
     return rows
 
@@ -822,6 +876,7 @@ async def run_continuation_switch_matrix(
     plan: list[Scenario],
     *,
     on_row: RowCallback = None,
+    label: str | None = None,
 ) -> list[dict[str, Any]]:
     """Attempt model changes on bridge-created continuation sessions."""
     rows: list[dict[str, Any]] = []
@@ -845,7 +900,14 @@ async def run_continuation_switch_matrix(
                     },
                 )
                 observation = await bridge.run(target, continued)
-            record = _transition_row(source, target, scenario, observation, prime)
+            record = _transition_row(
+                source,
+                target,
+                scenario,
+                observation,
+                prime,
+                label=label,
+            )
             _record(rows, record, on_row)
     return rows
 
@@ -868,12 +930,81 @@ def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _display_label(label: str | None) -> str:
+    return label if label is not None else "unlabeled legacy artifact"
+
+
+def artifact_label(rows: list[dict[str, Any]]) -> str | None:
+    """Return one artifact label, rejecting mixed or malformed rows."""
+    labels: set[str | None] = set()
+    for index, record in enumerate(rows):
+        raw = record.get("label")
+        if raw is None:
+            labels.add(None)
+            continue
+        if not isinstance(raw, str):
+            raise ValueError(f"matrix row {index} label must be a string")
+        label = normalize_label(raw)
+        if label != raw:
+            raise ValueError(f"matrix row {index} label is not normalized")
+        labels.add(label)
+    if len(labels) > 1:
+        raise ValueError("matrix artifact contains mixed labeled and unlabeled rows")
+    return next(iter(labels), None)
+
+
+def _validate_append_target(path: Path, label: str | None) -> None:
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    rows = load_rows(path)
+    if not rows:
+        return
+    existing_label = artifact_label(rows)
+    if existing_label != label:
+        raise ValueError(
+            f"cannot append {_display_label(label)!r} run to "
+            f"{_display_label(existing_label)!r} artifact"
+        )
+
+
+@contextmanager
+def _locked_output(path: Path, label: str | None) -> Iterator[Any]:
+    if _fcntl is not None:
+        with path.open("a+", encoding="utf-8") as handle:
+            _fcntl.flock(handle.fileno(), _fcntl.LOCK_EX)
+            try:
+                _validate_append_target(path, label)
+                handle.seek(0, os.SEEK_END)
+                yield handle
+            finally:
+                _fcntl.flock(handle.fileno(), _fcntl.LOCK_UN)
+        return
+    if _msvcrt is None:
+        raise RuntimeError("matrix output locking is not supported on this platform")
+    lock_path = path.resolve().with_suffix(path.suffix + ".lock")
+    with lock_path.open("a+b") as lock:
+        lock.seek(0)
+        lock.write(b"\0")
+        lock.flush()
+        lock.seek(0)
+        _msvcrt.locking(lock.fileno(), _msvcrt.LK_LOCK, 1)
+        try:
+            _validate_append_target(path, label)
+            with path.open("a", encoding="utf-8") as handle:
+                yield handle
+        finally:
+            lock.seek(0)
+            _msvcrt.locking(lock.fileno(), _msvcrt.LK_UNLCK, 1)
+
+
 def render_report(rows: list[dict[str, Any]]) -> str:
     """Markdown summary, generated so no report is ever written by hand."""
+    label = artifact_label(rows)
     summary = summarize(rows)
     lines = [
         "# Bridge e2e run",
         "",
+        f"- Label: {_display_label(label)}",
         f"- Requests: {summary['total']}",
         f"- Pass rate: {summary['pass_rate']:.1%}",
         f"- Median completed latency: {summary['median_ms']} ms",
@@ -938,8 +1069,17 @@ def _key(record: dict[str, Any]) -> tuple[str, str, str, bool]:
     )
 
 
-def compare(before: list[dict[str, Any]], after: list[dict[str, Any]]) -> dict[str, Any]:
+def compare(
+    before: list[dict[str, Any]],
+    after: list[dict[str, Any]],
+    *,
+    allow_same_label: bool = False,
+) -> dict[str, Any]:
     """Verdict transitions and latency delta between two runs."""
+    before_label = artifact_label(before)
+    after_label = artifact_label(after)
+    if not allow_same_label and before_label is not None and before_label == after_label:
+        raise ValueError(f"cannot compare two artifacts labeled {before_label!r}")
     left = {_key(record): record for record in before}
     right = {_key(record): record for record in after}
     regressions = []
@@ -960,19 +1100,31 @@ def compare(before: list[dict[str, Any]], after: list[dict[str, Any]]) -> dict[s
         "fixes": fixes,
         "pass_rate_before": summarize(before)["pass_rate"],
         "pass_rate_after": summarize(after)["pass_rate"],
+        "before_label": before_label,
+        "after_label": after_label,
     }
 
 
 def render_comparison(result: dict[str, Any]) -> str:
+    before_label = result.get("before_label")
+    after_label = result.get("after_label")
     lines = [
         "# Bridge e2e comparison",
         "",
+        f"- Before label: {_display_label(before_label)}",
+        f"- After label: {_display_label(after_label)}",
+        f"- Label transition: {_display_label(before_label)} -> {_display_label(after_label)}",
         f"- Shared cases: {result['shared']}",
         f"- Pass rate: {result['pass_rate_before']:.1%} -> {result['pass_rate_after']:.1%}",
         f"- Regressions: {len(result['regressions'])}",
         f"- Fixes: {len(result['fixes'])}",
         "",
     ]
+    if before_label is None or after_label is None:
+        lines.insert(
+            5,
+            "- Label identity is unavailable for at least one legacy artifact.",
+        )
     if result["regressions"]:
         lines.extend(["## Regressions", "", "| Case | Now | Detail |", "| --- | --- | --- |"])
         lines.extend(
@@ -988,9 +1140,15 @@ def render_comparison(result: dict[str, Any]) -> str:
 
 
 def load_rows(path: Path) -> list[dict[str, Any]]:
-    return [
-        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
-    ]
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if not isinstance(record, dict):
+            raise ValueError("matrix artifact rows must be JSON objects")
+        rows.append(record)
+    return rows
 
 
 @dataclass(slots=True)
@@ -1003,11 +1161,23 @@ class RunOptions:
     switch_settle_seconds: float = 5.0
     test_session_continuity: bool = False
     out: Path | None = None
+    label: str | None = None
 
 
 async def _run(options: RunOptions) -> int:
     out = options.out or Path("traces") / f"e2e-{datetime.now(UTC):%Y%m%dT%H%M%SZ}.jsonl"
+    label = None if options.label is None else normalize_label(options.label)
     out.parent.mkdir(parents=True, exist_ok=True)
+    with _locked_output(out, label) as handle:
+        return await _run_with_output(options, out, label, handle)
+
+
+async def _run_with_output(
+    options: RunOptions,
+    out: Path,
+    label: str | None,
+    handle: Any,
+) -> int:
     async with httpx.AsyncClient() as client:
         bridge = Bridge(base_url=options.base_url, api_key=options.api_key, client=client)
         models = options.models or await bridge.models()
@@ -1024,36 +1194,38 @@ async def _run(options: RunOptions) -> int:
             f"{len(continuation_plan)} continuation switches -> {out}",
             file=sys.stderr,
         )
-        with out.open("a", encoding="utf-8") as handle:
 
-            def write(record: dict[str, Any]) -> None:
-                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
-                handle.flush()
+        def write(record: dict[str, Any]) -> None:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+            handle.flush()
 
-            rows = await run_matrix(
+        rows = await run_matrix(
+            bridge,
+            models,
+            plan,
+            concurrency=options.concurrency,
+            on_row=write,
+            label=label,
+        )
+        rows.extend(
+            await run_switch_matrix(
                 bridge,
                 models,
-                plan,
-                concurrency=options.concurrency,
+                switch_plan,
+                settle_seconds=options.switch_settle_seconds,
                 on_row=write,
+                label=label,
             )
-            rows.extend(
-                await run_switch_matrix(
-                    bridge,
-                    models,
-                    switch_plan,
-                    settle_seconds=options.switch_settle_seconds,
-                    on_row=write,
-                )
+        )
+        rows.extend(
+            await run_continuation_switch_matrix(
+                bridge,
+                models,
+                continuation_plan,
+                on_row=write,
+                label=label,
             )
-            rows.extend(
-                await run_continuation_switch_matrix(
-                    bridge,
-                    models,
-                    continuation_plan,
-                    on_row=write,
-                )
-            )
+        )
     print(render_report(rows))
     return 1 if summarize(rows)["blocking"] else 0
 
@@ -1070,6 +1242,7 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--switch-settle-seconds", type=float, default=5.0)
     run_parser.add_argument("--test-session-continuity", action="store_true")
     run_parser.add_argument("--out", type=Path, default=None)
+    run_parser.add_argument("--label", type=_label_argument, default=None)
 
     report_parser = sub.add_parser("report", help="render a markdown report from a JSONL run")
     report_parser.add_argument("path", type=Path)
@@ -1077,13 +1250,18 @@ def main(argv: list[str] | None = None) -> int:
     compare_parser = sub.add_parser("compare", help="diff two JSONL runs")
     compare_parser.add_argument("before", type=Path)
     compare_parser.add_argument("after", type=Path)
+    compare_parser.add_argument("--allow-same-label", action="store_true")
 
     args = parser.parse_args(argv)
     if args.command == "report":
         print(render_report(load_rows(args.path)), end="")
         return 0
     if args.command == "compare":
-        result = compare(load_rows(args.before), load_rows(args.after))
+        result = compare(
+            load_rows(args.before),
+            load_rows(args.after),
+            allow_same_label=args.allow_same_label,
+        )
         print(render_comparison(result), end="")
         return 1 if result["regressions"] else 0
     options = RunOptions(
@@ -1095,6 +1273,7 @@ def main(argv: list[str] | None = None) -> int:
         switch_settle_seconds=args.switch_settle_seconds,
         test_session_continuity=args.test_session_continuity,
         out=args.out,
+        label=args.label,
     )
     return asyncio.run(_run(options))
 

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -949,7 +949,8 @@ def artifact_label(rows: list[dict[str, Any]]) -> str | None:
             raise ValueError(f"matrix row {index} label is not normalized")
         labels.add(label)
     if len(labels) > 1:
-        raise ValueError("matrix artifact contains mixed labeled and unlabeled rows")
+        found = sorted(_display_label(label) for label in labels)
+        raise ValueError(f"matrix artifact contains mixed labels: {found}")
     return next(iter(labels), None)
 
 
@@ -987,7 +988,12 @@ def _locked_output(path: Path, label: str | None) -> Iterator[Any]:
         lock.write(b"\0")
         lock.flush()
         lock.seek(0)
-        _msvcrt.locking(lock.fileno(), _msvcrt.LK_LOCK, 1)
+        while True:
+            try:
+                _msvcrt.locking(lock.fileno(), _msvcrt.LK_NBLCK, 1)
+                break
+            except OSError:
+                time.sleep(0.1)
         try:
             _validate_append_target(path, label)
             with path.open("a", encoding="utf-8") as handle:
@@ -1253,29 +1259,33 @@ def main(argv: list[str] | None = None) -> int:
     compare_parser.add_argument("--allow-same-label", action="store_true")
 
     args = parser.parse_args(argv)
-    if args.command == "report":
-        print(render_report(load_rows(args.path)), end="")
-        return 0
-    if args.command == "compare":
-        result = compare(
-            load_rows(args.before),
-            load_rows(args.after),
-            allow_same_label=args.allow_same_label,
+    try:
+        if args.command == "report":
+            print(render_report(load_rows(args.path)), end="")
+            return 0
+        if args.command == "compare":
+            result = compare(
+                load_rows(args.before),
+                load_rows(args.after),
+                allow_same_label=args.allow_same_label,
+            )
+            print(render_comparison(result), end="")
+            return 1 if result["regressions"] else 0
+        options = RunOptions(
+            base_url=args.base_url,
+            api_key=os.getenv("FACTORY_DROID_OPENAI_API_KEY"),
+            models=[value for value in args.models.split(",") if value],
+            concurrency=args.concurrency,
+            streaming=not args.no_stream,
+            switch_settle_seconds=args.switch_settle_seconds,
+            test_session_continuity=args.test_session_continuity,
+            out=args.out,
+            label=args.label,
         )
-        print(render_comparison(result), end="")
-        return 1 if result["regressions"] else 0
-    options = RunOptions(
-        base_url=args.base_url,
-        api_key=os.getenv("FACTORY_DROID_OPENAI_API_KEY"),
-        models=[value for value in args.models.split(",") if value],
-        concurrency=args.concurrency,
-        streaming=not args.no_stream,
-        switch_settle_seconds=args.switch_settle_seconds,
-        test_session_continuity=args.test_session_continuity,
-        out=args.out,
-        label=args.label,
-    )
-    return asyncio.run(_run(options))
+        return asyncio.run(_run(options))
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -25,7 +25,7 @@ import sys
 import time
 import unicodedata
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -48,6 +48,18 @@ except ImportError:
 DEFAULT_BASE_URL = "http://127.0.0.1:8787"
 _MAX_LABEL_LENGTH = 128
 RowCallback = Callable[[dict[str, Any]], None] | None
+
+
+class MatrixUsageError(ValueError):
+    """Bad invocation or bad artifact, as opposed to a run finding.
+
+    ``main`` turns this into exit code 2, so a misuse never reads as the
+    blocking failures ``run`` reports or the regressions ``compare`` reports.
+    It stays a ``ValueError`` so callers that only care about the value being
+    wrong keep working.
+    """
+
+
 _WEATHER_TOOL: dict[str, Any] = {
     "type": "function",
     "function": {
@@ -365,13 +377,13 @@ def normalize_label(value: str) -> str:
     """Trim and validate a label that identifies one matrix artifact."""
     label = value.strip()
     if not label:
-        raise ValueError("matrix label must not be empty")
+        raise MatrixUsageError("matrix label must not be empty")
     if any(char in "\n\r\u2028\u2029" for char in label):
-        raise ValueError("matrix label must not contain newlines or line separators")
+        raise MatrixUsageError("matrix label must not contain newlines or line separators")
     if any(unicodedata.category(char) == "Cc" for char in label):
-        raise ValueError("matrix label must not contain control characters")
+        raise MatrixUsageError("matrix label must not contain control characters")
     if len(label) > _MAX_LABEL_LENGTH:
-        raise ValueError(f"matrix label must be at most {_MAX_LABEL_LENGTH} characters")
+        raise MatrixUsageError(f"matrix label must be at most {_MAX_LABEL_LENGTH} characters")
     return label
 
 
@@ -767,7 +779,9 @@ def row(
         "detail": detail,
     }
     if label is not None:
-        record["label"] = normalize_label(label)
+        # Normalized once where the label enters the process; every reader
+        # checks it again through artifact_label.
+        record["label"] = label
     return record
 
 
@@ -943,14 +957,14 @@ def artifact_label(rows: list[dict[str, Any]]) -> str | None:
             labels.add(None)
             continue
         if not isinstance(raw, str):
-            raise ValueError(f"matrix row {index} label must be a string")
+            raise MatrixUsageError(f"matrix row {index} label must be a string")
         label = normalize_label(raw)
         if label != raw:
-            raise ValueError(f"matrix row {index} label is not normalized")
+            raise MatrixUsageError(f"matrix row {index} label is not normalized")
         labels.add(label)
     if len(labels) > 1:
         found = sorted(_display_label(label) for label in labels)
-        raise ValueError(f"matrix artifact contains mixed labels: {found}")
+        raise MatrixUsageError(f"matrix artifact contains mixed labels: {found}")
     return next(iter(labels), None)
 
 
@@ -962,7 +976,7 @@ def _validate_append_target(path: Path, label: str | None) -> None:
         return
     existing_label = artifact_label(rows)
     if existing_label != label:
-        raise ValueError(
+        raise MatrixUsageError(
             f"cannot append {_display_label(label)!r} run to "
             f"{_display_label(existing_label)!r} artifact"
         )
@@ -1001,6 +1015,10 @@ def _locked_output(path: Path, label: str | None) -> Iterator[Any]:
         finally:
             lock.seek(0)
             _msvcrt.locking(lock.fileno(), _msvcrt.LK_UNLCK, 1)
+    # A waiting run still holds this file open, and Windows refuses to unlink
+    # it then, so the leftover is swept on the run that finds it free.
+    with suppress(OSError):
+        lock_path.unlink()
 
 
 def render_report(rows: list[dict[str, Any]]) -> str:
@@ -1085,7 +1103,7 @@ def compare(
     before_label = artifact_label(before)
     after_label = artifact_label(after)
     if not allow_same_label and before_label is not None and before_label == after_label:
-        raise ValueError(f"cannot compare two artifacts labeled {before_label!r}")
+        raise MatrixUsageError(f"cannot compare two artifacts labeled {before_label!r}")
     left = {_key(record): record for record in before}
     right = {_key(record): record for record in after}
     regressions = []
@@ -1120,17 +1138,18 @@ def render_comparison(result: dict[str, Any]) -> str:
         f"- Before label: {_display_label(before_label)}",
         f"- After label: {_display_label(after_label)}",
         f"- Label transition: {_display_label(before_label)} -> {_display_label(after_label)}",
-        f"- Shared cases: {result['shared']}",
-        f"- Pass rate: {result['pass_rate_before']:.1%} -> {result['pass_rate_after']:.1%}",
-        f"- Regressions: {len(result['regressions'])}",
-        f"- Fixes: {len(result['fixes'])}",
-        "",
     ]
     if before_label is None or after_label is None:
-        lines.insert(
-            5,
-            "- Label identity is unavailable for at least one legacy artifact.",
-        )
+        lines.append("- Label identity is unavailable for at least one legacy artifact.")
+    lines.extend(
+        [
+            f"- Shared cases: {result['shared']}",
+            f"- Pass rate: {result['pass_rate_before']:.1%} -> {result['pass_rate_after']:.1%}",
+            f"- Regressions: {len(result['regressions'])}",
+            f"- Fixes: {len(result['fixes'])}",
+            "",
+        ]
+    )
     if result["regressions"]:
         lines.extend(["## Regressions", "", "| Case | Now | Detail |", "| --- | --- | --- |"])
         lines.extend(
@@ -1147,12 +1166,15 @@ def render_comparison(result: dict[str, Any]) -> str:
 
 def load_rows(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if not line.strip():
             continue
-        record = json.loads(line)
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise MatrixUsageError(f"{path}:{number} is not valid JSON: {exc}") from exc
         if not isinstance(record, dict):
-            raise ValueError("matrix artifact rows must be JSON objects")
+            raise MatrixUsageError(f"{path}:{number} is not a JSON object")
         rows.append(record)
     return rows
 
@@ -1170,12 +1192,18 @@ class RunOptions:
     label: str | None = None
 
 
-async def _run(options: RunOptions) -> int:
+def run_locked(options: RunOptions) -> int:
+    """Take the output lock, then run the matrix under it.
+
+    The lock is taken outside the event loop because waiting for it blocks,
+    and it is held for the whole run so a second run cannot interleave rows
+    into the same artifact.
+    """
     out = options.out or Path("traces") / f"e2e-{datetime.now(UTC):%Y%m%dT%H%M%SZ}.jsonl"
     label = None if options.label is None else normalize_label(options.label)
     out.parent.mkdir(parents=True, exist_ok=True)
     with _locked_output(out, label) as handle:
-        return await _run_with_output(options, out, label, handle)
+        return asyncio.run(_run_with_output(options, out, label, handle))
 
 
 async def _run_with_output(
@@ -1282,8 +1310,8 @@ def main(argv: list[str] | None = None) -> int:
             out=args.out,
             label=args.label,
         )
-        return asyncio.run(_run(options))
-    except ValueError as exc:
+        return run_locked(options)
+    except MatrixUsageError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -985,7 +985,14 @@ def test_artifact_labels_reject_mixed_rows_and_round_trip_unicode(
     e2e: ModuleType,
     tmp_path: Path,
 ) -> None:
-    rows = [e2e.row("m1", _scenario(e2e), _observation(e2e), label=" native Ż ")]
+    rows = [
+        e2e.row(
+            "m1",
+            _scenario(e2e),
+            _observation(e2e),
+            label=e2e.normalize_label(" native Ż "),
+        )
+    ]
     path = tmp_path / "unicode.jsonl"
     path.write_text(
         "\n".join(json.dumps(record, ensure_ascii=False) for record in rows) + "\n",
@@ -1004,6 +1011,37 @@ def test_artifact_labels_reject_mixed_rows_and_round_trip_unicode(
         e2e.artifact_label([*loaded, e2e.row("m2", _scenario(e2e), _observation(e2e))])
     assert "native Ż" in str(error.value)
     assert "unlabeled legacy artifact" in str(error.value)
+
+
+def test_artifact_labels_reject_a_writer_that_skipped_normalization(
+    e2e: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Rows are normalized once on write, so the read side has to check."""
+    path = tmp_path / "raw.jsonl"
+    row = e2e.row("m1", _scenario(e2e), _observation(e2e), label="native")
+    row["label"] = " native "
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    with pytest.raises(e2e.MatrixUsageError, match="not normalized"):
+        e2e.artifact_label(e2e.load_rows(path))
+
+    row["label"] = 7
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    with pytest.raises(e2e.MatrixUsageError, match="must be a string"):
+        e2e.artifact_label(e2e.load_rows(path))
+
+
+def test_load_rows_names_the_line_it_cannot_parse(e2e: ModuleType, tmp_path: Path) -> None:
+    path = tmp_path / "broken.jsonl"
+    path.write_text('{"model": "m1"}\nnot json\n', encoding="utf-8")
+
+    with pytest.raises(e2e.MatrixUsageError, match=r"broken\.jsonl:2 is not valid JSON"):
+        e2e.load_rows(path)
+
+    path.write_text("[1, 2]\n", encoding="utf-8")
+    with pytest.raises(e2e.MatrixUsageError, match=r"broken\.jsonl:1 is not a JSON object"):
+        e2e.load_rows(path)
 
 
 def test_artifact_labels_report_distinct_labels(e2e: ModuleType) -> None:

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -72,6 +72,27 @@ def test_scenarios_cover_both_transports_and_run_hostile_cases_once(e2e: ModuleT
     assert len(e2e.continuation_switch_scenarios(streaming=False)) == 1
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ("   ", "must not be empty"),
+        ("line\nbreak", "must not contain newlines"),
+        ("line\u2028break", "must not contain newlines"),
+        ("bad\x00label", "must not contain control characters"),
+        ("x" * 129, "at most 128"),
+    ],
+)
+def test_matrix_labels_are_trimmed_and_validated(
+    e2e: ModuleType,
+    value: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        e2e.normalize_label(value)
+
+    assert e2e.normalize_label("  native Ż  ") == "native Ż"
+
+
 def test_blank_argument_scenarios_accept_answer_or_tool_retry(e2e: ModuleType) -> None:
     scenarios = [
         scenario for scenario in e2e.scenarios() if scenario.name == "tool_blank_arguments"
@@ -609,10 +630,12 @@ async def test_matrix_runs_every_pair_and_streams_rows_out(e2e: ModuleType) -> N
             plan,
             concurrency=1,
             on_row=written.append,
+            label="native",
         )
 
     assert len(rows) == 3
     assert written == rows
+    assert all(record["label"] == "native" for record in rows)
     assert {row["model"] for row in rows} == {"m1", "m2"}
     assert sum(1 for row in rows if row["scenario"] == "hostile") == 1
 
@@ -660,6 +683,7 @@ async def test_switch_matrix_runs_a_serial_model_ring(e2e: ModuleType) -> None:
             plan,
             settle_seconds=0,
             on_row=written.append,
+            label="native",
         )
 
     assert seen_models == ["m1", "m2", "m2", "m3", "m3", "m1"]
@@ -669,6 +693,7 @@ async def test_switch_matrix_runs_a_serial_model_ring(e2e: ModuleType) -> None:
         ("m3", "m1"),
     ]
     assert all(row["prime_verdict"] == e2e.SUCCESS for row in rows)
+    assert all(record["label"] == "native" for record in rows)
     assert written == rows
 
 
@@ -770,6 +795,7 @@ async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) 
             ["m1", "m2"],
             plan,
             on_row=written.append,
+            label="native",
         )
 
     assert seen == [
@@ -781,6 +807,7 @@ async def test_continuation_switch_matrix_rejects_a_model_ring(e2e: ModuleType) 
         ("m1", "session-m2"),
     ]
     assert all(row["verdict"] == e2e.SUCCESS for row in rows)
+    assert all(record["label"] == "native" for record in rows)
     assert written == rows
 
 
@@ -897,6 +924,14 @@ def test_report_names_the_blocking_cases(e2e: ModuleType) -> None:
     assert "| Model | Pass | Total | Tool calls |" in report
 
 
+def test_report_displays_labels_and_legacy_artifacts(e2e: ModuleType) -> None:
+    labeled = e2e.render_report([e2e.row("m1", _scenario(e2e), _observation(e2e), label="native")])
+    legacy = e2e.render_report(_rows(e2e))
+
+    assert "- Label: native" in labeled
+    assert "- Label: unlabeled legacy artifact" in legacy
+
+
 def test_report_says_so_when_nothing_blocks(e2e: ModuleType) -> None:
     report = e2e.render_report([e2e.row("m1", _scenario(e2e), _observation(e2e))])
 
@@ -943,6 +978,71 @@ def test_comparison_keeps_transition_sources_distinct(e2e: ModuleType) -> None:
     second["source_model"] = "source-b"
 
     assert e2e.compare([first, second], [first, second])["shared"] == 2
+
+
+def test_artifact_labels_reject_mixed_rows_and_round_trip_unicode(
+    e2e: ModuleType,
+    tmp_path: Path,
+) -> None:
+    rows = [e2e.row("m1", _scenario(e2e), _observation(e2e), label=" native Ż ")]
+    path = tmp_path / "unicode.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(record, ensure_ascii=False) for record in rows) + "\n",
+        encoding="utf-8",
+    )
+
+    loaded = e2e.load_rows(path)
+
+    assert loaded[0]["label"] == "native Ż"
+    assert e2e.artifact_label(loaded) == "native Ż"
+    e2e._validate_append_target(path, "native Ż")
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text(" \n\n", encoding="utf-8")
+    e2e._validate_append_target(empty, "native")
+    with pytest.raises(ValueError, match="mixed"):
+        e2e.artifact_label([*loaded, e2e.row("m2", _scenario(e2e), _observation(e2e))])
+
+
+def test_compare_renders_distinct_labels_and_allows_legacy_inputs(e2e: ModuleType) -> None:
+    before = [e2e.row("m1", _scenario(e2e), _observation(e2e), label="text")]
+    after = [e2e.row("m1", _scenario(e2e), _observation(e2e), label="native")]
+
+    result = e2e.compare(before, after)
+    rendered = e2e.render_comparison(result)
+    legacy_rendered = e2e.render_comparison(e2e.compare(_rows(e2e), after))
+
+    assert result["before_label"] == "text"
+    assert result["after_label"] == "native"
+    assert "- Before label: text" in rendered
+    assert "- After label: native" in rendered
+    assert "- Label transition: text -> native" in rendered
+    assert "identity is unavailable" in legacy_rendered
+
+
+def test_compare_rejects_same_label_unless_overridden(e2e: ModuleType) -> None:
+    rows = [e2e.row("m1", _scenario(e2e), _observation(e2e), label="native")]
+
+    with pytest.raises(ValueError, match="cannot compare"):
+        e2e.compare(rows, rows)
+
+    assert e2e.compare(rows, rows, allow_same_label=True)["shared"] == 1
+
+
+def test_compare_command_allows_same_label_with_flag(
+    e2e: ModuleType,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    row = e2e.row("m1", _scenario(e2e), _observation(e2e), label="native")
+    before = tmp_path / "before.jsonl"
+    after = tmp_path / "after.jsonl"
+    for path in (before, after):
+        path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    code = e2e.main(["compare", str(before), str(after), "--allow-same-label"])
+
+    assert code == 0
+    assert "Before label: native" in capsys.readouterr().out
 
 
 def test_report_command_reads_a_jsonl_run(
@@ -1009,6 +1109,7 @@ def test_run_command_writes_rows_and_reports_blocking_findings(
     monkeypatch.delenv("FACTORY_DROID_OPENAI_API_KEY", raising=False)
     out = tmp_path / "nested" / "run.jsonl"
     args = ["run", "--no-stream", "--concurrency", "4", "--out", str(out)]
+    args.extend(["--label", "native"])
     if test_continuity:
         args.append("--test-session-continuity")
 
@@ -1017,5 +1118,30 @@ def test_run_command_writes_rows_and_reports_blocking_findings(
     rows = e2e.load_rows(out)
     assert code == 1
     assert rows
+    assert {row["label"] for row in rows} == {"native"}
     assert all(row["model"] == "m1" for row in rows if row["scenario"] != "hostile_unknown_model")
     assert "Bridge e2e run" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("label_args", [["--label", "native"], []])
+def test_run_rejects_mismatched_append_before_network(
+    e2e: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    label_args: list[str],
+) -> None:
+    out = tmp_path / "run.jsonl"
+    out.write_text(
+        json.dumps(e2e.row("m1", _scenario(e2e), _observation(e2e), label="text")) + "\n",
+        encoding="utf-8",
+    )
+
+    class NoNetworkClient:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+            raise AssertionError("network must not start")
+
+    monkeypatch.setattr(e2e.httpx, "AsyncClient", NoNetworkClient)
+
+    with pytest.raises(ValueError, match="cannot append"):
+        e2e.main(["run", *label_args, "--out", str(out)])

--- a/tests/test_e2e_matrix.py
+++ b/tests/test_e2e_matrix.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -999,8 +1000,88 @@ def test_artifact_labels_reject_mixed_rows_and_round_trip_unicode(
     empty = tmp_path / "empty.jsonl"
     empty.write_text(" \n\n", encoding="utf-8")
     e2e._validate_append_target(empty, "native")
-    with pytest.raises(ValueError, match="mixed"):
+    with pytest.raises(ValueError, match="mixed labels") as error:
         e2e.artifact_label([*loaded, e2e.row("m2", _scenario(e2e), _observation(e2e))])
+    assert "native Ż" in str(error.value)
+    assert "unlabeled legacy artifact" in str(error.value)
+
+
+def test_artifact_labels_report_distinct_labels(e2e: ModuleType) -> None:
+    rows = [
+        e2e.row("m1", _scenario(e2e), _observation(e2e), label="text"),
+        e2e.row("m2", _scenario(e2e), _observation(e2e), label="native"),
+    ]
+
+    with pytest.raises(ValueError, match="mixed labels") as error:
+        e2e.artifact_label(rows)
+
+    assert "native" in str(error.value)
+    assert "text" in str(error.value)
+
+
+def test_locked_output_waits_for_posix_lock(e2e: ModuleType, tmp_path: Path) -> None:
+    if e2e._fcntl is None:
+        pytest.skip("POSIX locking is unavailable")
+    path = tmp_path / "run.jsonl"
+    started = threading.Event()
+    acquired = threading.Event()
+    errors: list[BaseException] = []
+
+    def contend() -> None:
+        started.set()
+        try:
+            with e2e._locked_output(path, None):
+                acquired.set()
+        except BaseException as exc:
+            errors.append(exc)
+
+    with e2e._locked_output(path, None):
+        thread = threading.Thread(target=contend)
+        thread.start()
+        assert started.wait(1)
+        assert not acquired.wait(0.05)
+    thread.join(1)
+
+    assert not thread.is_alive()
+    assert not errors
+    assert acquired.is_set()
+
+
+def test_locked_output_retries_windows_lock(
+    e2e: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int, int]] = []
+            self.attempts = 0
+
+        def locking(self, fd: int, mode: int, size: int) -> None:
+            self.calls.append((fd, mode, size))
+            if mode == self.LK_NBLCK and self.attempts == 0:
+                self.attempts += 1
+                raise OSError("locked")
+
+    fake_msvcrt = FakeMsvcrt()
+    sleeps: list[float] = []
+    monkeypatch.setattr(e2e, "_fcntl", None)
+    monkeypatch.setattr(e2e, "_msvcrt", fake_msvcrt)
+    monkeypatch.setattr(e2e.time, "sleep", sleeps.append)
+    path = tmp_path / "run.jsonl"
+
+    with e2e._locked_output(path, None):
+        pass
+
+    assert [mode for _, mode, _ in fake_msvcrt.calls] == [
+        fake_msvcrt.LK_NBLCK,
+        fake_msvcrt.LK_NBLCK,
+        fake_msvcrt.LK_UNLCK,
+    ]
+    assert sleeps == [0.1]
 
 
 def test_compare_renders_distinct_labels_and_allows_legacy_inputs(e2e: ModuleType) -> None:
@@ -1128,6 +1209,7 @@ def test_run_rejects_mismatched_append_before_network(
     e2e: ModuleType,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
     label_args: list[str],
 ) -> None:
     out = tmp_path / "run.jsonl"
@@ -1143,5 +1225,7 @@ def test_run_rejects_mismatched_append_before_network(
 
     monkeypatch.setattr(e2e.httpx, "AsyncClient", NoNetworkClient)
 
-    with pytest.raises(ValueError, match="cannot append"):
-        e2e.main(["run", *label_args, "--out", str(out)])
+    code = e2e.main(["run", *label_args, "--out", str(out)])
+
+    assert code == 2
+    assert "error: cannot append" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Add normalized labels to matrix runs and every artifact row type.
- Reject mixed or incompatible append artifacts before network work.
- Report labels and guard same-label comparisons with an explicit override.
- Add portable exclusive output locking and document A/B runs.

Closes #87

## Validation

- Full test suite with 100 percent coverage
- Ruff and strict mypy
- OpenAPI validation, lock check, and package build
