### PR TITLE
feat(queue): admit foreground requests ahead of normal backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1444,6 +1444,15 @@ Admission control then bounds how many requests reach Droid. Requests beyond
 `FACTORY_DROID_OPENAI_MAX_QUEUE_SIZE`; once that is full the bridge answers
 `429` with a `Retry-After` header rather than queueing without limit.
 
+Chat requests may carry `X-Factory-Droid-Priority: high` to mark foreground
+traffic. High-priority requests are admitted ahead of queued normal work, so
+they wait for a free Droid slot rather than behind the backlog. When the queue
+is full, a high-priority request still gets in by rejecting the newest queued
+normal request - the one that has waited least - while a normal request that
+finds the queue full is rejected as before. An unknown header value fails
+closed with `400`. The header only affects `/v1/chat/completions`; session
+operations and model discovery always use the normal lane.
+
 `GET /metrics` renders Prometheus-style text. It is excluded from the OpenAPI
 contract because it is an operational endpoint, not part of the OpenAI API
 surface.
@@ -1457,7 +1466,7 @@ surface.
 | `factory_droid_openai_ttft_seconds` | Time to first token |
 | `factory_droid_openai_active_sessions` | Droid sessions running now |
 | `factory_droid_openai_queued_requests` | Requests waiting for admission |
-| `factory_droid_openai_overload_rejections_total` | Requests rejected with `429` |
+| `factory_droid_openai_overload_rejections_total` | Requests rejected with `429`, labelled `priority="high"|"normal"` |
 | `factory_droid_openai_payload_rejections_total` | Requests rejected with `413` |
 | `factory_droid_openai_forced_kills_total` | Droid processes that needed a kill |
 | `factory_droid_openai_model_discovery_failures_total` | Failed Droid model discovery attempts |

--- a/README.md
+++ b/README.md
@@ -1446,12 +1446,14 @@ Admission control then bounds how many requests reach Droid. Requests beyond
 
 Chat requests may carry `X-Factory-Droid-Priority: high` to mark foreground
 traffic. High-priority requests are admitted ahead of queued normal work, so
-they wait for a free Droid slot rather than behind the backlog. When the queue
-is full, a high-priority request still gets in by rejecting the newest queued
-normal request - the one that has waited least - while a normal request that
-finds the queue full is rejected as before. An unknown header value fails
-closed with `400`. The header only affects `/v1/chat/completions`; session
-operations and model discovery always use the normal lane.
+they wait for a free Droid slot rather than behind the backlog. When a full
+queue contains a normal waiter, a high-priority request replaces the newest
+normal waiter - the one that has waited least. When the queue contains only
+high-priority waiters, the new high-priority request is rejected with `429`.
+A normal request that finds the queue full is rejected as before. An unknown
+header value fails closed with `400`. The header only affects
+`/v1/chat/completions`; session operations and model discovery always use the
+normal lane.
 
 `GET /metrics` renders Prometheus-style text. It is excluded from the OpenAPI
 contract because it is an operational endpoint, not part of the OpenAI API
@@ -1466,7 +1468,7 @@ surface.
 | `factory_droid_openai_ttft_seconds` | Time to first token |
 | `factory_droid_openai_active_sessions` | Droid sessions running now |
 | `factory_droid_openai_queued_requests` | Requests waiting for admission |
-| `factory_droid_openai_overload_rejections_total` | Requests rejected with `429`, labelled `priority="high"|"normal"` |
+| `factory_droid_openai_overload_rejections_total` | Requests rejected with `429`, labelled `priority="high"` or `priority="normal"` |
 | `factory_droid_openai_payload_rejections_total` | Requests rejected with `413` |
 | `factory_droid_openai_forced_kills_total` | Droid processes that needed a kill |
 | `factory_droid_openai_model_discovery_failures_total` | Failed Droid model discovery attempts |

