### PR TITLE
fix(api): deduplicate truncation telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,9 @@ do not resend the prompt or attachments. Every retry keeps the original request
 deadline. A repeated malformed call still returns the notice, while a repeated
 truncated call returns `finish_reason="length"` without it. Streaming requests
 are not retried because response bytes may already have reached the client.
-Intermediate truncations log as `chat.attempt_truncated`; `chat.truncated` is
-reserved for the final request outcome.
+Non-final truncations log as `chat.attempt_truncated`. Its `will_retry` field
+distinguishes an actual retry from a dropped trailing partial call after a
+valid call. `chat.truncated` is reserved for the final request outcome.
 When an earlier call in the same turn did complete, the turn keeps
 `finish_reason="tool_calls"` so the client runs the call it already received.
 Close markers inside JSON strings are argument data, not framing. Ambiguous

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1722,44 +1722,49 @@ def create_app(
                                     else:
                                         raise
 
-                        if attempt != 0 or attempt_session_id is None or retry_reason is None:
+                        retry_request = (
+                            _model_output_retry_request(
+                                choice_request,
+                                session_id=attempt_session_id,
+                                reason=retry_reason,
+                            )
+                            if attempt == 0 and retry_reason is not None
+                            else None
+                        )
+                        if result is not None and result.truncation is not None:
+                            _log_truncated_tool_call(
+                                result.truncation,
+                                stream=False,
+                                run_request=attempt_request,
+                                usage=result.usage,
+                                attempt=attempt,
+                                choice=index,
+                                warm_age_ms=result.warm_age_ms,
+                                will_retry=retry_request is not None,
+                                has_tool_calls=bool(result.tool_calls),
+                            )
+                        if retry_request is None:
                             break
+                        retry_reason = cast("ModelOutputRetryReason", retry_reason)
                         log_warning(
                             "chat.retry",
                             stream=False,
                             reason=retry_reason,
                         )
                         metrics.record_features((f"model_output_retry:{retry_reason}",))
-                        if (
-                            retry_reason != "truncated_tool_call"
-                            or choice_request.session_id is not None
-                        ):
+                        if retry_request.session_id is not None:
                             await _wait_for_retry_cleanup(
                                 reaper,
-                                session_id=attempt_session_id,
+                                session_id=retry_request.session_id,
                                 deadline=deadline,
                                 timeout_seconds=timeout_seconds,
                             )
-                        attempt_request = _model_output_retry_request(
-                            choice_request,
-                            session_id=attempt_session_id,
-                            reason=retry_reason,
-                        )
+                        attempt_request = retry_request
                         attempt = 1
 
                     completed_result = cast("CollectedCompletion", result)
-                    if completed_result.truncation is not None:
+                    if completed_result.truncation is not None and not completed_result.tool_calls:
                         request.state.stream_outcome = "truncated"
-                        _log_truncated_tool_call(
-                            "chat.truncated",
-                            completed_result.truncation,
-                            stream=False,
-                            run_request=attempt_request,
-                            usage=completed_result.usage,
-                            attempt=attempt,
-                            choice=index,
-                            warm_age_ms=completed_result.warm_age_ms,
-                        )
                     elif completed_result.malformed_note is not None:
                         request.state.stream_outcome = "malformed"
                     if completed_result.session_id is not None:
@@ -1903,9 +1908,9 @@ def _retryable_structured_output_error(exc: ProtocolError) -> bool:
 def _model_output_retry_request(
     request: RunRequest,
     *,
-    session_id: str,
+    session_id: str | None,
     reason: ModelOutputRetryReason,
-) -> RunRequest:
+) -> RunRequest | None:
     if reason == "truncated_tool_call" and request.session_id is None:
         # Sonar cannot infer that dataclasses.replace preserves the input type.
         return cast(  # type: ignore[redundant-cast]
@@ -1917,6 +1922,8 @@ def _model_output_retry_request(
                 warm_session=None,
             ),
         )
