### PR TITLE
fix(pool): retire unused startup demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1510,6 +1510,9 @@ Requests that ask for a different model, for the model alias, or for the
 model's default reasoning effort on a session that carries an explicit one,
 log `pool.miss` and wait for a fresh session. The pool tracks the settings
 recent traffic used, so repeat traffic converges on exact matches.
+The initial default-model demand is only a startup seed. When the first
+request asks for another model or reasoning effort, the pool retires that
+unused seed and moves all capacity to the observed demand.
 
 Teardown runs after the response is finished, so session close and the second
 `droid exec` needs to exit no longer delay the last token. Set
@@ -1554,6 +1557,10 @@ DEBUG    2026-07-27T14:10:12+0200 event=droid.cleanup request_id=chatcmpl-8f2a c
 `pool.retune` and `droid.session_retuned` only when a session warmed for the
 same model is reused at another reasoning effort, and cleanup is logged after
 the response because it is detached.
+
+`elapsed_ms` on an intermediate event is the request age when that event was
+logged. A `pool.miss` happens after admission, so its `elapsed_ms` includes
+`queue_ms`; it is not the duration of the pool lookup or session startup.
 
 Phase fields, in the order they occur:
 

--- a/src/factory_droid_openai/pool.py
+++ b/src/factory_droid_openai/pool.py
@@ -134,6 +134,8 @@ class WarmSessionPool:
         self._native_sessions: dict[_WarmDemand, deque[WarmSession]] = defaultdict(deque)
         self._wanted: list[SessionKey] = []
         self._native_wanted: list[_WarmDemand] = []
+        # Startup cannot know which explicit model the first request will use.
+        self._initial_key: SessionKey | None = None
         self._wake = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
@@ -145,6 +147,7 @@ class WarmSessionPool:
         if not self.enabled or self._task is not None:
             return
         if initial_key is not None:
+            self._initial_key = initial_key
             self.note(initial_key)
         self._task = asyncio.create_task(self._loop())
 
@@ -165,6 +168,7 @@ class WarmSessionPool:
         self._native_sessions.clear()
         self._wanted.clear()
         self._native_wanted.clear()
+        self._initial_key = None
         self._publish()
         for session in sessions:
             self._reaper.submit(self._discard_session(session))
@@ -210,29 +214,39 @@ class WarmSessionPool:
         if not self.enabled:
             return None
         demand = _WarmDemand(key, catalog)
+        initial_demand: _WarmDemand | None = None
+        if self._initial_key is not None:
+            initial_demand = _WarmDemand(self._initial_key)
+            self._initial_key = None
+            if demand == initial_demand:
+                initial_demand = None
+            elif initial_demand.key in self._wanted:
+                self._wanted.remove(initial_demand.key)
         self.note(key, catalog)
         session = self._take_demand(demand)
-        if session is not None:
-            self._publish()
-            if self._metrics is not None:
-                self._metrics.increment_warm_hits()
-            log_debug("pool.hit", model=key.model_id, warm_sessions=self._total())
-            return session
-        session = self._take_retunable(demand)
-        if session is not None:
-            self._publish()
-            if self._metrics is not None:
-                self._metrics.increment_warm_hits()
-                self._metrics.increment_warm_retunes(WARM_RETUNE_EFFORT)
-            log_debug(
-                "pool.retune",
-                model=key.model_id,
-                reason=WARM_RETUNE_EFFORT,
-                warmed_for_effort=session.key.reasoning_effort,
-                warm_sessions=self._total(),
-            )
-            return session
+        retuned = False
+        if session is None:
+            session = self._take_retunable(demand)
+            retuned = session is not None
+        if initial_demand is not None:
+            self._drop_demand(initial_demand)
         self._publish()
