### PR TITLE
fix(api): retry truncated calls in fresh sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,11 +291,17 @@ and a plain-text bridge notice. The malformed JSON and the call are dropped,
 never executed or returned to the client. The notice names no tool-call
 format, because anything it named would itself be tool-call-shaped text in
 assistant content. Before returning that notice, a non-streaming request retries
-one malformed or incomplete call inside the same Droid session when no valid
-call was already produced. The retry uses a fixed correction prompt, keeps the
-original request deadline, and does not resend the original prompt or
-attachments. A repeated failure still returns the notice. Streaming requests
-are not retried because response bytes may already have reached the client.
+one malformed or incomplete call when no valid call was already produced. For
+an isolated request, a truncated tool call starts a fresh Droid session with
+the full original prompt, attachments, and a fixed correction instruction, so
+the partial output cannot consume the retry's context. Explicit continuations
+and other invalid outputs retry inside the same Droid session because their
+earlier history is not available in the current request. Same-session retries
+do not resend the prompt or attachments. Every retry keeps the original request
+deadline. A repeated failure still returns the notice. Streaming requests are
+not retried because response bytes may already have reached the client.
+Intermediate truncations log as `chat.attempt_truncated`; `chat.truncated` is
+reserved for the final request outcome.
 When an earlier call in the same turn did complete, the turn keeps
 `finish_reason="tool_calls"` so the client runs the call it already received.
 Close markers inside JSON strings are argument data, not framing. Ambiguous

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ the partial output cannot consume the retry's context. Explicit continuations
 and other invalid outputs retry inside the same Droid session because their
 earlier history is not available in the current request. Same-session retries
 do not resend the prompt or attachments. Every retry keeps the original request
-deadline. A repeated failure still returns the notice. Streaming requests are
-not retried because response bytes may already have reached the client.
+deadline. A repeated malformed call still returns the notice, while a repeated
+truncated call returns `finish_reason="length"` without it. Streaming requests
+are not retried because response bytes may already have reached the client.
 Intermediate truncations log as `chat.attempt_truncated`; `chat.truncated` is
 reserved for the final request outcome.
 When an earlier call in the same turn did complete, the turn keeps

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -140,7 +140,7 @@ _MODEL_OUTPUT_RETRY_PROMPTS: dict[ModelOutputRetryReason, str] = {
         "the original request directly without any tool call or explanation about this correction."
     ),
     "truncated_tool_call": (
-        "Your previous tool call was incomplete. Return the required tool call again as one "
+        "A previous tool call attempt was incomplete. Return the required tool call as one "
         "complete valid tool call. Output no explanation."
     ),
 }
@@ -1730,12 +1730,16 @@ def create_app(
                             reason=retry_reason,
                         )
                         metrics.record_features((f"model_output_retry:{retry_reason}",))
