### PR TITLE
feat(docker): enable Droid auto-updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist/
 .wrangler/
 traces/
 .playwright-mcp/
+.worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,35 @@
 #
 # Container image for the Factory Droid OpenAI Bridge.
 #
-# Builds a self-contained image that runs the bridge and a pinned Droid CLI.
+# Builds a self-contained image that runs the bridge and the Droid CLI.
 # The bridge listens on 0.0.0.0:8787 inside the container; bind it to
 # 127.0.0.1 on the host and front it with the bridge bearer token when
 # exposing it beyond loopback.
 #
 # Build args:
-#   PYTHON_VERSION   Python base image tag (default 3.13-slim).
-#   DROID_VERSION    Factory Droid CLI version (default: latest from npm registry).
-#   BRIDGE_VERSION   factory-droid-openai PyPI version (default: install from source).
+#   PYTHON_VERSION     Python base image tag (default 3.13-slim).
+#   DROID_VERSION      Factory Droid CLI version (default: latest from npm registry).
+#   DROID_AUTO_UPDATE  Enable runtime CLI updates (default: true).
+#   BRIDGE_VERSION     factory-droid-openai PyPI version (default: install from source).
 #
-# Droid auto-update is disabled so the resolved CLI version is locked in for the
-# lifetime of the image. Omit DROID_VERSION to auto-resolve latest at build time;
-# set it to pin a specific release.
+# Runtime auto-updates are enabled by default. They are performed by the CLI
+# itself and are not covered by the build-time checksum verification, so set
+# DROID_AUTO_UPDATE=false when the running CLI must match the image digest, or
+# when the container has no writable home directory or no egress to
+# downloads.factory.ai. Omit DROID_VERSION to resolve the latest release at
+# build time; set it to pin the initial release.
 
 ARG PYTHON_VERSION=3.13-slim
 ARG DROID_VERSION
+ARG DROID_AUTO_UPDATE=true
 
 FROM python:${PYTHON_VERSION} AS base
 
 ARG DROID_VERSION
 ARG BRIDGE_VERSION
 
+# FACTORY_DROID_AUTO_UPDATE_ENABLED is false here so no build step can swap the
+# verified binary. The requested runtime value is applied in the last layer.
 ENV FACTORY_DROID_OPENAI_HOST=0.0.0.0 \
     FACTORY_DROID_OPENAI_PORT=8787 \
     FACTORY_DROID_OPENAI_WORKDIR=/work \
@@ -83,10 +90,29 @@ RUN if [ -n "${BRIDGE_VERSION}" ]; then \
 # working directory (Factory-native tools are disabled), so a read-only host
 # mount at /work is safe. Sessions live in the per-user Factory config dir.
 RUN useradd --create-home --uid 1000 droid \
- && mkdir -p /home/droid/.factory \
- && chown -R droid:droid /work /home/droid/.factory
+ && mkdir -p /home/droid/.factory /home/droid/.local/bin \
+ && mv /usr/local/bin/droid /home/droid/.local/bin/droid \
+ && chown -R droid:droid /work /home/droid/.factory /home/droid/.local
+
+# The updater replaces the executable in place, so it has to live in a
+# directory the non-root runtime user owns.
+ENV PATH="/home/droid/.local/bin:${PATH}"
 USER droid
 WORKDIR /work
+
+# Prove the relocated binary resolves through PATH and is executable by the
+# runtime user. Updates are still disabled at this point, so the check cannot
+# replace the verified binary.
+RUN droid --version
+
+# Declared and consumed last, so toggling DROID_AUTO_UPDATE does not
+# invalidate the cached apt and install layers.
+ARG DROID_AUTO_UPDATE
+RUN case "${DROID_AUTO_UPDATE}" in \
+      true|false) ;; \
+      *) echo "DROID_AUTO_UPDATE must be true or false" >&2; exit 1 ;; \
+    esac
+ENV FACTORY_DROID_AUTO_UPDATE_ENABLED=${DROID_AUTO_UPDATE}
 
 EXPOSE 8787
 