+        if session is not None:
+            if self._metrics is not None:
+                self._metrics.increment_warm_hits()
+                if retuned:
+                    self._metrics.increment_warm_retunes(WARM_RETUNE_EFFORT)
+            if retuned:
+                log_debug(
+                    "pool.retune",
+                    model=key.model_id,
+                    reason=WARM_RETUNE_EFFORT,
+                    warmed_for_effort=session.key.reasoning_effort,
+                    warm_sessions=self._total(),
+                )
+            else:
+                log_debug("pool.hit", model=key.model_id, warm_sessions=self._total())
+            return session
         if self._metrics is not None:
             self._metrics.increment_warm_misses()
         log_debug("pool.miss", model=key.model_id, warm_sessions=self._total())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4123,6 +4123,40 @@ async def test_chat_completion_uses_a_warm_session(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_text_tool_catalogs_share_warm_session_demand(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("hi"), RunComplete(Usage())])
+    app = _app(tmp_path, runner)
+    key = SessionKey(model_id="gpt-5.6-luna", reasoning_effort="none")
+    app.state.pool.note(key)
+    app.state.pool.offer(_warm_session(key))
+    app.state.pool.offer(_warm_session(key))
+
+    async with _client(app) as client:
+        for name in ("search_observations", "recall"):
+            response = await client.post(
+                "/v1/chat/completions",
+                json=_payload(
+                    model="gpt-5.6-luna",
+                    reasoning_effort="none",
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                ),
+            )
+            assert response.status_code == 200
+
+    assert len(runner.requests) == 2
+    assert all(request.warm_session is not None for request in runner.requests)
+    assert "factory_droid_openai_warm_session_hits_total 2" in app.state.metrics.render()
+
+
+@pytest.mark.asyncio
 async def test_warm_session_key_follows_the_configured_reasoning_effort(tmp_path: Path) -> None:
     runner = FakeRunner([TextDelta("hi"), RunComplete(Usage())])
     settings = Settings(

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -22,6 +22,9 @@ KEY = SessionKey(model_id="model-a", reasoning_effort="high")
 OTHER_KEY = SessionKey(model_id="model-b", reasoning_effort=None)
 RETUNE_KEY = SessionKey(model_id="model-a", reasoning_effort="low")
 CROSS_MODEL_KEY = SessionKey(model_id="model-b", reasoning_effort="high")
+# Shape the bridge actually seeds the pool with: the model Droid defaults to.
+SEED_KEY = SessionKey(model_id=None, reasoning_effort=None)
+SEED_EFFORT_KEY = SessionKey(model_id=None, reasoning_effort="high")
 
 
 class FakeTransport:
@@ -658,6 +661,36 @@ async def test_first_observed_effort_reuses_one_startup_session() -> None:
     rendered = metrics.render()
     assert "factory_droid_openai_warm_session_hits_total 1" in rendered
     assert 'factory_droid_openai_warm_session_retunes_total{reason="effort"} 1' in rendered
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_model_less_startup_seed_retires_instead_of_retuning() -> None:
+    """An effort change on the startup seed cannot borrow one of its sessions.
+
+    The bridge seeds the pool with the model Droid defaults to, and a session
+    without an explicit model id cannot be repointed, so the whole seed has to
+    retire. Handing one over anyway would fail the turn in the runner.
+    """
+    log: list[str] = []
+    metrics = BridgeMetrics()
+    runner = FakeRunner(log=log)
+    pool = _pool(runner, size=2, metrics=metrics)
+
+    pool.start(initial_key=SEED_KEY)
+    await asyncio.sleep(0.05)
+    assert runner.warmed == 2
+
+    assert pool.acquire(SEED_EFFORT_KEY) is None
+    await asyncio.sleep(0.05)
+
+    assert log.count("discard:None") == 2
+    assert runner.warmed == 4
+    rendered = metrics.render()
+    assert "factory_droid_openai_warm_session_misses_total 1" in rendered
+    assert 'factory_droid_openai_warm_session_retunes_total{reason="effort"} 0' in rendered
+    assert pool.acquire(SEED_EFFORT_KEY) is not None
+    assert pool.acquire(SEED_EFFORT_KEY) is not None
     await pool.aclose()
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -540,14 +540,17 @@ async def test_pool_refills_after_a_session_is_taken() -> None:
 async def test_pool_sweeps_expired_sessions_in_the_background() -> None:
     log: list[str] = []
     runner = FakeRunner(log=log)
-    pool = _pool(runner, size=1, ttl_seconds=1.0)
+    pool = _pool(runner, size=2, ttl_seconds=1.0)
     pool.note(KEY)
     pool.offer(_session(created_at=asyncio.get_running_loop().time() - 10.0))
+    pool.offer(_session(created_at=asyncio.get_running_loop().time()))
 
     pool.start()
     await asyncio.sleep(0.05)
 
     assert sorted(log) == ["discard:model-a", "warm:model-a"]
+    assert pool.acquire(KEY) is not None
+    assert pool.acquire(KEY) is not None
     await pool.aclose()
 
 
@@ -558,7 +561,7 @@ async def test_pool_tolerates_warm_failures_without_metrics() -> None:
     pool.start(initial_key=KEY)
     await asyncio.sleep(0.05)
 
-    assert pool.acquire(KEY) is None
+    assert pool.acquire(OTHER_KEY) is None
     await pool.aclose()
 
 
@@ -607,6 +610,54 @@ async def test_pool_moves_capacity_to_the_key_traffic_switched_to() -> None:
     assert sorted(log) == ["discard:model-a", "warm:model-a", "warm:model-b"]
     session = pool.acquire(OTHER_KEY)
     assert session is not None
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_first_observed_key_replaces_the_startup_key() -> None:
+    log: list[str] = []
+    runner = FakeRunner(log=log)
+    pool = _pool(runner, size=2)
+
+    pool.start(initial_key=KEY)
+    await asyncio.sleep(0.05)
+    assert log == ["warm:model-a", "warm:model-a"]
+
+    assert pool.acquire(OTHER_KEY) is None
+    await asyncio.sleep(0.05)
+
+    assert log == [
+        "warm:model-a",
+        "warm:model-a",
+        "discard:model-a",
+        "discard:model-a",
+        "warm:model-b",
+        "warm:model-b",
+    ]
+    assert pool.acquire(OTHER_KEY) is not None
+    assert pool.acquire(OTHER_KEY) is not None
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_first_observed_effort_reuses_one_startup_session() -> None:
+    log: list[str] = []
+    metrics = BridgeMetrics()
+    runner = FakeRunner(log=log)
+    pool = _pool(runner, size=2, metrics=metrics)
+
+    pool.start(initial_key=KEY)
+    await asyncio.sleep(0.05)
+
+    session = pool.acquire(RETUNE_KEY)
+    await asyncio.sleep(0)
+
+    assert session is not None
+    assert session.key == KEY
+    assert log == ["warm:model-a", "warm:model-a", "discard:model-a"]
+    rendered = metrics.render()
+    assert "factory_droid_openai_warm_session_hits_total 1" in rendered
+    assert 'factory_droid_openai_warm_session_retunes_total{reason="effort"} 1' in rendered
     await pool.aclose()
 
 


### PR DESCRIPTION
## Summary

The startup pool seeds Droid's default model because no request exists yet.
That seed stayed in demand history after the first request selected an explicit
model. With `warm_sessions=2` it permanently reserved one slot, leaving only
one active warm session for burst traffic.

The first request now confirms or retires the seed. Exact and same-model effort
reuse still happen before remaining seed sessions are discarded. Text requests
with changing tool catalogs stay keyed only by model and reasoning effort.

No replay fixture here. The bug is pool scheduling before the model emits any
events, so deterministic pool and ASGI tests cover it.

Closes #101

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`
- [x] `uv run python scripts/generate_openapi.py`
- [x] `uv lock --check`

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.