-                        await _wait_for_retry_cleanup(
-                            reaper,
-                            session_id=attempt_session_id,
-                            deadline=deadline,
-                            timeout_seconds=timeout_seconds,
-                        )
+                        if (
+                            retry_reason != "truncated_tool_call"
+                            or choice_request.session_id is not None
+                        ):
+                            await _wait_for_retry_cleanup(
+                                reaper,
+                                session_id=attempt_session_id,
+                                deadline=deadline,
+                                timeout_seconds=timeout_seconds,
+                            )
                         attempt_request = _model_output_retry_request(
                             choice_request,
                             session_id=attempt_session_id,
@@ -1744,8 +1748,18 @@ def create_app(
                         attempt = 1
 
                     completed_result = cast("CollectedCompletion", result)
-                    if completed_result.truncated:
+                    if completed_result.truncation is not None:
                         request.state.stream_outcome = "truncated"
+                        _log_truncated_tool_call(
+                            "chat.truncated",
+                            completed_result.truncation,
+                            stream=False,
+                            run_request=attempt_request,
+                            usage=completed_result.usage,
+                            attempt=attempt,
+                            choice=index,
+                            warm_age_ms=completed_result.warm_age_ms,
+                        )
                     elif completed_result.malformed_note is not None:
                         request.state.stream_outcome = "malformed"
                     if completed_result.session_id is not None:
@@ -1823,6 +1837,17 @@ class BridgeHTTPError(Exception):
         self.headers = headers
 
 
+@dataclass(frozen=True, slots=True)
+class _TruncatedToolCall:
+    reason: str
+    tool_name: str | None
+    payload_bytes: int
+
+    @classmethod
+    def from_error(cls, exc: IncompleteToolCallError) -> _TruncatedToolCall:
+        return cls(str(exc), exc.tool_name, exc.payload_bytes)
+
+
 class CollectedCompletion:
     def __init__(self) -> None:
         self.text_parts: list[str] = []
@@ -1832,7 +1857,8 @@ class CollectedCompletion:
         self.completed = False
         self.session_id: str | None = None
         self.stopped = False
-        self.truncated = False
+        self.truncation: _TruncatedToolCall | None = None
+        self.warm_age_ms: float | None = None
         self.malformed_note: str | None = None
 
     @property
@@ -1842,6 +1868,10 @@ class CollectedCompletion:
     @property
     def reasoning(self) -> str:
         return "".join(self.reasoning_parts)
+
+    @property
+    def truncated(self) -> bool:
+        return self.truncation is not None
 
 
 def _completion_retry_reason(
@@ -1876,6 +1906,13 @@ def _model_output_retry_request(
     session_id: str,
     reason: ModelOutputRetryReason,
 ) -> RunRequest:
+    if reason == "truncated_tool_call" and request.session_id is None:
+        return replace(
+            request,
+            prompt=f"{request.prompt}\n\n{_MODEL_OUTPUT_RETRY_PROMPTS[reason]}",
+            session_id=None,
+            warm_session=None,
+        )
     return replace(
         request,
         prompt=_MODEL_OUTPUT_RETRY_PROMPTS[reason],
@@ -1883,6 +1920,40 @@ def _model_output_retry_request(
         documents=(),
         session_id=session_id,
         warm_session=None,
+    )
+
+
+def _warm_session_age_ms(request: RunRequest) -> float | None:
+    warm_session = request.warm_session
+    if warm_session is None:
+        return None
+    age = asyncio.get_running_loop().time() - warm_session.created_at
+    return round(max(0.0, age) * 1000, 1)
+
+
+def _log_truncated_tool_call(
+    event: str,
+    truncation: _TruncatedToolCall,
+    *,
+    stream: bool,
+    run_request: RunRequest,
+    usage: Usage,
+    attempt: int,
+    choice: int,
+    warm_age_ms: float | None,
+) -> None:
+    log_warning(
+        event,
+        stream=stream,
+        error_type="factory_protocol_error",
+        reason=truncation.reason,
+        tool_name=truncation.tool_name,
+        payload_bytes=truncation.payload_bytes,
+        attempt=attempt,
+        choice=choice,
+        warm=run_request.warm_session is not None,
+        warm_age_ms=warm_age_ms,
+        output_tokens=usage.output_tokens,
     )
 
 
@@ -1989,6 +2060,7 @@ async def _collect_completion(
     trace_choice: int = 0,
 ) -> CollectedCompletion:
     result = CollectedCompletion()
+    result.warm_age_ms = _warm_session_age_ms(run_request)
     stop_buffer = StopSequenceBuffer(stop_sequences)
     observed_ttft = not observe_ttft
 
@@ -2077,14 +2149,16 @@ async def _collect_completion(
                 # a tool-call payload returns completed output with
                 # finish_reason="length" instead of a 502. The partial call is
                 # dropped, never executed.
-                result.truncated = True
-                log_warning(
-                    "chat.truncated",
+                result.truncation = _TruncatedToolCall.from_error(exc)
+                _log_truncated_tool_call(
+                    "chat.attempt_truncated",
+                    result.truncation,
                     stream=False,
-                    error_type="factory_protocol_error",
-                    reason=str(exc),
-                    tool_name=exc.tool_name,
-                    payload_bytes=exc.payload_bytes,
+                    run_request=run_request,
+                    usage=result.usage,
+                    attempt=trace_attempt,
+                    choice=trace_choice,
+                    warm_age_ms=result.warm_age_ms,
                 )
         held = stop_buffer.flush()
         if held:
@@ -2171,6 +2245,7 @@ async def _stream_completion(
     trace_event: Callable[..., None] | None = None,
 ) -> AsyncIterator[str]:
     usage = Usage()
+    warm_age_ms = _warm_session_age_ms(run_request)
     completed = False
     saw_tool_call = False
     saw_text = False
@@ -2365,13 +2440,15 @@ async def _stream_completion(
             # blind-retrying an unrecoverable request. The partial call is
             # dropped, never executed.
             outcome = "truncated"
-            log_warning(
+            _log_truncated_tool_call(
                 "chat.truncated",
+                _TruncatedToolCall.from_error(exc),
                 stream=True,
-                error_type="factory_protocol_error",
-                reason=str(exc),
-                tool_name=exc.tool_name,
-                payload_bytes=exc.payload_bytes,
+                run_request=run_request,
+                usage=usage,
+                attempt=0,
+                choice=0,
+                warm_age_ms=warm_age_ms,
             )
             held = stop_buffer.flush()
             if held:

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1907,12 +1907,13 @@ def _model_output_retry_request(
     reason: ModelOutputRetryReason,
 ) -> RunRequest:
     if reason == "truncated_tool_call" and request.session_id is None:
-        return replace(
+        retry_request: RunRequest = replace(
             request,
             prompt=f"{request.prompt}\n\n{_MODEL_OUTPUT_RETRY_PROMPTS[reason]}",
             session_id=None,
             warm_session=None,
         )
+        return retry_request
     return replace(
         request,
         prompt=_MODEL_OUTPUT_RETRY_PROMPTS[reason],

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1907,13 +1907,16 @@ def _model_output_retry_request(
     reason: ModelOutputRetryReason,
 ) -> RunRequest:
     if reason == "truncated_tool_call" and request.session_id is None:
-        retry_request: RunRequest = replace(
-            request,
-            prompt=f"{request.prompt}\n\n{_MODEL_OUTPUT_RETRY_PROMPTS[reason]}",
-            session_id=None,
-            warm_session=None,
+        # Sonar cannot infer that dataclasses.replace preserves the input type.
+        return cast(  # type: ignore[redundant-cast]
+            "RunRequest",
+            replace(
+                request,
+                prompt=f"{request.prompt}\n\n{_MODEL_OUTPUT_RETRY_PROMPTS[reason]}",
+                session_id=None,
+                warm_session=None,
+            ),
         )
-        return retry_request
     return replace(
         request,
         prompt=_MODEL_OUTPUT_RETRY_PROMPTS[reason],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.metadata
+import io
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ import pytest
 from fastapi.exceptions import RequestValidationError
 from jsonschema.validators import validator_for
 
+from factory_droid_openai import logs
 from factory_droid_openai import telemetry as telemetry_module
 from factory_droid_openai.app import (
     AdmissionController,
@@ -2450,11 +2452,78 @@ async def test_non_streaming_malformed_tool_call_retries_same_session(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_truncated_tool_call_retries_same_session(tmp_path: Path) -> None:
+async def test_non_streaming_truncated_tool_call_retries_fresh_session(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = RetryRunner(
         [
             "retry/truncated-tool.jsonl",
             "retry/plain-answer.jsonl",
+        ]
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Check weather"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,QUJD"},
+                    },
+                ],
+            }
+        ],
+    )
+    app = _app(tmp_path, runner)
+    key = SessionKey(model_id=None, reasoning_effort=None)
+    warm = WarmSession(
+        key=key,
+        client=cast("Any", object()),
+        transport=None,
+        session_id="warm-session",
+        created_at=asyncio.get_running_loop().time() - 1.0,
+    )
+    app.state.pool.note(key)
+    app.state.pool.offer(warm)
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "Direct answer"
+    assert len(runner.requests) == 2
+    assert runner.requests[0].warm_session is warm
+    assert runner.requests[1].session_id is None
+    assert runner.requests[1].warm_session is None
+    assert runner.requests[0].prompt in runner.requests[1].prompt
+    assert runner.requests[1].images == runner.requests[0].images
+    assert "incomplete" in runner.requests[1].prompt
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    attempts = [record for record in records if record["event"] == "chat.attempt_truncated"]
+    assert len(attempts) == 1
+    assert attempts[0]["attempt"] == 0
+    assert attempts[0]["choice"] == 0
+    assert attempts[0]["warm"] is True
+    assert attempts[0]["warm_age_ms"] >= 1000.0
+    assert attempts[0]["output_tokens"] == 0
+    assert not any(record["event"] == "chat.truncated" for record in records)
+
+
+@pytest.mark.asyncio
+async def test_repeated_truncated_tool_call_logs_final_outcome(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = RetryRunner(
+        [
+            "retry/truncated-tool.jsonl",
+            "retry/truncated-tool.jsonl",
         ]
     )
     payload = _payload(
@@ -2469,9 +2538,52 @@ async def test_non_streaming_truncated_tool_call_retries_same_session(tmp_path: 
         response = await client.post("/v1/chat/completions", json=payload)
 
     assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "length"
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    attempts = [record for record in records if record["event"] == "chat.attempt_truncated"]
+    final = [record for record in records if record["event"] == "chat.truncated"]
+    assert [record["attempt"] for record in attempts] == [0, 1]
+    assert len(final) == 1
+    assert final[0]["attempt"] == 1
+    assert final[0]["warm"] is False
+    assert final[0]["output_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_continuation_truncated_tool_call_retries_same_session(tmp_path: Path) -> None:
+    runner = RetryRunner(
+        [
+            "retry/truncated-tool.jsonl",
+            "retry/plain-answer.jsonl",
+        ]
+    )
+    settings = Settings(
+        droid_path="droid",
+        workdir=tmp_path,
+        timeout_seconds=30.0,
+        session_continuity=True,
+    )
+    app = create_app(settings, runner_factory=cast("RunnerFactory", lambda: runner))
+    app.state.sessions.remember("session-9", SessionKey(model_id=None, reasoning_effort=None))
+    payload = _payload(
+        factory_droid_session_id="session-9",
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ],
+    )
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
     assert response.json()["choices"][0]["message"]["content"] == "Direct answer"
     assert len(runner.requests) == 2
+    assert runner.requests[0].session_id == "session-9"
     assert runner.requests[1].session_id == "replay-session"
+    assert runner.requests[1].prompt != runner.requests[0].prompt
     assert "incomplete" in runner.requests[1].prompt
 
 


### PR DESCRIPTION
## Summary

Retries truncated non-streaming tool calls in a fresh Droid session for isolated requests. It sends the full original prompt and attachments again, plus a correction. Partial model output no longer takes context from the retry.

Explicit continuations still retry in the same session because the request does not contain full earlier history. Fresh retries start without waiting for detached cleanup and keep the original deadline.

Splits intermediate `chat.attempt_truncated` from final `chat.truncated`. Both paths log attempt, choice, warm origin, warm age, and output tokens. This fixes the inflated production count and gives enough data for the pinned CLI A/B.

No new live fixture. This changes bridge retry orchestration and logging. Deterministic ASGI tests reuse the recorded truncated event stream.

Closes #115

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

1815 tests pass with 100% branch coverage. Also ran `uv run python scripts/generate_openapi.py` and `uv lock --check`. Local OpenAPI generation only reordered existing response keys, so the committed contract stays unchanged.

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of truncated tool calls by retrying isolated requests in a fresh session while preserving the original prompt and attachments.
  * Added clearer retry behavior for explicit continuations and other invalid outputs.

* **Bug Fixes**
  * Improved truncation reporting, distinguishing intermediate retry attempts from final request outcomes.
  * Preserved request deadlines across retries and maintained the restriction that streaming requests are not retried.

* **Documentation**
  * Updated the README with the revised retry and truncation logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->