### PR TITLE
feat(session): cache Droid tool discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,13 +1729,19 @@ For every Droid session, the bridge:
 1. Selects Droid's `auto` interaction mode with autonomy `off`.
 2. Requests no additional MCP servers from the SDK.
 3. Cancels permission requests and interactive questions.
-4. Optionally waits `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` for configured MCP
-   servers, which only widens the verification snapshot and is off by default.
-5. Discovers the native and MCP tool catalog known at that moment through
-   `droid.list_tools`.
-6. Disables every discovered tool ID and verifies no unexpected tool remains.
-   Tools that appear after this point stay denied, because Droid defaults to
-   deny once a disabled set has been sent.
+4. Before an uncached discovery, optionally waits
+   `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` for configured MCP servers. This
+   only widens the snapshot and is off by default.
+5. Discovers Droid-owned native and MCP tool IDs through `droid.list_tools`.
+   The bridge caches this snapshot for the resolved Droid executable and the
+   active user and project settings and MCP files. A CLI replacement or
+   profile change invalidates it. Per-request `openai-bridge` IDs are never
+   cached.
+6. Applies the discovered or cached disabled set, then calls
+   `droid.list_tools` once to verify no unexpected tool remains. A new tool
+   found during verification is disabled in the bounded retry and added to the
+   snapshot. Tools that appear after this point stay denied, because Droid
+   defaults to deny once a disabled set has been sent.
 7. Rejects any Factory-native tool event as a second line of defense, naming the
    tool in the error. Droid keeps two of its own meta tools callable whatever a
    session disables, `exit-spec-mode` and the deferred-tool loader; weaker

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -22,7 +22,7 @@ from jsonschema.validators import validator_for
 
 from factory_droid_openai.availability import ModelQuarantine
 from factory_droid_openai.config import DEFAULT_TOOL_CALL_DRAIN_SECONDS, Settings
-from factory_droid_openai.droid_rpc import DroidRpcExtension
+from factory_droid_openai.droid_rpc import DroidRpcExtension, ToolCatalogCache
 from factory_droid_openai.logs import bind_request, current_timeline
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import info as log_info
@@ -807,6 +807,14 @@ def create_app(
     )
     metrics = BridgeMetrics()
     reaper = BackgroundReaper(metrics=metrics)