--- a/README.md
+++ b/README.md
@@ -484,9 +484,14 @@ each release:
 docker pull ghcr.io/mrwogu/factory-droid-openai:latest
 ```
 
-The image bundles a pinned Droid CLI with auto-updates disabled, so the
-bridge and CLI versions are reproducible. Droid runs as a non-root user
-(`uid 1000`) and the bridge listens on `0.0.0.0:8787` inside the container.
+The image installs a SHA256-verified Droid CLI release. Auto-updates are
+enabled by default, so new Droid processes can use newer CLI versions without
+rebuilding the bridge image. Runtime updates are performed by the Droid CLI
+itself and are not covered by the build-time checksum verification, so a
+long-running container can drift from the CLI version in the published image.
+Build or run with updates disabled when the running CLI must match the image
+digest. Droid runs as a non-root user (`uid 1000`) and the bridge listens on
+`0.0.0.0:8787` inside the container.
 
 Run it with a Factory service-account key and a bridge bearer token. Bind
 the port to loopback on the host so the bridge is not exposed to the
@@ -511,6 +516,21 @@ export FACTORY_DROID_OPENAI_API_KEY="$(python -c 'import secrets; print(secrets.
 docker compose up -d
 ```
 
+The update setting is inherited by every Droid subprocess. Droid checks for
+updates when a new process starts. Existing processes keep their current
+version; restarting the container is not required for future requests. Restart
+the container only when all warm sessions must switch immediately. Updates
+modify the current container filesystem, not the published image, so a
+recreated container starts from the image version and checks again.
+
+Runtime updates need a writable `/home/droid/.local/bin` and outbound HTTPS to
+`downloads.factory.ai`. Set `FACTORY_DROID_AUTO_UPDATE_ENABLED=false` when the
+container runs with `--read-only`, runs as a UID other than `1000`, or has no
+such egress; otherwise every new Droid process retries the update. Warm
+sessions start several Droid processes, so the same executable can be replaced
+while other processes are being spawned. Disable updates when the CLI version
+has to stay identical across a burst of requests.
+
 Podman works as a drop-in replacement. Use `podman-compose` or replace
 `docker` with `podman` in the commands above. The compose file uses
 `${VAR:?error}` syntax to require environment variables; set both keys in
@@ -525,9 +545,23 @@ in `docker-compose.yml` when using Compose, to run without a workdir.
 To build the image locally instead of pulling it:
 
 ```bash
+# Runtime auto-updates are enabled by default.
 docker build -t factory-droid-openai .
-# or, pinning the Droid CLI version:
-docker build --build-arg DROID_VERSION=0.174.0 -t factory-droid-openai .
+# Pin the initial CLI release and disable runtime updates:
+docker build \
+  --build-arg DROID_VERSION=0.174.0 \
+  --build-arg DROID_AUTO_UPDATE=false \
+  -t factory-droid-openai .
+```
+
+Override the image default in a running container with
+`FACTORY_DROID_AUTO_UPDATE_ENABLED=false`. The compose file forwards that
+variable from the host only when it is set, so an image built with
+`DROID_AUTO_UPDATE=false` stays pinned without any runtime override:
+
+```bash
+export FACTORY_DROID_AUTO_UPDATE_ENABLED=false
+docker compose up -d
 ```
 
 Authentication inside a container uses `FACTORY_API_KEY` only. Interactive
@@ -1282,6 +1316,7 @@ error types.
 | `FACTORY_DROID_OPENAI_PORT` | `8787` | Listen port |
 | `FACTORY_DROID_OPENAI_API_KEY` | unset | Optional bearer token |
 | `FACTORY_DROID_PATH` | `droid` | Droid executable path |
