### PR TITLE
feat(native): fail closed on MCP policy blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,24 @@ request, and it is mounted only while the flag is on. Droid reaches it at
 `http://127.0.0.1:<port>`; set `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL`
 when the bridge answers on a different address than it binds.
 
+Enterprise-managed `mcpPolicy` settings must allow the MCP server hostname.
+For the default endpoint, the managed settings need an entry equivalent to:
+
+```json
+{
+  "mcpPolicy": {
+    "enabled": true,
+    "allowlist": ["127.0.0.1"]
+  }
+}
+```
+
+If `FACTORY_DROID_OPENAI_NATIVE_TOOL_CALL_URL` is set, allow its hostname
+instead. The bridge checks that `openai-bridge` connects and that its exact
+request tool catalog is available before sending the prompt. A policy
+rejection fails closed as `factory_native_tool_unavailable` with HTTP `503`.
+Confirm the final managed-settings shape with your Factory administrator.
+
 Whether the flag is worth it depends on the model. It pays off for a model that
 misses tool contracts on the text path: one that ignores `tool_choice=required`,
 answers in prose instead of calling a tool, or writes a call the parser has to
@@ -1666,6 +1684,16 @@ factory_native_tool_blocked
 Droid attempted to use one of its own tools instead of returning bridge
 protocol output. Retry with a clearer request or inspect the supplied system
 and user messages for conflicting instructions.
+
+### Native tool server unavailable
+
+```text
+factory_native_tool_unavailable
+```
+
+Native setup could not connect `openai-bridge` or verify the exact request tool
+catalog. For an enterprise `mcpPolicy` rejection, allow the hostname named in
+the error and confirm the managed settings with your Factory administrator.
 
 ### Incomplete response
 

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
+from urllib.parse import urlsplit
 
 from droid_sdk.errors import DroidClientError
 from droid_sdk.schemas.enums import (
@@ -10,6 +12,8 @@ from droid_sdk.schemas.enums import (
     DroidInteractionMode,
     DroidServerMethod,
 )
+
+from factory_droid_openai.mcp_tools import MCP_SERVER_NAME, MCP_TOOL_ID_PREFIX
 
 if TYPE_CHECKING:
     from droid_sdk import DroidClient
@@ -19,6 +23,7 @@ _RPC_TIMEOUT_SECONDS = 30.0
 # metadata RPCs. The caller's own timeout still bounds the operation.
 _COMPACTION_TIMEOUT_SECONDS = 300.0
 _MCP_POLL_SECONDS = 0.1
+_NATIVE_MCP_WAIT_SECONDS = 5.0
 _TOOL_DISABLE_RETRIES = 3
 _TOOL_DISABLE_RETRY_SECONDS = 0.1
 _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
@@ -27,6 +32,15 @@ _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
 # fetches a schema Droid already holds, and the model needs it to reach those
 # tools at all.
 _DEFERRED_TOOL_LOADER_IDS = frozenset({"tool-search-cli"})
+_MCP_POLICY_PATTERN = re.compile(
+    r"(?:mcp\s*policy|allowlist|allow\s+list|organization policy|"
+    r"not allowed|disallowed|denied|blocked)",
+    re.IGNORECASE,
+)
+
+
+class NativeToolUnavailableError(DroidClientError):
+    """The bridge's MCP server or exact native tool catalog is unavailable."""
 
 
 class _ProtocolEngine(Protocol):
@@ -125,6 +139,8 @@ class DroidRpcExtension:
         client: DroidClient,
         *,
         keep_tool_prefix: str | None = None,
+        expected_tool_ids: frozenset[str] | None = None,
+        native_server_url: str | None = None,
     ) -> None:
         """Disable every Droid tool, optionally sparing one id prefix.
 
@@ -132,17 +148,27 @@ class DroidRpcExtension:
         MCP callable. Everything Droid owns still goes away, so a turn can only
         reach tools the OpenAI client asked for.
         """
-        await self._wait_for_mcp_catalog(client)
+        if expected_tool_ids is None:
+            await self._wait_for_mcp_catalog(client)
+        else:
+            await self._wait_for_native_mcp_server(client, native_server_url)
         tools = await self._list_tools(client)
         if not tools:
             raise DroidClientError("Droid returned an empty native tool catalog")
         tool_ids = {_required_str(tool, "id") for tool in tools}