+    tool_catalog_cache = ToolCatalogCache(
+        droid_path=resolved_settings.droid_path,
+        workdir=resolved_settings.workdir,
+    )
+    rpc_extension = DroidRpcExtension(
+        mcp_settle_seconds=resolved_settings.mcp_settle_seconds,
+        tool_catalog_cache=tool_catalog_cache,
+    )
     resolved_runner_factory = runner_factory or (
         lambda: DroidRunner(
             droid_path=resolved_settings.droid_path,
@@ -817,9 +825,7 @@ def create_app(
             metrics=metrics,
             worktree=resolved_settings.worktree,
             append_system_prompt_file=resolved_settings.append_system_prompt_file,
-            rpc_extension=DroidRpcExtension(
-                mcp_settle_seconds=resolved_settings.mcp_settle_seconds,
-            ),
+            rpc_extension=rpc_extension,
             reaper=reaper if resolved_settings.detached_cleanup else None,
         )
     )
@@ -926,6 +932,7 @@ def create_app(
     application.state.reaper = reaper
     application.state.quarantine = quarantine
     application.state.telemetry = telemetry
+    application.state.tool_catalog_cache = tool_catalog_cache
     application.state.native_tools = native_tools
     if resolved_settings.native_tool_calls:
         # The token in each path is the credential, so the endpoint carries no

--- a/src/factory_droid_openai/droid_rpc.py
+++ b/src/factory_droid_openai/droid_rpc.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
+import shutil
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 from urllib.parse import urlsplit
 
@@ -16,6 +19,8 @@ from droid_sdk.schemas.enums import (
 from factory_droid_openai.mcp_tools import MCP_SERVER_NAME, MCP_TOOL_ID_PREFIX
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from droid_sdk import DroidClient
 
 _RPC_TIMEOUT_SECONDS = 30.0
@@ -36,6 +41,12 @@ _CONNECTED_MCP_STATUS = "connected"
 _FAILED_MCP_STATUSES = frozenset({"failed", "disconnected", "disabled"})
 _MCP_URL_FIELDS = ("url", "uri")
 _DEFAULT_PORTS = {"http": 80, "https": 443}
+_TOOL_CATALOG_PROFILE_FILES = (
+    "settings.json",
+    "settings.local.json",
+    "org-managed-settings.json",
+    "mcp.json",
+)
 _MCP_POLICY_PATTERN = re.compile(
     r"(?:mcp\s*policy|allowlist|allow\s+list|organization\s+policy)",
     re.IGNORECASE,
@@ -54,6 +65,102 @@ class _ProtocolEngine(Protocol):
         timeout: float | None = None,
         request_id: str | None = None,
     ) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _FileIdentity:
+    path: str
+    device: int | None = None
+    inode: int | None = None
+    size: int | None = None
+    modified_ns: int | None = None
+    changed_ns: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolCatalogIdentity:
+    droid: _FileIdentity
+    profile_root: str
+    settings: tuple[_FileIdentity, ...]
+    workdir: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolCatalogRevision:
+    identity: _ToolCatalogIdentity
+    generation: int
+
+
+class ToolCatalogCache:
+    """Caches Droid-owned tool IDs while the CLI and profile stay unchanged."""
+
+    def __init__(
+        self,
+        *,
+        droid_path: str,
+        workdir: Path,
+        profile_root: Callable[[], Path] = lambda: Path(
+            os.environ.get("FACTORY_HOME_OVERRIDE") or Path.home() / ".factory"
+        ),
+    ) -> None:
+        self._droid_path = droid_path
+        self._workdir = workdir
+        self._profile_root = profile_root
+        self._lock = asyncio.Lock()
+        self._identity: _ToolCatalogIdentity | None = None
+        self._tool_ids: frozenset[str] | None = None
+        self._generation = 0
+
+    async def get(
+        self,
+        discover: Callable[[], Awaitable[list[dict[str, Any]]]],
+        *,
+        dynamic_prefix: str | None,
+    ) -> tuple[_ToolCatalogRevision, set[str], bool]:
+        identity = await asyncio.to_thread(self._current_identity)
+        async with self._lock:
+            if identity == self._identity and self._tool_ids is not None:
+                tool_ids = set(self._tool_ids)
+                tool_ids.difference_update(_matching(tool_ids, dynamic_prefix))
+                return _ToolCatalogRevision(identity, self._generation), tool_ids, True
+            tool_ids = _required_tool_ids(await discover())
+            self._identity = identity
+            self._tool_ids = frozenset(tool_ids - _matching(tool_ids, dynamic_prefix))
+            self._generation += 1
+            return _ToolCatalogRevision(identity, self._generation), tool_ids, False
+
+    async def remember(
+        self,
+        revision: _ToolCatalogRevision,
+        tool_ids: set[str],
+        *,
+        dynamic_prefix: str | None,
+    ) -> None:
+        async with self._lock:
+            if revision.identity != self._identity:
+                return
+            remembered = tool_ids - _matching(tool_ids, dynamic_prefix)
+            if revision.generation != self._generation:
+                concurrent = set(self._tool_ids or ())
+                concurrent.difference_update(_matching(concurrent, dynamic_prefix))
+                remembered.update(concurrent)
+            self._tool_ids = frozenset(remembered)
+            self._generation += 1
+
+    def _current_identity(self) -> _ToolCatalogIdentity:
+        profile_root = self._profile_root().expanduser()
+        executable = _resolve_executable(self._droid_path, self._workdir)
+        project_root = _project_root(self._workdir)
+        settings_paths = {profile_root / name for name in _TOOL_CATALOG_PROFILE_FILES}
+        settings_paths.update(
+            project_root / ".factory" / name for name in _TOOL_CATALOG_PROFILE_FILES
+        )
+        return _ToolCatalogIdentity(
+            droid=_file_identity(executable),
+            profile_root=str(profile_root.resolve(strict=False)),
+            settings=tuple(_file_identity(path) for path in sorted(settings_paths)),
+            workdir=str(self._workdir.resolve(strict=False)),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,8 +198,14 @@ class CompactionResult:
 class DroidRpcExtension:
     """Compatibility shim for RPCs not yet exposed by droid-sdk-python."""
 
-    def __init__(self, *, mcp_settle_seconds: float = 0.0) -> None:
+    def __init__(
+        self,
+        *,
+        mcp_settle_seconds: float = 0.0,
+        tool_catalog_cache: ToolCatalogCache | None = None,
+    ) -> None:
         self._mcp_settle_seconds = max(0.0, mcp_settle_seconds)
+        self._tool_catalog_cache = tool_catalog_cache
 
     async def add_user_message(
         self,
@@ -151,15 +264,31 @@ class DroidRpcExtension:
         MCP callable. Everything Droid owns still goes away, so a turn can only
         reach tools the OpenAI client asked for.
         """
-        if expected_tool_ids is None:
-            await self._wait_for_mcp_catalog(client)
-        else:
-            await self._wait_for_native_mcp_server(client, native_server_url)
-        tools = await self._list_tools(client)
-        if not tools:
-            raise DroidClientError("Droid returned an empty native tool catalog")
-        tool_ids = {_required_str(tool, "id") for tool in tools}
         if expected_tool_ids is not None:
+            await self._wait_for_native_mcp_server(client, native_server_url)
+
+        async def discover() -> list[dict[str, Any]]:
+            if expected_tool_ids is None:
+                await self._wait_for_mcp_catalog(client)
+            return await self._list_tools(client)
+
+        cache = (
+            self._tool_catalog_cache
+            if keep_tool_prefix is None or expected_tool_ids is not None
+            else None
+        )
+        cache_revision: _ToolCatalogRevision | None = None
+        cache_hit = False
+        if cache is None:
+            tool_ids = _required_tool_ids(await discover())
+        else:
+            cache_revision, tool_ids, cache_hit = await cache.get(
+                discover,
+                dynamic_prefix=keep_tool_prefix,
+            )
+        if expected_tool_ids is not None:
+            if cache_hit:
+                tool_ids.update(expected_tool_ids)
             self._verify_native_tool_ids(tool_ids, expected_tool_ids)
         tolerated = _UNAVOIDABLE_TOOL_IDS
         if keep_tool_prefix is not None:
@@ -182,17 +311,28 @@ class DroidRpcExtension:
                     "disabledToolIds": sorted(tool_ids - kept),
                 },
             )
+            verification = await self._list_tools(client)
+            if not verification:
+                raise DroidClientError("Droid returned an empty native tool catalog")
             remaining: set[str] = set()
-            for tool in await self._list_tools(client):
+            verified_tool_ids: set[str] = set()
+            for tool in verification:
                 tool_id = _required_str(tool, "id")
-                tool_ids.add(tool_id)
+                verified_tool_ids.add(tool_id)
                 if _required_bool(tool, "currentlyAllowed"):
                     remaining.add(tool_id)
+            tool_ids = verified_tool_ids
             if expected_tool_ids is not None:
                 self._verify_native_tool_ids(tool_ids, expected_tool_ids)
                 missing_expected = set(expected_tool_ids - remaining)
             unexpected = remaining - tolerated - _matching(remaining, keep_tool_prefix)
             if not unexpected and not missing_expected:
+                if cache is not None and cache_revision is not None:
+                    await cache.remember(
+                        cache_revision,
+                        tool_ids,
+                        dynamic_prefix=keep_tool_prefix,
+                    )
                 return
             if attempt + 1 < _TOOL_DISABLE_RETRIES:
                 await asyncio.sleep(_TOOL_DISABLE_RETRY_SECONDS)
@@ -362,6 +502,44 @@ class DroidRpcExtension:
         if not isinstance(result, dict):
             raise DroidClientError(f"{method} returned a malformed result")
         return result
+
+
+def _required_tool_ids(tools: list[dict[str, Any]]) -> set[str]:
+    if not tools:
+        raise DroidClientError("Droid returned an empty native tool catalog")
+    return {_required_str(tool, "id") for tool in tools}
+
+
+def _resolve_executable(droid_path: str, workdir: Path) -> Path:
+    candidate = Path(droid_path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    if droid_path != candidate.name:
+        return workdir / candidate
+    return Path(shutil.which(droid_path) or workdir / candidate)
+
+
+def _project_root(workdir: Path) -> Path:
+    for directory in (workdir, *workdir.parents):
+        if (directory / ".git").exists():
+            return directory
+    return workdir
+
+
+def _file_identity(path: Path) -> _FileIdentity:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        stat = resolved.stat()
+    except (OSError, RuntimeError):
+        return _FileIdentity(str(path.expanduser().absolute()))
+    return _FileIdentity(
+        path=str(resolved),
+        device=stat.st_dev,
+        inode=stat.st_ino,
+        size=stat.st_size,
+        modified_ns=stat.st_mtime_ns,
+        changed_ns=stat.st_ctime_ns,
+    )
 
 
 def _matching(tool_ids: set[str], prefix: str | None) -> set[str]:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4920,6 +4920,23 @@ async def test_detached_cleanup_can_be_disabled(tmp_path: Path) -> None:
         assert "factory_droid_openai_warm_sessions 0" in app.state.metrics.render()
 
 
+def test_default_runner_factory_shares_the_tool_catalog_cache(tmp_path: Path) -> None:
+    app = create_app(
+        Settings(
+            droid_path="droid",
+            workdir=tmp_path,
+            warm_sessions=0,
+            telemetry=False,
+        )
+    )
+
+    first = app.state.pool._runner_factory()
+    second = app.state.pool._runner_factory()
+
+    assert first._rpc is second._rpc
+    assert first._rpc._tool_catalog_cache is app.state.tool_catalog_cache
+
+
 @pytest.mark.asyncio
 async def test_lifespan_flushes_anonymous_telemetry(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -10,12 +10,14 @@ from factory_droid_openai import droid_rpc as rpc_module
 from factory_droid_openai.droid_rpc import (
     DroidRpcExtension,
     NativeToolUnavailableError,
+    ToolCatalogCache,
     _ProtocolEngine,
 )
 from factory_droid_openai.mcp_tools import MCP_TOOL_ID_PREFIX
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from droid_sdk import DroidClient
 
@@ -245,6 +247,318 @@ async def test_disable_native_tools_skips_the_mcp_probe_by_default() -> None:
         "droid.update_session_settings",
         "droid.list_tools",
     ]
+
+
+def _tool_catalog_protocol(tool_ids: list[str]) -> FakeProtocol:
+    disabled: set[str] = set()
+
+    def handler(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "droid.list_mcp_servers":
+            return {"result": {"servers": [{"name": "openai-bridge", "status": "connected"}]}}
+        if method == "droid.list_tools":
+            return {
+                "result": {
+                    "tools": [
+                        {
+                            "id": tool_id,
+                            "currentlyAllowed": (
+                                tool_id not in disabled or tool_id == "exit-spec-mode"
+                            ),
+                        }
+                        for tool_id in tool_ids
+                    ]
+                }
+            }
+        if method == "droid.update_session_settings":
+            disabled.update(params["disabledToolIds"])
+            return {"result": {}}
+        raise AssertionError(method)
+
+    return FakeProtocol(handler)
+
+
+def _tool_catalog_cache(tmp_path: Path) -> tuple[ToolCatalogCache, Path, Path]:
+    executable = tmp_path / "droid"
+    executable.write_text("version one", encoding="utf-8")
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    cache = ToolCatalogCache(
+        droid_path=str(executable),
+        workdir=tmp_path,
+        profile_root=lambda: profile,
+    )
+    return cache, executable, profile
+
+
+def test_tool_catalog_cache_uses_the_factory_profile_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "factory-home"
+    monkeypatch.setenv("FACTORY_HOME_OVERRIDE", str(profile))
+    cache = ToolCatalogCache(droid_path="missing-droid", workdir=tmp_path)
+
+    identity = cache._current_identity()
+
+    assert identity.profile_root == str(profile)
+
+
+def test_tool_catalog_cache_resolves_relative_cli_and_project_paths(tmp_path: Path) -> None:
+    repository = tmp_path / "repo"
+    workdir = repository / "nested"
+    workdir.mkdir(parents=True)
+    (repository / ".git").mkdir()
+    executable = workdir / "bin" / "droid"
+    executable.parent.mkdir()
+    executable.write_text("version one", encoding="utf-8")
+    profile = tmp_path / "profile"
+    cache = ToolCatalogCache(
+        droid_path="bin/droid",
+        workdir=workdir,
+        profile_root=lambda: profile,
+    )
+
+    identity = cache._current_identity()
+
+    assert identity.droid.path == str(executable)
+    assert str(repository / ".factory" / "mcp.json") in {
+        setting.path for setting in identity.settings
+    }
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_reuses_a_cached_discovery(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+    first = _tool_catalog_protocol(["read-cli", "exit-spec-mode"])
+    second = _tool_catalog_protocol(["read-cli", "exit-spec-mode"])
+
+    await extension.disable_native_tools(_client(first))
+    await extension.disable_native_tools(_client(second))
+
+    assert [method for method, _, _ in first.calls] == [
+        "droid.list_tools",
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+    assert [method for method, _, _ in second.calls] == [
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("changed", ["cli", "profile", "project", "mcp"])
+async def test_tool_catalog_cache_invalidates_with_its_identity(
+    tmp_path: Path,
+    changed: str,
+) -> None:
+    cache, executable, profile = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+
+    await extension.disable_native_tools(
+        _client(_tool_catalog_protocol(["read-cli", "exit-spec-mode"]))
+    )
+    if changed == "cli":
+        executable.write_text("version two is different", encoding="utf-8")
+    elif changed == "profile":
+        (profile / "settings.json").write_text('{"mcpServers": {}}', encoding="utf-8")
+    elif changed == "project":
+        project_settings = tmp_path / ".factory"
+        project_settings.mkdir()
+        (project_settings / "settings.local.json").write_text(
+            '{"mcpServers": {}}',
+            encoding="utf-8",
+        )
+    else:
+        (profile / "mcp.json").write_text('{"mcpServers": {}}', encoding="utf-8")
+    protocol = _tool_catalog_protocol(["read-cli", "exit-spec-mode"])
+
+    await extension.disable_native_tools(_client(protocol))
+
+    assert [method for method, _, _ in protocol.calls] == [
+        "droid.list_tools",
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cached_discovery_absorbs_new_tools_found_by_verification(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+    await extension.disable_native_tools(
+        _client(_tool_catalog_protocol(["read-cli", "exit-spec-mode"]))
+    )
+    second = _tool_catalog_protocol(["read-cli", "write-cli", "exit-spec-mode"])
+
+    await extension.disable_native_tools(_client(second))
+    third = _tool_catalog_protocol(["read-cli", "write-cli", "exit-spec-mode"])
+    await extension.disable_native_tools(_client(third))
+
+    updates = [
+        params for method, params, _ in second.calls if method == "droid.update_session_settings"
+    ]
+    assert [params["disabledToolIds"] for params in updates] == [
+        ["exit-spec-mode", "read-cli"],
+        ["exit-spec-mode", "read-cli", "write-cli"],
+    ]
+    assert [method for method, _, _ in third.calls] == [
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+    assert third.calls[0][1]["disabledToolIds"] == [
+        "exit-spec-mode",
+        "read-cli",
+        "write-cli",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cached_discovery_drops_tools_absent_from_verification(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+    await extension.disable_native_tools(_client(_tool_catalog_protocol(["read-cli", "write-cli"])))
+    await extension.disable_native_tools(_client(_tool_catalog_protocol(["read-cli"])))
+    protocol = _tool_catalog_protocol(["read-cli"])
+
+    await extension.disable_native_tools(_client(protocol))
+
+    assert protocol.calls[0][1]["disabledToolIds"] == ["read-cli"]
+
+
+@pytest.mark.asyncio
+async def test_cached_discovery_uses_each_bridge_tool_catalog(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+    weather = f"{MCP_TOOL_ID_PREFIX}get_weather"
+    news = f"{MCP_TOOL_ID_PREFIX}get_news"
+
+    await extension.disable_native_tools(
+        _client(_tool_catalog_protocol(["read-cli", weather])),
+        keep_tool_prefix=MCP_TOOL_ID_PREFIX,
+        expected_tool_ids=frozenset({weather}),
+    )
+    protocol = _tool_catalog_protocol(["read-cli", news])
+    await extension.disable_native_tools(
+        _client(protocol),
+        keep_tool_prefix=MCP_TOOL_ID_PREFIX,
+        expected_tool_ids=frozenset({news}),
+    )
+
+    assert [method for method, _, _ in protocol.calls] == [
+        "droid.list_mcp_servers",
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+    assert protocol.calls[1][1]["enabledToolIds"] == [news]
+    assert protocol.calls[1][1]["disabledToolIds"] == ["read-cli"]
+
+
+@pytest.mark.asyncio
+async def test_cached_discovery_filters_stale_bridge_tool_ids(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+    stale = f"{MCP_TOOL_ID_PREFIX}stale"
+    weather = f"{MCP_TOOL_ID_PREFIX}get_weather"
+    await extension.disable_native_tools(_client(_tool_catalog_protocol(["read-cli", stale])))
+    protocol = _tool_catalog_protocol(["read-cli", weather])
+
+    await extension.disable_native_tools(
+        _client(protocol),
+        keep_tool_prefix=MCP_TOOL_ID_PREFIX,
+        expected_tool_ids=frozenset({weather}),
+    )
+
+    assert protocol.calls[1][1]["enabledToolIds"] == [weather]
+    assert protocol.calls[1][1]["disabledToolIds"] == ["read-cli"]
+
+
+@pytest.mark.asyncio
+async def test_cached_discovery_bypasses_an_unknown_dynamic_catalog(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+    extension = DroidRpcExtension(tool_catalog_cache=cache)
+    first = f"{MCP_TOOL_ID_PREFIX}first"
+    second = f"{MCP_TOOL_ID_PREFIX}second"
+
+    await extension.disable_native_tools(
+        _client(_tool_catalog_protocol(["read-cli", first])),
+        keep_tool_prefix=MCP_TOOL_ID_PREFIX,
+    )
+    protocol = _tool_catalog_protocol(["read-cli", second])
+    await extension.disable_native_tools(
+        _client(protocol),
+        keep_tool_prefix=MCP_TOOL_ID_PREFIX,
+    )
+
+    assert [method for method, _, _ in protocol.calls] == [
+        "droid.list_tools",
+        "droid.update_session_settings",
+        "droid.list_tools",
+    ]
+    assert protocol.calls[1][1]["enabledToolIds"] == [second]
+
+
+@pytest.mark.asyncio
+async def test_tool_catalog_cache_ignores_a_stale_verification(tmp_path: Path) -> None:
+    cache, _, profile = _tool_catalog_cache(tmp_path)
+
+    async def discover_first() -> list[dict[str, Any]]:
+        return [{"id": "read-cli", "currentlyAllowed": True}]
+
+    first_identity, _, _ = await cache.get(discover_first, dynamic_prefix=None)
+    (profile / "settings.json").write_text("{}", encoding="utf-8")
+
+    async def discover_second() -> list[dict[str, Any]]:
+        return [{"id": "write-cli", "currentlyAllowed": True}]
+
+    second_identity, _, _ = await cache.get(discover_second, dynamic_prefix=None)
+    assert first_identity != second_identity
+    await cache.remember(first_identity, {"stale-cli"}, dynamic_prefix=None)
+
+    async def must_not_discover() -> list[dict[str, Any]]:
+        raise AssertionError("the new profile snapshot should remain cached")
+
+    _, tool_ids, cache_hit = await cache.get(must_not_discover, dynamic_prefix=None)
+
+    assert cache_hit is True
+    assert tool_ids == {"write-cli"}
+
+
+@pytest.mark.asyncio
+async def test_tool_catalog_cache_merges_concurrent_verifications(tmp_path: Path) -> None:
+    cache, _, _ = _tool_catalog_cache(tmp_path)
+
+    async def discover() -> list[dict[str, Any]]:
+        return [{"id": "read-cli", "currentlyAllowed": True}]
+
+    first_revision, _, _ = await cache.get(discover, dynamic_prefix=None)
+    second_revision, _, _ = await cache.get(discover, dynamic_prefix=None)
+
+    await cache.remember(first_revision, {"read-cli", "write-cli"}, dynamic_prefix=None)
+    await cache.remember(second_revision, {"read-cli", "search-cli"}, dynamic_prefix=None)
+    _, tool_ids, cache_hit = await cache.get(discover, dynamic_prefix=None)
+
+    assert cache_hit is True
+    assert tool_ids == {"read-cli", "search-cli", "write-cli"}
+
+
+@pytest.mark.asyncio
+async def test_disable_native_tools_rejects_an_empty_verification() -> None:
+    catalog_reads = 0
+
+    def handler(method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        nonlocal catalog_reads
+        if method == "droid.list_tools":
+            catalog_reads += 1
+            tools = [{"id": "read-cli", "currentlyAllowed": True}] if catalog_reads == 1 else []
+            return {"result": {"tools": tools}}
+        if method == "droid.update_session_settings":
+            return {"result": {}}
+        raise AssertionError(method)
+
+    with pytest.raises(DroidClientError, match="empty native tool catalog"):
+        await DroidRpcExtension().disable_native_tools(_client(FakeProtocol(handler)))
 
 
 @pytest.mark.asyncio

--- a/tests/test_droid_rpc.py
+++ b/tests/test_droid_rpc.py
@@ -303,6 +303,37 @@ def test_tool_catalog_cache_uses_the_factory_profile_override(
     assert identity.profile_root == str(profile)
 
 
+def test_tool_catalog_cache_defaults_to_the_factory_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.delenv("FACTORY_HOME_OVERRIDE", raising=False)
+    monkeypatch.setattr("factory_droid_openai.droid_rpc.Path.home", lambda: home)
+    cache = ToolCatalogCache(droid_path="missing-droid", workdir=tmp_path)
+
+    identity = cache._current_identity()
+
+    assert identity.profile_root == str(home / ".factory")
+
+
+def test_tool_catalog_cache_resolves_a_bare_cli_from_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "droid"
+    executable.write_text("version one", encoding="utf-8")
+    monkeypatch.setattr(
+        "factory_droid_openai.droid_rpc.shutil.which",
+        lambda _: str(executable),
+    )
+    cache = ToolCatalogCache(droid_path="droid", workdir=tmp_path)
+
+    identity = cache._current_identity()
+
+    assert identity.droid.path == str(executable.resolve())
+
+
 def test_tool_catalog_cache_resolves_relative_cli_and_project_paths(tmp_path: Path) -> None:
     repository = tmp_path / "repo"
     workdir = repository / "nested"


### PR DESCRIPTION
## Summary

Cache Droid-owned tool IDs between sessions when the resolved CLI binary and profile configuration fingerprint still matches. The cache is shared by runners from one bridge instance.

Each session still applies the disabled set and runs final `droid.list_tools` verification. New IDs go through the existing bounded retry. Per-request `openai-bridge` IDs are not cached. CLI replacements and changes in user or project settings and MCP files invalidate the snapshot.

A cache hit removes the first discovery call. No live-model fixture here because this behavior finishes before a prompt or model event. Deterministic RPC tests cover hit, invalidation, drift, concurrency, and fail-closed verification.

Closes #108

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

Also ran `uv run python scripts/generate_openapi.py` and `uv lock --check`. Local OpenAPI generation changed key order only, so I did not commit that drift.

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Tool catalogs are now cached and reused when the Droid executable, profile, project, and MCP settings remain unchanged.
  * Caches refresh automatically when relevant settings or executable paths change.

* **Reliability**
  * Tool verification now detects unexpected tools and updates the cached catalog accordingly.
  * Dynamic per-request tool catalogs remain isolated and stale tool entries are filtered.

* **Tests**
  * Added coverage for cache reuse, invalidation, concurrent verification, path resolution, and dynamic tool handling.

* **Documentation**
  * Updated tool execution safety guidance to describe catalog caching and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->