--- a/openapi.json
+++ b/openapi.json
@@ -1066,6 +1066,24 @@
     "/v1/chat/completions": {
       "post": {
         "operationId": "chat_completions_v1_chat_completions_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Factory-Droid-Priority",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Factory-Droid-Priority"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -10,9 +10,9 @@ import uuid
 from collections import OrderedDict, deque
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Annotated, Any, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar
 
-from fastapi import Depends, FastAPI, Request, Response, Security
+from fastapi import Depends, FastAPI, Header, Request, Response, Security
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -226,6 +226,24 @@ MODEL_RETRIEVE_RESPONSES: dict[int | str, dict[str, Any]] = {
 
 FactoryOperationResult = TypeVar("FactoryOperationResult")
 
+# Priority hint for the admission queue. Unknown header values fail closed
+# so a typo cannot silently demote foreground traffic to the normal lane.
+RequestPriority = Literal["high", "normal"]
+_PRIORITY_HEADER = "X-Factory-Droid-Priority"
+_PRIORITY_HIGH: RequestPriority = "high"
+_PRIORITY_NORMAL: RequestPriority = "normal"
+
+
+def _request_priority(value: str | None) -> RequestPriority | None:
+    if value is None:
+        return _PRIORITY_NORMAL
+    lowered = value.lower()
+    if lowered == _PRIORITY_HIGH:
+        return _PRIORITY_HIGH
+    if lowered == _PRIORITY_NORMAL:
+        return _PRIORITY_NORMAL
+    return None
+
 
 class AdmissionRejectedError(RuntimeError):
     pass
@@ -427,7 +445,22 @@ class AdmissionLease:
             raise cancelled
 
 
+@dataclass(eq=False)
+class _AdmissionTicket:
+    priority: RequestPriority
+    rejected: bool = False
+
+
 class AdmissionController:
+    """Bounded admission with a priority lane in front of the FIFO queue.
+
+    A high-priority request is admitted ahead of queued normal work, so it
+    waits only for a free slot rather than behind the whole backlog. When the
+    queue is full, a high-priority request still gets in by rejecting the
+    newest queued normal waiter - the one that has waited least - while a
+    normal request that finds the queue full is rejected as before.
+    """
+
     def __init__(
         self,
         *,
@@ -440,33 +473,49 @@ class AdmissionController:
         self._metrics = metrics
         self._condition = asyncio.Condition()
         self._active = 0
-        self._waiters: deque[object] = deque()
+        self._waiters: deque[_AdmissionTicket] = deque()
+        self._priority_waiters: deque[_AdmissionTicket] = deque()
 
-    async def acquire(self, deadline: float) -> AdmissionLease:
+    async def acquire(
+        self,
+        deadline: float,
+        *,
+        priority: RequestPriority = _PRIORITY_NORMAL,
+    ) -> AdmissionLease:
         loop = asyncio.get_running_loop()
         started = loop.time()
-        ticket: object | None = None
+        ticket: _AdmissionTicket | None = None
         async with self._condition:
             if deadline <= loop.time():
                 raise TimeoutError
-            if self._active >= self._max_concurrency or self._waiters:
-                if len(self._waiters) >= self._max_queue_size:
-                    raise AdmissionRejectedError
-                ticket = object()
-                self._waiters.append(ticket)
+            if self._active >= self._max_concurrency or self._waiters or self._priority_waiters:
+                if len(self._waiters) + len(self._priority_waiters) >= self._max_queue_size:
+                    if priority == _PRIORITY_HIGH and self._waiters:
+                        # The queue is full of background work: reject the
+                        # newest normal waiter rather than the foreground
+                        # request trying to get in.
+                        self._waiters.pop().rejected = True
+                        self._condition.notify_all()
+                    else:
+                        raise AdmissionRejectedError
+                ticket = _AdmissionTicket(priority)
+                lane = self._priority_waiters if priority == _PRIORITY_HIGH else self._waiters
+                lane.append(ticket)
                 self._publish()
                 try:
                     async with asyncio.timeout_at(deadline):
-                        while (
-                            self._active >= self._max_concurrency or self._waiters[0] is not ticket
+                        while not ticket.rejected and (
+                            self._active >= self._max_concurrency or not self._is_next(ticket)
                         ):
                             await self._condition.wait()
                 except (TimeoutError, asyncio.CancelledError):
-                    self._waiters.remove(ticket)
+                    self._discard_ticket(ticket)
                     self._publish()
                     self._condition.notify_all()
                     raise
-                self._waiters.popleft()
+                if ticket.rejected:
+                    raise AdmissionRejectedError
+                self._discard_ticket(ticket)
 
             self._active += 1
             self._publish()
@@ -480,10 +529,22 @@ class AdmissionController:
             self._publish()
             self._condition.notify_all()
 
+    def _is_next(self, ticket: _AdmissionTicket) -> bool:
+        if ticket.priority == _PRIORITY_HIGH:
+            return self._priority_waiters[0] is ticket
+        return not self._priority_waiters and self._waiters[0] is ticket
+
+    def _discard_ticket(self, ticket: _AdmissionTicket) -> None:
+        # An evicted waiter may time out or be cancelled before it wakes up,
+        # so the ticket can already be gone from its lane.
+        lane = self._priority_waiters if ticket.priority == _PRIORITY_HIGH else self._waiters
+        if ticket in lane:
+            lane.remove(ticket)
+
     def _publish(self) -> None:
         self._metrics.set_admission(
             active=self._active,
-            queued=len(self._waiters),
+            queued=len(self._waiters) + len(self._priority_waiters),
         )
 
 
@@ -1205,11 +1266,21 @@ def create_app(
     async def chat_completions(
         payload: ChatCompletionRequest,
         request: Request,
+        priority_header: Annotated[str | None, Header(alias=_PRIORITY_HEADER)] = None,
     ) -> JSONResponse | StreamingResponse:
         # Requests rejected before the handler (validation, auth, request size)
         # never reach this line, so they stay reported as "not_applicable".
         request.state.telemetry_mode = "stream" if payload.stream else "non_stream"
         request.state.telemetry_model_family = model_family(payload.model)
+        priority = _request_priority(priority_header)
+        if priority is None:
+            request.state.telemetry_error_type = "invalid_request_error"
+            log_warning("chat.rejected", status=400, phase="priority")
+            return _error_response(
+                f"{_PRIORITY_HEADER} must be '{_PRIORITY_HIGH}' or '{_PRIORITY_NORMAL}'.",
+                400,
+                "invalid_request_error",
+            )
         timeout_seconds = min(
             payload.timeout or resolved_settings.timeout_seconds,
             resolved_settings.timeout_seconds,
@@ -1230,6 +1301,7 @@ def create_app(
             reasoning_effort=_effective_reasoning_effort(payload, resolved_settings),
             reasoning_effort_overridden=resolved_settings.reasoning_effort is not None,
             continuation=payload.factory_droid_session_id is not None,
+            priority=priority,
         )
 
         rejection = _validate_options(payload, resolved_settings)
@@ -1347,11 +1419,11 @@ def create_app(
         session_use = acquire_session_use(session_id) if session_id is not None else None
 
         try:
-            lease = await admission.acquire(deadline)
+            lease = await admission.acquire(deadline, priority=priority)
         except AdmissionRejectedError:
             if session_use is not None:
                 session_use.release()
-            metrics.increment_overload_rejections()
+            metrics.increment_overload_rejections(priority)
             request.state.telemetry_error_type = "rate_limit_error"
             log_warning("chat.rejected", status=429, phase="queue")
             return _error_response(

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -10,6 +10,12 @@ from dataclasses import dataclass
 WARM_RETUNE_EFFORT = "effort"
 _WARM_RETUNE_REASONS = (WARM_RETUNE_EFFORT,)
 
+# Admission rejection priorities, rendered even at zero so a dashboard keeps
+# its series between restarts.
+PRIORITY_HIGH = "high"
+PRIORITY_NORMAL = "normal"
+_REJECTION_PRIORITIES = (PRIORITY_HIGH, PRIORITY_NORMAL)
+
 
 @dataclass(frozen=True, slots=True)
 class RequestMetric:
@@ -41,7 +47,7 @@ class BridgeMetrics:
         self._ttft_count = 0
         self._active_sessions = 0
         self._queued_requests = 0
-        self._overload_rejections = 0
+        self._overload_rejections: Counter[str] = Counter()
         self._payload_rejections = 0
         self._forced_kills = 0
         self._model_discovery_failures = 0
@@ -101,9 +107,9 @@ class BridgeMetrics:
             self._active_sessions = active
             self._queued_requests = queued
 
-    def increment_overload_rejections(self) -> None:
+    def increment_overload_rejections(self, priority: str = PRIORITY_NORMAL) -> None:
         with self._lock:
-            self._overload_rejections += 1
+            self._overload_rejections[priority] += 1
 
     def increment_payload_rejections(self) -> None:
         with self._lock:
@@ -182,6 +188,10 @@ class BridgeMetrics:
                 (reason, self._warm_retunes[reason])
                 for reason in sorted({*_WARM_RETUNE_REASONS, *self._warm_retunes})
             ]
+            overload_rejections = [
+                (priority, self._overload_rejections[priority])
+                for priority in _REJECTION_PRIORITIES
+            ]
             values = {
                 "request_duration_sum": self._request_duration_sum,
                 "request_duration_count": self._request_duration_count,
@@ -193,7 +203,6 @@ class BridgeMetrics:
                 "ttft_count": self._ttft_count,
                 "active_sessions": self._active_sessions,
                 "queued_requests": self._queued_requests,
-                "overload_rejections": self._overload_rejections,
                 "payload_rejections": self._payload_rejections,
                 "forced_kills": self._forced_kills,
                 "model_discovery_failures": self._model_discovery_failures,
@@ -234,7 +243,10 @@ class BridgeMetrics:
             "# TYPE factory_droid_openai_queued_requests gauge",
             f"factory_droid_openai_queued_requests {values['queued_requests']}",
             "# TYPE factory_droid_openai_overload_rejections_total counter",
-            (f"factory_droid_openai_overload_rejections_total {values['overload_rejections']}"),
+            *[
+                (f'factory_droid_openai_overload_rejections_total{{priority="{priority}"}} {count}')
+                for priority, count in overload_rejections
+            ],
             "# TYPE factory_droid_openai_payload_rejections_total counter",
             (f"factory_droid_openai_payload_rejections_total {values['payload_rejections']}"),
             "# TYPE factory_droid_openai_forced_kills_total counter",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import json
+from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import pytest
@@ -75,10 +76,44 @@ from factory_droid_openai.runner import (
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-    from pathlib import Path
-    from typing import Any
 
     from factory_droid_openai.app import RunnerFactory
+
+
+def _recorded_usage(payload: dict[str, Any]) -> Usage:
+    details = payload.get("prompt_tokens_details") or {}
+    return Usage(
+        input_tokens=int(payload.get("prompt_tokens", 0)),
+        output_tokens=int(payload.get("completion_tokens", 0)),
+        cache_read_tokens=int(details.get("cached_tokens", 0)),
+    )
+
+
+def _recorded_event(record: dict[str, Any]) -> RunEvent:
+    kind = record["kind"]
+    if kind == "text_delta":
+        return TextDelta(record["text"])
+    if kind == "reasoning_delta":
+        return ReasoningDelta(record["text"])
+    if kind == "usage":
+        return UsageUpdate(_recorded_usage(record["usage"]))
+    if kind == "run_complete":
+        return RunComplete(_recorded_usage(record["usage"]))
+    if kind == "status":
+        return StatusUpdate(record["state"])
+    if kind == "session_started":
+        return SessionStarted("replay-session")
+    raise AssertionError(f"unknown recorded event kind: {kind}")
+
+
+def _recorded_events(name: str) -> list[RunEvent]:
+    path = Path(__file__).parent / "fixtures" / "events" / name
+    records = [
+        cast("dict[str, Any]", json.loads(line))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    return [_recorded_event(record) for record in records if record["kind"] != "meta"]
 
 
 class FakeRunner:
@@ -188,8 +223,8 @@ class BlockingRunner(FakeRunner):
 
 
 class GateRunner(FakeRunner):
-    def __init__(self) -> None:
-        super().__init__([])
+    def __init__(self, events: list[RunEvent] | None = None) -> None:
+        super().__init__(events if events is not None else [RunComplete(Usage())])
         self.started = asyncio.Event()
         self.release = asyncio.Event()
 
@@ -198,7 +233,8 @@ class GateRunner(FakeRunner):
         self.started.set()
         try:
             await self.release.wait()
-            yield RunComplete(Usage())
+            for event in self.events:
+                yield event
         finally:
             self.closed = True
 
@@ -1559,7 +1595,7 @@ async def test_evicted_waiter_cancellation_after_removal_is_clean() -> None:
 async def test_priority_header_admits_foreground_before_backlog(
     tmp_path: Path,
 ) -> None:
-    runner = GateRunner()
+    runner = GateRunner(_recorded_events("hello--gpt-5-4-mini.jsonl"))
     app = create_app(
         Settings(
             workdir=tmp_path,
@@ -1626,7 +1662,7 @@ async def test_unknown_priority_header_fails_closed(tmp_path: Path) -> None:
 async def test_full_queue_rejects_newest_normal_waiter_for_priority_request(
     tmp_path: Path,
 ) -> None:
-    runner = GateRunner()
+    runner = GateRunner(_recorded_events("hello--gpt-5-4-mini.jsonl"))
     app = create_app(
         Settings(
             workdir=tmp_path,
@@ -1669,7 +1705,7 @@ async def test_full_queue_rejects_newest_normal_waiter_for_priority_request(
 async def test_priority_request_rejected_when_queue_full_of_priority_work_over_http(
     tmp_path: Path,
 ) -> None:
-    runner = GateRunner()
+    runner = GateRunner(_recorded_events("hello--gpt-5-4-mini.jsonl"))
     app = create_app(
         Settings(
             workdir=tmp_path,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,7 +15,9 @@ from factory_droid_openai import telemetry as telemetry_module
 from factory_droid_openai.app import (
     AdmissionController,
     AdmissionLease,
+    AdmissionRejectedError,
     FinalizingStreamingResponse,
+    RequestPriority,
     RequestSizeLimitMiddleware,
     SessionRegistry,
     StructuredOutput,
@@ -28,6 +30,7 @@ from factory_droid_openai.app import (
     _payload_size_bucket,
     _request_mode,
     _request_outcome,
+    _request_priority,
     _request_route,
     _request_telemetry_features,
     _RequestPayloadLimitError,
@@ -1424,6 +1427,284 @@ async def test_bounded_queue_rejects_overload_before_stream_headers(
         )
 
     assert retried.status_code == 200
+
+
+def test_priority_header_parsing() -> None:
+    assert _request_priority(None) == "normal"
+    assert _request_priority("normal") == "normal"
+    assert _request_priority("HIGH") == "high"
+    assert _request_priority("urgent") is None
+
+
+def test_overload_rejection_metrics_render_both_priorities_at_zero() -> None:
+    text = BridgeMetrics().render()
+
+    assert 'factory_droid_openai_overload_rejections_total{priority="high"} 0' in text
+    assert 'factory_droid_openai_overload_rejections_total{priority="normal"} 0' in text
+
+
+@pytest.mark.asyncio
+async def test_priority_admission_jumps_queued_normal_work() -> None:
+    metrics = BridgeMetrics()
+    admission = AdmissionController(max_concurrency=1, max_queue_size=4, metrics=metrics)
+    deadline = asyncio.get_running_loop().time() + 30
+    active = await admission.acquire(deadline)
+    first = asyncio.create_task(admission.acquire(deadline))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(admission.acquire(deadline))
+    await asyncio.sleep(0)
+    foreground = asyncio.create_task(admission.acquire(deadline, priority="high"))
+    await asyncio.sleep(0)
+
+    await active.release()
+    foreground_lease = await foreground
+    assert not first.done()
+    assert not second.done()
+
+    await foreground_lease.release()
+    first_lease = await first
+    await first_lease.release()
+    second_lease = await second
+    await second_lease.release()
+
+
+@pytest.mark.asyncio
+async def test_normal_request_queues_behind_priority_waiter() -> None:
+    admitted: list[str] = []
+    metrics = BridgeMetrics()
+    admission = AdmissionController(max_concurrency=1, max_queue_size=2, metrics=metrics)
+    deadline = asyncio.get_running_loop().time() + 30
+
+    async def acquire_and_release(priority: RequestPriority) -> None:
+        lease = await admission.acquire(deadline, priority=priority)
+        admitted.append(priority)
+        await lease.release()
+
+    active = await admission.acquire(deadline)
+    foreground = asyncio.create_task(acquire_and_release("high"))
+    await asyncio.sleep(0)
+    await active.release()
+    # Same task continues before the woken priority waiter can run, so this
+    # acquire is queued while the slot is already free.
+    background_lease = await admission.acquire(deadline)
+    admitted.append("normal")
+    await background_lease.release()
+    await foreground
+
+    assert admitted == ["high", "normal"]
+
+
+@pytest.mark.asyncio
+async def test_priority_admission_rejects_newest_normal_waiter_when_queue_full() -> None:
+    metrics = BridgeMetrics()
+    admission = AdmissionController(max_concurrency=1, max_queue_size=2, metrics=metrics)
+    deadline = asyncio.get_running_loop().time() + 30
+    active = await admission.acquire(deadline)
+    first = asyncio.create_task(admission.acquire(deadline))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(admission.acquire(deadline))
+    await asyncio.sleep(0)
+    foreground = asyncio.create_task(admission.acquire(deadline, priority="high"))
+
+    with pytest.raises(AdmissionRejectedError):
+        await second
+    assert not first.done()
+
+    await active.release()
+    foreground_lease = await foreground
+    await foreground_lease.release()
+    first_lease = await first
+    await first_lease.release()
+
+
+@pytest.mark.asyncio
+async def test_priority_request_rejected_when_queue_full_of_priority_work() -> None:
+    metrics = BridgeMetrics()
+    admission = AdmissionController(max_concurrency=1, max_queue_size=1, metrics=metrics)
+    deadline = asyncio.get_running_loop().time() + 30
+    active = await admission.acquire(deadline)
+    queued_high = asyncio.create_task(admission.acquire(deadline, priority="high"))
+    await asyncio.sleep(0)
+
+    with pytest.raises(AdmissionRejectedError):
+        await admission.acquire(deadline, priority="high")
+
+    await active.release()
+    high_lease = await queued_high
+    await high_lease.release()
+
+
+@pytest.mark.asyncio
+async def test_evicted_waiter_cancellation_after_removal_is_clean() -> None:
+    metrics = BridgeMetrics()
+    admission = AdmissionController(max_concurrency=1, max_queue_size=1, metrics=metrics)
+    deadline = asyncio.get_running_loop().time() + 30
+    active = await admission.acquire(deadline)
+    evicted = asyncio.create_task(admission.acquire(deadline))
+    await asyncio.sleep(0)
+    foreground = asyncio.create_task(admission.acquire(deadline, priority="high"))
+    evicted.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await evicted
+
+    await active.release()
+    foreground_lease = await foreground
+    await foreground_lease.release()
+
+    assert "factory_droid_openai_queued_requests 0" in metrics.render()
+
+
+@pytest.mark.asyncio
+async def test_priority_header_admits_foreground_before_backlog(
+    tmp_path: Path,
+) -> None:
+    runner = GateRunner()
+    app = create_app(
+        Settings(
+            workdir=tmp_path,
+            timeout_seconds=30,
+            max_concurrency=1,
+            max_queue_size=4,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    async with _client(app) as client:
+        active = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=_payload(messages=[{"role": "user", "content": "active"}]),
+            )
+        )
+        await runner.started.wait()
+        background = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=_payload(
+                    stream=True,
+                    messages=[{"role": "user", "content": "background"}],
+                ),
+            )
+        )
+        await _wait_for_metric(app, "factory_droid_openai_queued_requests 1")
+        foreground = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=_payload(messages=[{"role": "user", "content": "foreground"}]),
+                headers={"X-Factory-Droid-Priority": "HIGH"},
+            )
+        )
+        await _wait_for_metric(app, "factory_droid_openai_queued_requests 2")
+
+        runner.release.set()
+        assert (await active).status_code == 200
+        assert (await foreground).status_code == 200
+        assert (await background).status_code == 200
+
+    prompts = [request.prompt for request in runner.requests]
+    background_at = next(index for index, prompt in enumerate(prompts) if "background" in prompt)
+    foreground_at = next(index for index, prompt in enumerate(prompts) if "foreground" in prompt)
+    assert foreground_at < background_at
+
+
+@pytest.mark.asyncio
+async def test_unknown_priority_header_fails_closed(tmp_path: Path) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(),
+            headers={"X-Factory-Droid-Priority": "urgent"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert runner.requests == []
+
+
+@pytest.mark.asyncio
+async def test_full_queue_rejects_newest_normal_waiter_for_priority_request(
+    tmp_path: Path,
+) -> None:
+    runner = GateRunner()
+    app = create_app(
+        Settings(
+            workdir=tmp_path,
+            timeout_seconds=30,
+            max_concurrency=1,
+            max_queue_size=1,
+            retry_after_seconds=2,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    async with _client(app) as client:
+        active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
+        await runner.started.wait()
+        background = asyncio.create_task(
+            client.post("/v1/chat/completions", json=_payload(stream=True))
+        )
+        await _wait_for_metric(app, "factory_droid_openai_queued_requests 1")
+        foreground = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=_payload(),
+                headers={"X-Factory-Droid-Priority": "high"},
+            )
+        )
+
+        rejected = await background
+        runner.release.set()
+        assert (await active).status_code == 200
+        assert (await foreground).status_code == 200
+
+    assert rejected.status_code == 429
+    assert rejected.headers["retry-after"] == "2"
+    assert rejected.json()["error"]["type"] == "rate_limit_error"
+    metrics = app.state.metrics.render()
+    assert 'factory_droid_openai_overload_rejections_total{priority="normal"} 1' in metrics
+    assert 'factory_droid_openai_overload_rejections_total{priority="high"} 0' in metrics
+
+
+@pytest.mark.asyncio
+async def test_priority_request_rejected_when_queue_full_of_priority_work_over_http(
+    tmp_path: Path,
+) -> None:
+    runner = GateRunner()
+    app = create_app(
+        Settings(
+            workdir=tmp_path,
+            timeout_seconds=30,
+            max_concurrency=1,
+            max_queue_size=1,
+            retry_after_seconds=3,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+    async with _client(app) as client:
+        active = asyncio.create_task(client.post("/v1/chat/completions", json=_payload()))
+        await runner.started.wait()
+        queued_high = asyncio.create_task(
+            client.post(
+                "/v1/chat/completions",
+                json=_payload(stream=True),
+                headers={"X-Factory-Droid-Priority": "high"},
+            )
+        )
+        await _wait_for_metric(app, "factory_droid_openai_queued_requests 1")
+        rejected = await client.post(
+            "/v1/chat/completions",
+            json=_payload(),
+            headers={"X-Factory-Droid-Priority": "high"},
+        )
+        runner.release.set()
+        assert (await active).status_code == 200
+        assert (await queued_high).status_code == 200
+
+    assert rejected.status_code == 429
+    assert rejected.headers["retry-after"] == "3"
+    metrics = app.state.metrics.render()
+    assert 'factory_droid_openai_overload_rejections_total{priority="high"} 1' in metrics
+    assert 'factory_droid_openai_overload_rejections_total{priority="normal"} 0' in metrics
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Priority admission for the request queue, closes #107.

Chat requests can now send `X-Factory-Droid-Priority: high` (or `normal`, the default). The admission controller keeps two lanes:

- a high request waits only for a free slot - it is admitted before queued normal work, not behind the backlog
- when the queue is full, a high request still gets in: the newest queued normal waiter (the one that has waited least) is rejected with the usual 429 + `Retry-After`, and the foreground request takes its place
- a queue full of high requests rejects further high requests, so background floods cannot wedge out foreground traffic by claiming the priority lane themselves
- unknown header values fail closed with 400 instead of silently demoting to normal
- the header only affects `/v1/chat/completions`; session operations and model discovery stay in the normal lane

`factory_droid_openai_overload_rejections_total` now carries a `priority="high"|"normal"` label, rendered even at zero so dashboards keep both series across restarts. README, and the OpenAPI contract document the header.

Why a lane and not more slots: production showed hindsight background workers saturating the queue and starving foreground recall. More slots fix capacity, not fairness, and capacity is finite on small hosts.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

Full suite: 1803 passed, 100% branch coverage. `uv lock --check` also clean. openapi.json was hand-edited to add only the new header parameter, because local regeneration also rewrites response blocks with generic `4XX` (local FastAPI version, unrelated drift; the contract test confirms the committed file matches generation).

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.

Queue behavior is deterministic and needs no model at all, so it is covered with direct controller tests and ASGI tests against fake runners instead of replay fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional high-priority handling for chat completion requests using the `X-Factory-Droid-Priority` header.
  * High-priority requests can move ahead of queued normal requests and may be admitted when the queue is full.
  * Invalid priority values now return a `400` error.

* **Monitoring**
  * Overload rejection metrics now distinguish between high- and normal-priority requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->