+| `FACTORY_DROID_AUTO_UPDATE_ENABLED` | unset | Read by the Droid CLI, not the bridge; `false` disables CLI self-updates. The container image sets it from the `DROID_AUTO_UPDATE` build arg |
 | `FACTORY_DROID_OPENAI_WORKDIR` | current directory | Droid working directory |
 | `FACTORY_DROID_OPENAI_TIMEOUT_SECONDS` | `600` | Maximum request duration |
 | `FACTORY_DROID_OPENAI_SESSION_INIT_TIMEOUT_SECONDS` | `60` | Session connect, initialize/load, and tool-safety cap; maximum `60` for `droid-sdk==0.1.2` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@
 #   The bridge disables all Factory-native tools, so the mount can be
 #   read-only. Remove the volumes block below if you do not need a workdir.
 #   Set FACTORY_DROID_SETTINGS_FILE to mount one Droid settings.json read-only.
+#   Set FACTORY_DROID_AUTO_UPDATE_ENABLED=false to keep the CLI version that
+#   ships in the image instead of updating at runtime.
 #
 # Usage:
 #   export FACTORY_API_KEY=fk-...
@@ -22,18 +24,24 @@ services:
     # Always pull the newest image on `docker compose up`.
     pull_policy: always
     # Build locally instead of pulling the published image:
-    # build: .
+    # build:
+    #   context: .
+    #   args:
+    #     DROID_AUTO_UPDATE: ${DROID_AUTO_UPDATE:-true}
     ports:
       - "127.0.0.1:8787:8787"
     environment:
-      FACTORY_API_KEY: ${FACTORY_API_KEY:?FACTORY_API_KEY must be set}
-      FACTORY_DROID_OPENAI_API_KEY: ${FACTORY_DROID_OPENAI_API_KEY:?FACTORY_DROID_OPENAI_API_KEY must be set}
+      - FACTORY_API_KEY=${FACTORY_API_KEY:?FACTORY_API_KEY must be set}
+      - FACTORY_DROID_OPENAI_API_KEY=${FACTORY_DROID_OPENAI_API_KEY:?FACTORY_DROID_OPENAI_API_KEY must be set}
+      # Forwarded only when set on the host, so an image built with
+      # DROID_AUTO_UPDATE=false stays pinned by default.
+      - FACTORY_DROID_AUTO_UPDATE_ENABLED
       # Optional overrides:
-      # FACTORY_DROID_OPENAI_MAX_CONCURRENCY: "2"
-      # FACTORY_DROID_OPENAI_WARM_SESSIONS: "2"
-      # FACTORY_DROID_OPENAI_TIMEOUT_SECONDS: "600"
-      # FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS: "300"
-      # FACTORY_DROID_OPENAI_TELEMETRY: "false"
+      # - FACTORY_DROID_OPENAI_MAX_CONCURRENCY=2
+      # - FACTORY_DROID_OPENAI_WARM_SESSIONS=2
+      # - FACTORY_DROID_OPENAI_TIMEOUT_SECONDS=600
+      # - FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS=300
+      # - FACTORY_DROID_OPENAI_TELEMETRY=false
     # Optional read-only mounts. Uncomment `volumes` and either entry needed.
     # volumes:
     #   - ./:/work:ro


### PR DESCRIPTION
## Summary

- Enable Droid CLI auto-updates by default with `DROID_AUTO_UPDATE=true`.
- Install the runtime binary in the UID 1000 user's writable bin directory.
- Add Compose, workflow, opt-out, and update lifecycle documentation.

## Validation

- Podman builds with default, enabled, and disabled update modes.
- Non-root image smoke test and `droid update --check` passed.
- Invalid `DROID_AUTO_UPDATE` value rejected.
- Compose true/false interpolation passed.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` - 1753 passed, 100% coverage
- `uv run python scripts/generate_openapi.py`
- `uv run openapi-spec-validator openapi.json`
- `uv lock --check`
- `uv build`
- `prs validate`, `prs diff`, `prs check`

Closes #99