+        if expected_tool_ids is not None:
+            self._verify_native_tool_ids(tool_ids, expected_tool_ids)
         tolerated = _UNAVOIDABLE_TOOL_IDS
         if keep_tool_prefix is not None:
             tolerated = tolerated | _DEFERRED_TOOL_LOADER_IDS
         unexpected: set[str] = set()
+        missing_expected: set[str] = set()
         for attempt in range(_TOOL_DISABLE_RETRIES):
-            kept = _matching(tool_ids, keep_tool_prefix)
+            kept = (
+                set(expected_tool_ids)
+                if expected_tool_ids is not None
+                else _matching(tool_ids, keep_tool_prefix)
+            )
             await self._request(
                 client,
                 DroidServerMethod.UPDATE_SESSION_SETTINGS.value,
@@ -159,13 +185,73 @@ class DroidRpcExtension:
                 tool_ids.add(tool_id)
                 if _required_bool(tool, "currentlyAllowed"):
                     remaining.add(tool_id)
+            if expected_tool_ids is not None:
+                self._verify_native_tool_ids(tool_ids, expected_tool_ids)
+                missing_expected = set(expected_tool_ids - remaining)
             unexpected = remaining - tolerated - _matching(remaining, keep_tool_prefix)
-            if not unexpected:
+            if not unexpected and not missing_expected:
                 return
             if attempt + 1 < _TOOL_DISABLE_RETRIES:
                 await asyncio.sleep(_TOOL_DISABLE_RETRY_SECONDS)
+        if missing_expected:
+            raise NativeToolUnavailableError(
+                "Droid did not keep every bridge tool enabled: "
+                + ", ".join(sorted(missing_expected))
+            )
         rendered = ", ".join(sorted(unexpected))
         raise DroidClientError(f"Failed to disable native Droid tools: {rendered}")
+
+    async def _wait_for_native_mcp_server(
+        self,
+        client: DroidClient,
+        server_url: str | None,
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _NATIVE_MCP_WAIT_SECONDS
+        while True:
+            result = await self._request(client, DroidServerMethod.LIST_MCP_SERVERS.value, {})
+            servers = _required_list(result, "servers")
+            target = [server for server in servers if server.get("name") == MCP_SERVER_NAME]
+            if len(target) > 1:
+                raise NativeToolUnavailableError(
+                    f"Droid reported multiple MCP servers named '{MCP_SERVER_NAME}'"
+                )
+            if target:
+                server = target[0]
+                status = _state_value(server.get("status"))
+                if status == "connected":
+                    return
+                if status in {"failed", "disconnected", "disabled"}:
+                    raise _native_server_error(server, server_url)
+                if status != "connecting":
+                    raise NativeToolUnavailableError(
+                        f"Droid MCP server '{MCP_SERVER_NAME}' has unknown status {status!r}"
+                    )
+            if loop.time() >= deadline:
+                hostname = _server_hostname(server_url)
+                raise NativeToolUnavailableError(
+                    f"Droid MCP server '{MCP_SERVER_NAME}' did not connect at {hostname} "
+                    f"within {_NATIVE_MCP_WAIT_SECONDS:.1f} seconds"
+                )
+            await asyncio.sleep(_MCP_POLL_SECONDS)
+
+    @staticmethod
+    def _verify_native_tool_ids(
+        tool_ids: set[str],
+        expected_tool_ids: frozenset[str],
+    ) -> None:
+        missing = expected_tool_ids - tool_ids
+        unexpected = _matching(tool_ids, MCP_TOOL_ID_PREFIX) - expected_tool_ids
+        if not missing and not unexpected:
+            return
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(sorted(missing)))
+        if unexpected:
+            details.append("unexpected " + ", ".join(sorted(unexpected)))
+        raise NativeToolUnavailableError(
+            "Droid MCP tool catalog does not match bridge tools: " + "; ".join(details)
+        )
 
     async def _wait_for_mcp_catalog(self, client: DroidClient) -> None:
         # Off by default: MCP servers that never leave "connecting" would
@@ -271,6 +357,33 @@ def _matching(tool_ids: set[str], prefix: str | None) -> set[str]:
     if prefix is None:
         return set()
     return {tool_id for tool_id in tool_ids if tool_id.startswith(prefix)}
+
+
+def _native_server_error(
+    server: dict[str, Any],
+    server_url: str | None,
+) -> NativeToolUnavailableError:
+    detail = server.get("error")
+    message = detail if isinstance(detail, str) and detail else "connection failed"
+    hostname = _server_hostname(server_url)
+    if _MCP_POLICY_PATTERN.search(message):
+        return NativeToolUnavailableError(
+            f"Factory Droid MCP server '{MCP_SERVER_NAME}' was rejected by mcpPolicy. "
+            f"Allow hostname '{hostname}' in the managed MCP allowlist: {message}"
+        )
+    return NativeToolUnavailableError(
+        f"Factory Droid MCP server '{MCP_SERVER_NAME}' failed at {hostname}: {message}"
+    )
+
+
+def _server_hostname(server_url: str | None) -> str:
+    if server_url is None:
+        return "the configured native tool URL"
+    return urlsplit(server_url).hostname or "the configured native tool URL"
+
+
+def _state_value(value: object) -> str:
+    return str(getattr(value, "value", value))
 
 
 def _protocol(client: DroidClient) -> _ProtocolEngine:

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -32,6 +32,10 @@ _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
 # fetches a schema Droid already holds, and the model needs it to reach those
 # tools at all.
 _DEFERRED_TOOL_LOADER_IDS = frozenset({"tool-search-cli"})
+_CONNECTED_MCP_STATUS = "connected"
+_FAILED_MCP_STATUSES = frozenset({"failed", "disconnected", "disabled"})
+_MCP_URL_FIELDS = ("url", "uri")
+_DEFAULT_PORTS = {"http": 80, "https": 443}
 _MCP_POLICY_PATTERN = re.compile(
     r"(?:mcp\s*policy|allowlist|allow\s+list|organization\s+policy)",
     re.IGNORECASE,
@@ -207,6 +211,7 @@ class DroidRpcExtension:
     ) -> None:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + _NATIVE_MCP_WAIT_SECONDS
+        last_status: str | None = None
         while True:
             timeout = min(_RPC_TIMEOUT_SECONDS, max(0.1, deadline - loop.time()))
             result = await self._request(
@@ -219,24 +224,25 @@ class DroidRpcExtension:
             target = [server for server in servers if _native_server_matches(server, server_url)]
             if len(target) > 1:
                 raise NativeToolUnavailableError(
-                    f"Droid reported multiple MCP servers named '{MCP_SERVER_NAME}'"
+                    f"Droid reported multiple MCP servers named '{MCP_SERVER_NAME}': "
+                    + ", ".join(sorted(_reported_endpoint(server) for server in target))
                 )
             if target:
                 server = target[0]
-                status = _state_value(server.get("status"))
-                if status == "connected":
+                last_status = _state_value(server.get("status"))
+                if last_status == _CONNECTED_MCP_STATUS:
                     return
-                if status in {"failed", "disconnected", "disabled"}:
+                if last_status in _FAILED_MCP_STATUSES:
                     raise _native_server_error(server, server_url)
-                if status != "connecting":
-                    raise NativeToolUnavailableError(
-                        f"Droid MCP server '{MCP_SERVER_NAME}' has unknown status {status!r}"
-                    )
+                # Every other status, including one a newer Droid introduces,
+                # is a reason to keep polling: only the deadline decides, so a
+                # renamed "connecting" cannot fail an otherwise healthy turn.
             if loop.time() >= deadline:
                 hostname = _server_hostname(server_url)
+                seen = "" if last_status is None else f", last status {last_status!r}"
                 raise NativeToolUnavailableError(
                     f"Droid MCP server '{MCP_SERVER_NAME}' did not connect at {hostname} "
-                    f"within {_NATIVE_MCP_WAIT_SECONDS:.1f} seconds"
+                    f"within {_NATIVE_MCP_WAIT_SECONDS:.1f} seconds{seen}"
                 )
             await asyncio.sleep(_MCP_POLL_SECONDS)
 
@@ -367,7 +373,44 @@ def _matching(tool_ids: set[str], prefix: str | None) -> set[str]:
 def _native_server_matches(server: dict[str, Any], server_url: str | None) -> bool:
     if server.get("name") != MCP_SERVER_NAME:
         return False
-    return all(server[field] == server_url for field in ("url", "uri") if field in server)
+    reported = [server[field] for field in _MCP_URL_FIELDS if field in server]
+    if not reported:
+        # Droid may list a server without echoing its URL, and the name is then
+        # all there is to match on.
+        return True
+    return all(_same_endpoint(value, server_url) for value in reported)
+
+
+def _reported_endpoint(server: dict[str, Any]) -> str:
+    for field in _MCP_URL_FIELDS:
+        value = server.get(field)
+        if isinstance(value, str) and value:
+            return value
+    return "no URL reported"
+
+
+def _same_endpoint(reported: object, configured: str | None) -> bool:
+    """Compare two URLs by endpoint identity rather than by spelling."""
+    if configured is None or not isinstance(reported, str):
+        return False
+    left = _endpoint_identity(reported)
+    right = _endpoint_identity(configured)
+    return left is not None and left == right
+
+
+def _endpoint_identity(url: str) -> tuple[str, str, int | None, str] | None:
+    parts = urlsplit(url)
+    try:
+        port = parts.port
+    except ValueError:
+        return None
+    scheme = parts.scheme.lower()
+    return (
+        scheme,
+        (parts.hostname or "").lower(),
+        port if port is not None else _DEFAULT_PORTS.get(scheme),
+        parts.path.rstrip("/"),
+    )
 
 
 def _native_server_error(

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -33,8 +33,7 @@ _UNAVOIDABLE_TOOL_IDS = frozenset({"exit-spec-mode"})
 # tools at all.
 _DEFERRED_TOOL_LOADER_IDS = frozenset({"tool-search-cli"})
 _MCP_POLICY_PATTERN = re.compile(
-    r"(?:mcp\s*policy|allowlist|allow\s+list|organization policy|"
-    r"not allowed|disallowed|denied|blocked)",
+    r"(?:mcp\s*policy|allowlist|allow\s+list|organization\s+policy)",
     re.IGNORECASE,
 )
 
@@ -209,9 +208,15 @@ class DroidRpcExtension:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + _NATIVE_MCP_WAIT_SECONDS
         while True:
-            result = await self._request(client, DroidServerMethod.LIST_MCP_SERVERS.value, {})
+            timeout = min(_RPC_TIMEOUT_SECONDS, max(0.1, deadline - loop.time()))
+            result = await self._request(
+                client,
+                DroidServerMethod.LIST_MCP_SERVERS.value,
+                {},
+                timeout=timeout,
+            )
             servers = _required_list(result, "servers")
-            target = [server for server in servers if server.get("name") == MCP_SERVER_NAME]
+            target = [server for server in servers if _native_server_matches(server, server_url)]
             if len(target) > 1:
                 raise NativeToolUnavailableError(
                     f"Droid reported multiple MCP servers named '{MCP_SERVER_NAME}'"
@@ -357,6 +362,12 @@ def _matching(tool_ids: set[str], prefix: str | None) -> set[str]:
     if prefix is None:
         return set()
     return {tool_id for tool_id in tool_ids if tool_id.startswith(prefix)}
+
+
+def _native_server_matches(server: dict[str, Any], server_url: str | None) -> bool:
+    if server.get("name") != MCP_SERVER_NAME:
+        return False
+    return all(server[field] == server_url for field in ("url", "uri") if field in server)
 
 
 def _native_server_error(

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -43,6 +43,7 @@ from factory_droid_openai.droid_rpc import (
     ContextBreakdown,
     ContextStats,
     DroidRpcExtension,
+    NativeToolUnavailableError,
 )
 from factory_droid_openai.logs import TRACE as _TRACE_LEVEL
 from factory_droid_openai.logs import current_timeline
@@ -562,10 +563,21 @@ class DroidRunner:
                                 enabled_tool_ids=[],
                             )
                         initialized = True
+                        native_binding = request.native_tools
                         await self._rpc.disable_native_tools(
                             client,
                             keep_tool_prefix=(
-                                None if request.native_tools is None else MCP_TOOL_ID_PREFIX
+                                None if native_binding is None else MCP_TOOL_ID_PREFIX
+                            ),
+                            expected_tool_ids=(
+                                None
+                                if native_binding is None
+                                else frozenset(
+                                    f"{MCP_TOOL_ID_PREFIX}{name}" for name in native_binding.names
+                                )
+                            ),
+                            native_server_url=(
+                                None if native_binding is None else native_binding.url
                             ),
                         )
 
@@ -731,6 +743,12 @@ class DroidRunner:
                 f"Factory Droid session '{request.session_id}' was not found.",
                 status_code=404,
                 error_type="session_not_found",
+            ) from exc
+        except NativeToolUnavailableError as exc:
+            raise RunnerError(
+                str(exc),
+                status_code=503,
+                error_type="factory_native_tool_unavailable",
             ) from exc
         except DroidClientError as exc:
             model_id = _resolve_model_id(request.model, request.model_alias)

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -672,19 +672,50 @@ async def test_native_tool_setup_reports_missing_bridge_server(
 
 @pytest.mark.asyncio
 async def test_native_tool_setup_rejects_duplicate_bridge_servers() -> None:
+    url = "http://127.0.0.1:8787/factory/mcp/token"
+
     def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
         if method == "droid.list_mcp_servers":
             return {
                 "result": {
                     "servers": [
-                        {"name": "openai-bridge", "status": "connected"},
+                        {"name": "openai-bridge", "status": "connected", "url": url},
                         {"name": "openai-bridge", "status": "connected"},
                     ]
                 }
             }
         raise AssertionError(method)
 
-    with pytest.raises(NativeToolUnavailableError, match="multiple"):
+    with pytest.raises(NativeToolUnavailableError, match="multiple") as error:
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+            native_server_url=url,
+        )
+
+    # Naming what was reported is what tells an operator whether the extra
+    # entry is a stale bridge or a foreign server borrowing the name.
+    assert url in str(error.value)
+    assert "no URL reported" in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_reports_a_failed_status() -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {"name": "openai-bridge", "status": "disconnected", "error": "gone"}
+                    ]
+                }
+            }
+        raise AssertionError(method)
+
+    with pytest.raises(
+        NativeToolUnavailableError,
+        match="failed at the configured native tool URL",
+    ):
         await DroidRpcExtension().disable_native_tools(
             _client(FakeProtocol(handler)),
             expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
@@ -692,31 +723,75 @@ async def test_native_tool_setup_rejects_duplicate_bridge_servers() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("status", "message"),
-    [
-        ("disconnected", "failed at the configured native tool URL"),
-        ("mystery", "unknown status"),
-    ],
-)
-async def test_native_tool_setup_reports_non_connected_status(
-    status: str,
-    message: str,
+async def test_native_tool_setup_waits_out_an_unrecognized_status(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A status name this bridge does not know is a wait, not a verdict."""
+    monkeypatch.setattr(rpc_module, "_NATIVE_MCP_WAIT_SECONDS", 0.0)
+
     def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
         if method == "droid.list_mcp_servers":
-            return {
-                "result": {
-                    "servers": [{"name": "openai-bridge", "status": status, "error": "gone"}]
-                }
-            }
+            return {"result": {"servers": [{"name": "openai-bridge", "status": "mystery"}]}}
         raise AssertionError(method)
 
-    with pytest.raises(NativeToolUnavailableError, match=message):
+    with pytest.raises(
+        NativeToolUnavailableError,
+        match=r"did not connect.*last status 'mystery'",
+    ):
         await DroidRpcExtension().disable_native_tools(
             _client(FakeProtocol(handler)),
             expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
         )
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_accepts_a_server_that_leaves_an_unknown_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statuses = iter(["initializing", "connected"])
+
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"name": "openai-bridge", "status": next(statuses)}]}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": f"{MCP_TOOL_ID_PREFIX}get_weather",
+                            "currentlyAllowed": True,
+                        }
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            return {"result": {}}
+        raise AssertionError(method)
+
+    monkeypatch.setattr(rpc_module, "_NATIVE_MCP_WAIT_SECONDS", 1.0)
+
+    await DroidRpcExtension().disable_native_tools(
+        _client(FakeProtocol(handler)),
+        keep_tool_prefix="mcp_openai-bridge_",
+        expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+    )
+
+
+def test_native_server_matching_compares_endpoint_identity() -> None:
+    matches = rpc_module._native_server_matches
+    url = "http://127.0.0.1:8787/factory/mcp/tok"
+
+    # Spelling Droid may normalize on its way back: trailing slash, case, and
+    # an explicit default port all name the same endpoint.
+    assert matches({"name": "openai-bridge", "url": f"{url}/"}, url)
+    assert matches({"name": "openai-bridge", "url": url.replace("http", "HTTP")}, url)
+    assert matches({"name": "openai-bridge", "url": "http://host/mcp"}, "http://host:80/mcp")
+    assert matches({"name": "openai-bridge"}, url)
+    assert not matches({"name": "openai-bridge", "url": "http://127.0.0.1:9999/x"}, url)
+    assert not matches({"name": "openai-bridge", "url": "http://127.0.0.1:port/x"}, url)
+    assert not matches({"name": "openai-bridge", "url": 7}, url)
+    assert not matches({"name": "openai-bridge", "url": url}, None)
+    assert rpc_module._reported_endpoint({"name": "openai-bridge"}) == "no URL reported"
 
 
 def test_native_tool_error_helpers_render_hostnames() -> None:

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -437,6 +437,7 @@ async def test_disable_native_tools_spares_the_tools_the_bridge_published() -> N
 async def test_native_tool_setup_waits_for_only_the_bridge_server() -> None:
     disabled: set[str] = set()
     expected = frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"})
+    native_server_url = "http://127.0.0.1:8787/factory/mcp/token"
 
     def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
         if method == "droid.list_mcp_servers":
@@ -444,7 +445,11 @@ async def test_native_tool_setup_waits_for_only_the_bridge_server() -> None:
                 "result": {
                     "servers": [
                         {"name": "ambient", "status": "connecting"},
-                        {"name": "openai-bridge", "status": "connected"},
+                        {
+                            "name": "openai-bridge",
+                            "status": "connected",
+                            "url": native_server_url,
+                        },
                     ]
                 }
             }
@@ -473,7 +478,7 @@ async def test_native_tool_setup_waits_for_only_the_bridge_server() -> None:
         _client(protocol),
         keep_tool_prefix="mcp_openai-bridge_",
         expected_tool_ids=expected,
-        native_server_url="http://127.0.0.1:8787/factory/mcp/token",
+        native_server_url=native_server_url,
     )
 
     assert protocol.calls[0][0] == "droid.list_mcp_servers"
@@ -548,6 +553,62 @@ async def test_native_tool_setup_reports_mcp_policy_rejection() -> None:
 
 
 @pytest.mark.asyncio
+async def test_native_tool_setup_rejects_a_mismatched_native_server_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rpc_module, "_NATIVE_MCP_WAIT_SECONDS", 0.0)
+
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {
+                            "name": "openai-bridge",
+                            "status": "connected",
+                            "url": "http://foreign.example/mcp",
+                        }
+                    ]
+                }
+            }
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match="did not connect"):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+            native_server_url="http://127.0.0.1:8787/factory/mcp/token",
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_maps_permission_failure_as_connection_error() -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {
+                            "name": "openai-bridge",
+                            "status": "failed",
+                            "error": "Permission denied",
+                        }
+                    ]
+                }
+            }
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match="failed at") as error:
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+            native_server_url="http://127.0.0.1:8787/factory/mcp/token",
+        )
+
+    assert "mcpPolicy" not in str(error.value)
+
+
+@pytest.mark.asyncio
 async def test_native_tool_setup_waits_for_connecting_bridge_server(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -581,6 +642,13 @@ async def test_native_tool_setup_waits_for_connecting_bridge_server(
     )
 
     assert [method for method, _, _ in protocol.calls].count("droid.list_mcp_servers") == 2
+    timeouts = [
+        timeout for method, _, timeout in protocol.calls if method == "droid.list_mcp_servers"
+    ]
+    assert timeouts[0] is not None
+    assert timeouts[1] is not None
+    assert timeouts[0] <= 1.0
+    assert timeouts[1] < timeouts[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from droid_sdk.errors import DroidClientError
 
-from factory_droid_openai.droid_rpc import DroidRpcExtension, _ProtocolEngine
+from factory_droid_openai import droid_rpc as rpc_module
+from factory_droid_openai.droid_rpc import (
+    DroidRpcExtension,
+    NativeToolUnavailableError,
+    _ProtocolEngine,
+)
+from factory_droid_openai.mcp_tools import MCP_TOOL_ID_PREFIX
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -425,6 +431,264 @@ async def test_disable_native_tools_spares_the_tools_the_bridge_published() -> N
 
     assert enabled == {"mcp_openai-bridge_get_weather"}
     assert disabled == {"exit-spec-mode", "read-cli", "tool-search-cli"}
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_waits_for_only_the_bridge_server() -> None:
+    disabled: set[str] = set()
+    expected = frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"})
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {"name": "ambient", "status": "connecting"},
+                        {"name": "openai-bridge", "status": "connected"},
+                    ]
+                }
+            }
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {"id": "read-cli", "currentlyAllowed": "read-cli" not in disabled},
+                        {"id": "exit-spec-mode", "currentlyAllowed": True},
+                        {"id": "tool-search-cli", "currentlyAllowed": True},
+                        {
+                            "id": f"{MCP_TOOL_ID_PREFIX}get_weather",
+                            "currentlyAllowed": True,
+                        },
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            disabled.update(params["disabledToolIds"])
+            return {"result": {}}
+        raise AssertionError(method)
+
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension().disable_native_tools(
+        _client(protocol),
+        keep_tool_prefix="mcp_openai-bridge_",
+        expected_tool_ids=expected,
+        native_server_url="http://127.0.0.1:8787/factory/mcp/token",
+    )
+
+    assert protocol.calls[0][0] == "droid.list_mcp_servers"
+    update = next(params for method, params, _ in protocol.calls if "update" in method)
+    assert update["enabledToolIds"] == [f"{MCP_TOOL_ID_PREFIX}get_weather"]
+    assert update["disabledToolIds"] == ["exit-spec-mode", "read-cli", "tool-search-cli"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tools", "message"),
+    [
+        (
+            [{"id": "read-cli", "currentlyAllowed": True}],
+            "missing mcp_openai-bridge_get_weather",
+        ),
+        (
+            [
+                {"id": "mcp_openai-bridge_get_weather", "currentlyAllowed": True},
+                {"id": "mcp_openai-bridge_other", "currentlyAllowed": True},
+            ],
+            "unexpected mcp_openai-bridge_other",
+        ),
+    ],
+)
+async def test_native_tool_setup_rejects_an_inexact_tool_catalog(
+    tools: list[dict[str, Any]],
+    message: str,
+) -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"name": "openai-bridge", "status": "connected"}]}}
+        if method == "droid.list_tools":
+            return {"result": {"tools": tools}}
+        if method == "droid.update_session_settings":
+            raise AssertionError("inexact catalogs must fail before settings update")
+        raise AssertionError(method)
+
+    protocol = FakeProtocol(handler)
+
+    with pytest.raises(NativeToolUnavailableError, match=message):
+        await DroidRpcExtension().disable_native_tools(
+            _client(protocol),
+            keep_tool_prefix="mcp_openai-bridge_",
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_reports_mcp_policy_rejection() -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {
+                            "name": "openai-bridge",
+                            "status": "failed",
+                            "error": "server denied by organization mcpPolicy allowlist",
+                        }
+                    ]
+                }
+            }
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match=r"mcpPolicy.*127.0.0.1"):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+            native_server_url="http://127.0.0.1:8787/factory/mcp/token",
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_waits_for_connecting_bridge_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statuses = iter(["connecting", "connected"])
+
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"name": "openai-bridge", "status": next(statuses)}]}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": f"{MCP_TOOL_ID_PREFIX}get_weather",
+                            "currentlyAllowed": True,
+                        }
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            return {"result": {}}
+        raise AssertionError(method)
+
+    monkeypatch.setattr(rpc_module, "_NATIVE_MCP_WAIT_SECONDS", 1.0)
+    protocol = FakeProtocol(handler)
+
+    await DroidRpcExtension().disable_native_tools(
+        _client(protocol),
+        keep_tool_prefix="mcp_openai-bridge_",
+        expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+    )
+
+    assert [method for method, _, _ in protocol.calls].count("droid.list_mcp_servers") == 2
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_reports_missing_bridge_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rpc_module, "_NATIVE_MCP_WAIT_SECONDS", 0.0)
+
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"name": "ambient", "status": "failed"}]}}
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match=r"openai-bridge.*127.0.0.1"):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+            native_server_url="http://127.0.0.1:8787/factory/mcp/token",
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_rejects_duplicate_bridge_servers() -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {"name": "openai-bridge", "status": "connected"},
+                        {"name": "openai-bridge", "status": "connected"},
+                    ]
+                }
+            }
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match="multiple"):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [
+        ("disconnected", "failed at the configured native tool URL"),
+        ("mystery", "unknown status"),
+    ],
+)
+async def test_native_tool_setup_reports_non_connected_status(
+    status: str,
+    message: str,
+) -> None:
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [{"name": "openai-bridge", "status": status, "error": "gone"}]
+                }
+            }
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match=message):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+        )
+
+
+def test_native_tool_error_helpers_render_hostnames() -> None:
+    assert rpc_module._server_hostname(None) == "the configured native tool URL"
+    assert rpc_module._server_hostname("not a URL") == "the configured native tool URL"
+    assert rpc_module._state_value(SimpleNamespace(value="connected")) == "connected"
+    assert rpc_module._state_value("connected") == "connected"
+
+
+@pytest.mark.asyncio
+async def test_native_tool_setup_rejects_a_tool_that_stays_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rpc_module, "_TOOL_DISABLE_RETRIES", 1)
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"name": "openai-bridge", "status": "connected"}]}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": f"{MCP_TOOL_ID_PREFIX}get_weather",
+                            "currentlyAllowed": False,
+                        }
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            assert params["enabledToolIds"] == [f"{MCP_TOOL_ID_PREFIX}get_weather"]
+            return {"result": {}}
+        raise AssertionError(method)
+
+    with pytest.raises(NativeToolUnavailableError, match="did not keep"):
+        await DroidRpcExtension().disable_native_tools(
+            _client(FakeProtocol(handler)),
+            keep_tool_prefix="mcp_openai-bridge_",
+            expected_tool_ids=frozenset({f"{MCP_TOOL_ID_PREFIX}get_weather"}),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2013,6 +2013,14 @@ class NativeToolClient(FakeClient):
         timeout: float | None = None,
         request_id: str | None = None,
     ) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {"name": "openai-bridge", "status": "connected"},
+                    ]
+                }
+            }
         if method != "droid.list_tools":
             return await super().send_request(method, params, timeout, request_id)
         del request_id
@@ -2028,10 +2036,39 @@ class NativeToolClient(FakeClient):
                     # Droid keeps the deferred-tool loader callable whenever a
                     # session has a tool left to load.
                     {"id": "tool-search-cli", "currentlyAllowed": True},
-                    {"id": f"{MCP_TOOL_ID_PREFIX}get_weather", "currentlyAllowed": True},
+                    *(
+                        {
+                            "id": f"{MCP_TOOL_ID_PREFIX}{name}",
+                            "currentlyAllowed": True,
+                        }
+                        for name in ("get_weather", "write_file", "ping")
+                    ),
                 ]
             }
         }
+
+
+class PolicyBlockedNativeToolClient(FakeClient):
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        timeout: float | None = None,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {
+                "result": {
+                    "servers": [
+                        {
+                            "name": "openai-bridge",
+                            "status": "failed",
+                            "error": "blocked by organization mcpPolicy allowlist",
+                        }
+                    ]
+                }
+            }
+        return await super().send_request(method, params, timeout, request_id)
 
 
 def _native_binding() -> NativeToolBinding:
@@ -2078,8 +2115,30 @@ async def test_runner_publishes_client_tools_to_droid_over_mcp(tmp_path: Path) -
         {"name": "openai-bridge", "type": "http", "url": binding.url}
     ]
     settings = [params for method, params, _ in client.rpc_requests if "enabledToolIds" in params]
-    assert settings[0]["enabledToolIds"] == [f"{MCP_TOOL_ID_PREFIX}get_weather"]
+    assert settings[0]["enabledToolIds"] == [
+        f"{MCP_TOOL_ID_PREFIX}get_weather",
+        f"{MCP_TOOL_ID_PREFIX}ping",
+        f"{MCP_TOOL_ID_PREFIX}write_file",
+    ]
     assert settings[0]["disabledToolIds"] == ["exit-spec-mode", "read-cli", "tool-search-cli"]
+
+
+@pytest.mark.asyncio
+async def test_runner_maps_native_mcp_policy_rejection_to_503(tmp_path: Path) -> None:
+    client = PolicyBlockedNativeToolClient([])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match=r"mcpPolicy.*127.0.0.1") as error:
+        await _collect(runner, _request(native_tools=_native_binding()))
+
+    assert error.value.status_code == 503
+    assert error.value.error_type == "factory_native_tool_unavailable"
+    assert client.prompt == ""
+    assert client.closed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Wait for the bridge-owned openai-bridge MCP server without relying on unrelated servers.
- Require the exact request tool catalog before prompt submission.
- Map MCP policy and native catalog failures to HTTP 503 factory_native_tool_unavailable.
- Document enterprise mcpPolicy hostname allowlists and add regression coverage.

Closes #88

## Validation

- Full test suite with 100 percent coverage
- Ruff and strict mypy
- OpenAPI validation, lock check, and package build