+    if session_id is None:
+        return None
     return replace(
         request,
         prompt=_MODEL_OUTPUT_RETRY_PROMPTS[reason],
@@ -1936,7 +1943,6 @@ def _warm_session_age_ms(request: RunRequest) -> float | None:
 
 
 def _log_truncated_tool_call(
-    event: str,
     truncation: _TruncatedToolCall,
     *,
     stream: bool,
@@ -1945,9 +1951,11 @@ def _log_truncated_tool_call(
     attempt: int,
     choice: int,
     warm_age_ms: float | None,
+    will_retry: bool,
+    has_tool_calls: bool,
 ) -> None:
     log_warning(
-        event,
+        "chat.attempt_truncated" if will_retry or has_tool_calls else "chat.truncated",
         stream=stream,
         error_type="factory_protocol_error",
         reason=truncation.reason,
@@ -1958,6 +1966,7 @@ def _log_truncated_tool_call(
         warm=run_request.warm_session is not None,
         warm_age_ms=warm_age_ms,
         output_tokens=usage.output_tokens,
+        will_retry=will_retry,
     )
 
 
@@ -2154,16 +2163,6 @@ async def _collect_completion(
                 # finish_reason="length" instead of a 502. The partial call is
                 # dropped, never executed.
                 result.truncation = _TruncatedToolCall.from_error(exc)
-                _log_truncated_tool_call(
-                    "chat.attempt_truncated",
-                    result.truncation,
-                    stream=False,
-                    run_request=run_request,
-                    usage=result.usage,
-                    attempt=trace_attempt,
-                    choice=trace_choice,
-                    warm_age_ms=result.warm_age_ms,
-                )
         held = stop_buffer.flush()
         if held:
             result.text_parts.append(held)
@@ -2443,9 +2442,8 @@ async def _stream_completion(
             # finish_reason="length" - so clients continue instead of
             # blind-retrying an unrecoverable request. The partial call is
             # dropped, never executed.
-            outcome = "truncated"
+            outcome = "success" if saw_tool_call else "truncated"
             _log_truncated_tool_call(
-                "chat.truncated",
                 _TruncatedToolCall.from_error(exc),
                 stream=True,
                 run_request=run_request,
@@ -2453,6 +2451,8 @@ async def _stream_completion(
                 attempt=0,
                 choice=0,
                 warm_age_ms=warm_age_ms,
+                will_retry=False,
+                has_tool_calls=saw_tool_call,
             )
             held = stop_buffer.flush()
             if held:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -210,16 +210,27 @@ class FakeRunner:
 
 
 class RetryRunner(FakeRunner):
-    def __init__(self, attempts: list[str]) -> None:
+    def __init__(
+        self,
+        attempts: list[str],
+        *,
+        omit_session_started_attempts: frozenset[int] = frozenset(),
+    ) -> None:
         super().__init__([])
         self.attempts = attempts
+        self.omit_session_started_attempts = omit_session_started_attempts
 
     async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
         self.requests.append(request)
+        attempt = len(self.requests) - 1
         if request.warm_session is not None:
             request.warm_session.consumed = True
         try:
-            for event in _recorded_events(self.attempts[len(self.requests) - 1]):
+            for event in _recorded_events(self.attempts[attempt]):
+                if attempt in self.omit_session_started_attempts and isinstance(
+                    event, SessionStarted
+                ):
+                    continue
                 yield event
         finally:
             self.closed = True
@@ -1162,6 +1173,8 @@ async def test_truncated_payload_after_a_tool_call_keeps_tool_calls_finish(
 ) -> None:
     # "length" would make the client ask the model to continue instead of
     # running the call it already received.
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = FakeRunner(
         [
             TextDelta(
@@ -1182,7 +1195,8 @@ async def test_truncated_payload_after_a_tool_call_keeps_tool_calls_finish(
         ],
     )
 
-    async with _client(_app(tmp_path, runner)) as client:
+    app = _app(tmp_path, runner)
+    async with _client(app) as client:
         response = await client.post("/v1/chat/completions", json=payload)
 
     assert response.status_code == 200
@@ -1203,6 +1217,16 @@ async def test_truncated_payload_after_a_tool_call_keeps_tool_calls_finish(
         choice = response.json()["choices"][0]
         assert choice["finish_reason"] == "tool_calls"
         assert len(choice["message"]["tool_calls"]) == 1
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    attempts = [record for record in records if record["event"] == "chat.attempt_truncated"]
+    assert len(attempts) == 1
+    assert attempts[0]["stream"] is stream
+    assert attempts[0]["will_retry"] is False
+    assert not any(record["event"] == "chat.truncated" for record in records)
+    request_metrics = app.state.metrics.telemetry_snapshot().requests
+    assert len(request_metrics) == 1
+    assert request_metrics[0].outcome == "success"
+    assert request_metrics[0].mode == ("stream" if stream else "non_stream")
 
 
 @pytest.mark.asyncio
@@ -2459,7 +2483,8 @@ async def test_non_streaming_truncated_tool_call_retries_fresh_session(tmp_path:
         [
             "retry/truncated-tool.jsonl",
             "retry/plain-answer.jsonl",
-        ]
+        ],
+        omit_session_started_attempts=frozenset({0}),
     )
     payload = _payload(
         tools=[
@@ -2505,6 +2530,7 @@ async def test_non_streaming_truncated_tool_call_retries_fresh_session(tmp_path:
     assert runner.requests[0].prompt in runner.requests[1].prompt
     assert runner.requests[1].images == runner.requests[0].images
     assert "incomplete" in runner.requests[1].prompt
+    assert app.state.sessions.key("replay-session") == key
     records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
     attempts = [record for record in records if record["event"] == "chat.attempt_truncated"]
     assert len(attempts) == 1
@@ -2513,6 +2539,10 @@ async def test_non_streaming_truncated_tool_call_retries_fresh_session(tmp_path:
     assert attempts[0]["warm"] is True
     assert attempts[0]["warm_age_ms"] >= 1000.0
     assert attempts[0]["output_tokens"] == 0
+    assert attempts[0]["will_retry"] is True
+    retries = [record for record in records if record["event"] == "chat.retry"]
+    assert len(retries) == 1
+    assert retries[0]["reason"] == "truncated_tool_call"
     assert not any(record["event"] == "chat.truncated" for record in records)
 
 
@@ -2542,11 +2572,13 @@ async def test_repeated_truncated_tool_call_logs_final_outcome(tmp_path: Path) -
     records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
     attempts = [record for record in records if record["event"] == "chat.attempt_truncated"]
     final = [record for record in records if record["event"] == "chat.truncated"]
-    assert [record["attempt"] for record in attempts] == [0, 1]
+    assert [record["attempt"] for record in attempts] == [0]
+    assert attempts[0]["will_retry"] is True
     assert len(final) == 1
     assert final[0]["attempt"] == 1
     assert final[0]["warm"] is False
     assert final[0]["output_tokens"] == 0
+    assert final[0]["will_retry"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #119.

The duplicate events came from two paths logging the same truncation. It happens when one valid tool call is followed by an incomplete next call. No retry is correct there because it could duplicate the valid call. The response keeps `finish_reason="tool_calls"`.

Non-streaming logging now runs after the retry decision. Each truncation emits one event. `chat.attempt_truncated` covers a retry or a dropped trailing partial call. `chat.truncated` is only the final `length` outcome. New `will_retry` field makes the difference explicit. Requests with a valid call stay successful in telemetry.

Fresh isolated retries also work when Droid exposes no session ID. That path creates a new session, so the old session ID is not needed.

No new live fixture. Existing recorded retry fixtures cover the model output. ASGI tests reproduce the missing session event and valid-call plus trailing partial-call paths deterministically.

The one-off 113 second 502 had no separate bridge signature and was not reproducible. This PR does not guess at a new error mapping for it.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing`
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry and truncation handling for streamed and non-streamed requests.
  * Truncated tool-call responses now correctly distinguish between attempts that will retry and trailing partial calls that will be dropped.
  * Final truncation events are recorded only when appropriate, with clearer request outcome reporting.

* **Documentation**
  * Updated tool-call retry logging documentation to reflect the revised event behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->