### PR TITLE
feat(telemetry): log retry outcomes and attempt breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ are not retried because response bytes may already have reached the client.
 Non-final truncations log as `chat.attempt_truncated`. Its `will_retry` field
 distinguishes an actual retry from a dropped trailing partial call after a
 valid call. `chat.truncated` is reserved for the final request outcome.
+`chat.retry` names the reason, model, and warm age of the attempt that will be
+retried. `chat.retry_outcome` closes the loop with `recovered`, `refailed`, or
+`not_attempted` plus the retry's attempt number on the same `request_id`.
+`not_attempted` marks a reason that had no same-session id to retry in.
 When an earlier call in the same turn did complete, the turn keeps
 `finish_reason="tool_calls"` so the client runs the call it already received.
 Close markers inside JSON strings are argument data, not framing. Ambiguous

--- a/README.md
+++ b/README.md
@@ -303,11 +303,14 @@ truncated call returns `finish_reason="length"` without it. Streaming requests
 are not retried because response bytes may already have reached the client.
 Non-final truncations log as `chat.attempt_truncated`. Its `will_retry` field
 distinguishes an actual retry from a dropped trailing partial call after a
-valid call. `chat.truncated` is reserved for the final request outcome.
-`chat.retry` names the reason, model, and warm age of the attempt that will be
-retried. `chat.retry_outcome` closes the loop with `recovered`, `refailed`, or
-`not_attempted` plus the retry's attempt number on the same `request_id`.
-`not_attempted` marks a reason that had no same-session id to retry in.
+valid call, and `has_tool_calls` makes clear why that partial call cannot be
+retried regardless of its size. `chat.truncated` is reserved for the final
+request outcome. `chat.retry` names the reason, model, warm state, and warm age
+of the attempt that will be retried. `chat.retry_outcome` closes the loop with
+`recovered`, `refailed`, or `not_attempted` plus the retry's attempt number on
+the same `request_id`. `not_attempted` marks a same-session retry reason that
+had no session id. `chat.failed` names the model for streaming and non-streaming
+failures.
 When an earlier call in the same turn did complete, the turn keeps
 `finish_reason="tool_calls"` so the client runs the call it already received.
 Close markers inside JSON strings are argument data, not framing. Ambiguous

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -105,6 +105,7 @@ ModelOutputRetryReason = Literal[
     "tool_without_catalog",
     "truncated_tool_call",
 ]
+RetryOutcome = Literal["recovered", "refailed", "not_attempted"]
 BearerCredentials = Annotated[
     HTTPAuthorizationCredentials | None,
     Security(HTTPBearer(auto_error=False)),
@@ -1650,6 +1651,7 @@ def create_app(
         choices: list[dict[str, Any]] = []
         total_usage = Usage()
         started_session: str | None = None
+        retry_reason_in_flight: ModelOutputRetryReason | None = None
         try:
             async with lease:
                 # Choices run one after another so n completions never exceed the
@@ -1664,6 +1666,8 @@ def create_app(
                     attempt_request = choice_request
                     result: CollectedCompletion | None = None
                     attempt = 0
+                    retry_in_flight = False
+                    retry_reason_in_flight = None
                     while True:
                         attempt_session_id: str | None = None
 
@@ -1699,6 +1703,12 @@ def create_app(
                                 raise
                         else:
                             if result is None:
+                                if retry_in_flight and retry_reason_in_flight is not None:
+                                    _log_retry_outcome(
+                                        retry_reason_in_flight,
+                                        "refailed",
+                                        attempt=attempt,
+                                    )
                                 request.state.telemetry_error_type = "client_disconnected"
                                 return _error_response(
                                     "Client disconnected.",
@@ -1744,12 +1754,28 @@ def create_app(
                                 has_tool_calls=bool(result.tool_calls),
                             )
                         if retry_request is None:
+                            if retry_in_flight and retry_reason_in_flight is not None:
+                                outcome: RetryOutcome = (
+                                    "refailed" if retry_reason is not None else "recovered"
+                                )
+                                _log_retry_outcome(
+                                    retry_reason_in_flight,
+                                    outcome,
+                                    attempt=attempt,
+                                )
+                            elif not retry_in_flight and retry_reason is not None:
+                                _log_retry_outcome(retry_reason, "not_attempted", attempt=attempt)
                             break
                         retry_reason = cast("ModelOutputRetryReason", retry_reason)
+                        retry_in_flight = True
+                        retry_reason_in_flight = retry_reason
                         log_warning(
                             "chat.retry",
                             stream=False,
                             reason=retry_reason,
+                            model=payload.model,
+                            warm=attempt_request.warm_session is not None,
+                            warm_age_ms=result.warm_age_ms if result is not None else None,
                         )
                         metrics.record_features((f"model_output_retry:{retry_reason}",))
                         if retry_request.session_id is not None:
@@ -1774,16 +1800,26 @@ def create_app(
                     choices.append(_choice_dict(completed_result, index))
         except ProtocolError as exc:
             request.state.telemetry_error_type = "factory_protocol_error"
+            if retry_reason_in_flight is not None:
+                _log_retry_outcome(retry_reason_in_flight, "refailed", attempt=1)
             log_warning(
                 "chat.failed",
                 status=502,
                 error_type="factory_protocol_error",
                 reason=str(exc),
+                model=payload.model,
             )
             return _error_response(str(exc), 502, "factory_protocol_error")
         except RunnerError as exc:
             request.state.telemetry_error_type = exc.error_type
-            log_warning("chat.failed", status=exc.status_code, error_type=exc.error_type)
+            if retry_reason_in_flight is not None:
+                _log_retry_outcome(retry_reason_in_flight, "refailed", attempt=1)
+            log_warning(
+                "chat.failed",
+                status=exc.status_code,
+                error_type=exc.error_type,
+                model=payload.model,
+            )
             note_runner_failure(payload.model, exc)
             return _error_response(str(exc), exc.status_code, exc.error_type)
         finally:
@@ -1902,6 +1938,20 @@ def _retryable_structured_output_error(exc: ProtocolError) -> bool:
             "Factory Droid returned invalid structured JSON output",
             "Factory Droid structured output violated the requested schema",
         )
+    )
+
+
+def _log_retry_outcome(
+    reason: ModelOutputRetryReason,
+    outcome: RetryOutcome,
+    *,
+    attempt: int,
+) -> None:
+    log_warning(
+        "chat.retry_outcome",
+        reason=reason,
+        outcome=outcome,
+        attempt=attempt,
     )
 
 

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1676,6 +1676,7 @@ def create_app(
                             attempt_session_id = started_id
 
                         retry_reason: ModelOutputRetryReason | None = None
+                        attempt_warm_age_ms = _warm_session_age_ms(attempt_request)
                         try:
                             result = await _collect_completion_or_disconnect(
                                 request=request,
@@ -1693,12 +1694,15 @@ def create_app(
                                 trace_choice=index,
                             )
                         except ProtocolError as exc:
-                            if (
-                                attempt == 0
-                                and attempt_session_id is not None
-                                and str(exc) == _TOOL_WITHOUT_CATALOG_ERROR
-                            ):
+                            if attempt == 0 and str(exc) == _TOOL_WITHOUT_CATALOG_ERROR:
                                 retry_reason = "tool_without_catalog"
+                                if attempt_session_id is None:
+                                    _log_retry_outcome(
+                                        retry_reason,
+                                        "not_attempted",
+                                        attempt=attempt,
+                                    )
+                                    raise
                             else:
                                 raise
                         else:
@@ -1723,12 +1727,15 @@ def create_app(
                                 try:
                                     _validate_structured_output(result.text, structured)
                                 except ProtocolError as exc:
-                                    if (
-                                        attempt == 0
-                                        and attempt_session_id is not None
-                                        and _retryable_structured_output_error(exc)
-                                    ):
+                                    if attempt == 0 and _retryable_structured_output_error(exc):
                                         retry_reason = "structured_output"
+                                        if attempt_session_id is None:
+                                            _log_retry_outcome(
+                                                retry_reason,
+                                                "not_attempted",
+                                                attempt=attempt,
+                                            )
+                                            raise
                                     else:
                                         raise
 
@@ -1775,7 +1782,9 @@ def create_app(
                             reason=retry_reason,
                             model=payload.model,
                             warm=attempt_request.warm_session is not None,
-                            warm_age_ms=result.warm_age_ms if result is not None else None,
+                            warm_age_ms=(
+                                result.warm_age_ms if result is not None else attempt_warm_age_ms
+                            ),
                         )
                         metrics.record_features((f"model_output_retry:{retry_reason}",))
                         if retry_request.session_id is not None:
@@ -2017,6 +2026,7 @@ def _log_truncated_tool_call(
         warm_age_ms=warm_age_ms,
         output_tokens=usage.output_tokens,
         will_retry=will_retry,
+        has_tool_calls=has_tool_calls,
     )
 
 
@@ -2567,11 +2577,17 @@ async def _stream_completion(
                 stream=True,
                 error_type="factory_protocol_error",
                 reason=str(exc),
+                model=model,
             )
             yield _sse(_error_body(str(exc), "factory_protocol_error"))
         except RunnerError as exc:
             outcome = "timeout" if exc.error_type == "factory_droid_timeout" else "error"
-            log_warning("chat.failed", stream=True, error_type=exc.error_type)
+            log_warning(
+                "chat.failed",
+                stream=True,
+                error_type=exc.error_type,
+                model=model,
+            )
             if failure_callback is not None:
                 failure_callback(model, exc)
             yield _sse(_error_body(str(exc), exc.error_type))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2476,6 +2476,197 @@ async def test_non_streaming_malformed_tool_call_retries_same_session(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_malformed_without_session_logs_not_attempted(
+    tmp_path: Path,
+) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = RetryRunner(
+        ["retry/malformed-tool.jsonl", "retry/valid-tool.jsonl"],
+        omit_session_started_attempts=frozenset({0}),
+    )
+    payload = _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ]
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert len(runner.requests) == 1
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "malformed_tool_call"
+    assert outcomes[0]["outcome"] == "not_attempted"
+    assert outcomes[0]["attempt"] == 0
+    assert not any(record["event"] == "chat.retry" for record in records)
+
+
+@pytest.mark.asyncio
+async def test_retry_refailed_when_protocol_error_on_retry(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    truncated = _recorded_events("retry/truncated-tool.jsonl")
+
+    class RetryThenProtocolError(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__([])
+
+        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+            self.requests.append(request)
+            if request.warm_session is not None:
+                request.warm_session.consumed = True
+            try:
+                if len(self.requests) == 1:
+                    for event in truncated:
+                        yield event
+                else:
+                    yield TextDelta("\ud800")
+                    yield RunComplete(Usage())
+            finally:
+                self.closed = True
+
+    async with _client(_app(tmp_path, RetryThenProtocolError())) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}]
+            ),
+        )
+
+    assert response.status_code == 502
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "truncated_tool_call"
+    assert outcomes[0]["outcome"] == "refailed"
+    assert outcomes[0]["attempt"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_refailed_when_runner_error_on_retry(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    truncated = _recorded_events("retry/truncated-tool.jsonl")
+
+    class RetryThenRunnerError(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__([])
+
+        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+            self.requests.append(request)
+            if request.warm_session is not None:
+                request.warm_session.consumed = True
+            try:
+                if len(self.requests) == 1:
+                    for event in truncated:
+                        yield event
+                else:
+                    raise RunnerError("boom", status_code=503, error_type="factory_droid_sdk_error")
+            finally:
+                self.closed = True
+
+    async with _client(_app(tmp_path, RetryThenRunnerError())) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(
+                tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}]
+            ),
+        )
+
+    assert response.status_code == 503
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "truncated_tool_call"
+    assert outcomes[0]["outcome"] == "refailed"
+    assert outcomes[0]["attempt"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_refailed_when_client_disconnects_on_retry(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    truncated = _recorded_events("retry/truncated-tool.jsonl")
+
+    class RetryThenBlock(FakeRunner):
+        def __init__(self) -> None:
+            super().__init__([])
+            self.retry_started = asyncio.Event()
+
+        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+            self.requests.append(request)
+            if request.warm_session is not None:
+                request.warm_session.consumed = True
+            try:
+                if len(self.requests) == 1:
+                    for event in truncated:
+                        yield event
+                else:
+                    self.retry_started.set()
+                    await asyncio.Event().wait()
+            finally:
+                self.closed = True
+
+    runner = RetryThenBlock()
+    app = _app(tmp_path, runner)
+    body = json.dumps(
+        _payload(tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}])
+    ).encode()
+    delivered = False
+
+    async def receive() -> Any:
+        nonlocal delivered
+        if not delivered:
+            delivered = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        await runner.retry_started.wait()
+        return {"type": "http.disconnect"}
+
+    sent: list[Any] = []
+
+    async def send(message: Any) -> None:
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/chat/completions",
+            "raw_path": b"/v1/chat/completions",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"host", b"test"),
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("127.0.0.1", 4242),
+            "server": ("test", 80),
+        },
+        receive,
+        send,
+    )
+
+    assert sent[0]["status"] == 499
+    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "truncated_tool_call"
+    assert outcomes[0]["outcome"] == "refailed"
+    assert outcomes[0]["attempt"] == 1
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_truncated_tool_call_retries_fresh_session(tmp_path: Path) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
@@ -2543,6 +2734,13 @@ async def test_non_streaming_truncated_tool_call_retries_fresh_session(tmp_path:
     retries = [record for record in records if record["event"] == "chat.retry"]
     assert len(retries) == 1
     assert retries[0]["reason"] == "truncated_tool_call"
+    assert retries[0]["model"] == "factory-droid"
+    assert retries[0]["warm"] is True
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "truncated_tool_call"
+    assert outcomes[0]["outcome"] == "recovered"
+    assert outcomes[0]["attempt"] == 1
     assert not any(record["event"] == "chat.truncated" for record in records)
 
 
@@ -2579,6 +2777,11 @@ async def test_repeated_truncated_tool_call_logs_final_outcome(tmp_path: Path) -
     assert final[0]["warm"] is False
     assert final[0]["output_tokens"] == 0
     assert final[0]["will_retry"] is False
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    assert outcomes[0]["reason"] == "truncated_tool_call"
+    assert outcomes[0]["outcome"] == "refailed"
+    assert outcomes[0]["attempt"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -399,14 +399,35 @@ def _warning_records(log_stream: io.StringIO) -> list[dict[str, Any]]:
     return [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
 
 
-def _weather_payload() -> dict[str, object]:
+def _weather_payload(**overrides: object) -> dict[str, object]:
     return _payload(
         tools=[
             {
                 "type": "function",
-                "function": {"name": "weather", "parameters": {}},
+                "function": {
+                    "name": "weather",
+                    "description": "Read the weather.",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
             }
-        ]
+        ],
+        **overrides,
+    )
+
+
+def _integer_answer_payload() -> dict[str, object]:
+    return _payload(
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "integer"}},
+                    "required": ["answer"],
+                },
+            },
+        }
     )
 
 
@@ -1324,7 +1345,9 @@ async def test_truncated_payload_after_a_tool_call_keeps_tool_calls_finish(
     assert len(attempts) == 1
     assert attempts[0]["stream"] is stream
     assert attempts[0]["will_retry"] is False
+    assert attempts[0]["has_tool_calls"] is True
     assert not any(record["event"] == "chat.truncated" for record in records)
+    assert not any(record["event"] == "chat.retry_outcome" for record in records)
     request_metrics = app.state.metrics.telemetry_snapshot().requests
     assert len(request_metrics) == 1
     assert request_metrics[0].outcome == "success"
@@ -2256,6 +2279,8 @@ async def test_metrics_cover_latency_ttft_overload_and_payload_rejections(
 
 @pytest.mark.asyncio
 async def test_streaming_runner_error_uses_sse_error_shape(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = FakeRunner(
         [],
         error=RunnerError(
@@ -2266,7 +2291,7 @@ async def test_streaming_runner_error_uses_sse_error_shape(tmp_path: Path) -> No
     async with _client(_app(tmp_path, runner)) as client:
         response = await client.post(
             "/v1/chat/completions",
-            json=_payload(stream=True),
+            json=_payload(model="gpt-test", stream=True),
         )
         metrics = await client.get("/metrics")
 
@@ -2278,10 +2303,16 @@ async def test_streaming_runner_error_uses_sse_error_shape(tmp_path: Path) -> No
     assert events[-1] == "[DONE]"
     assert json.loads(events[-2])["error"]["type"] == "factory_droid_sdk_error"
     assert 'outcome="error",status="200"} 1' in metrics.text
+    failed = next(
+        record for record in _warning_records(log_stream) if record["event"] == "chat.failed"
+    )
+    assert failed["model"] == "gpt-test"
 
 
 @pytest.mark.asyncio
 async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = FakeRunner(
         [
             TextDelta(
@@ -2291,6 +2322,7 @@ async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> 
         ]
     )
     payload = _payload(
+        model="gpt-test",
         stream=True,
         tools=[
             {
@@ -2308,6 +2340,10 @@ async def test_streaming_protocol_error_uses_sse_error_shape(tmp_path: Path) -> 
         if line.startswith('data: {"error"')
     )
     assert error_event["error"]["type"] == "factory_protocol_error"
+    failed = next(
+        record for record in _warning_records(log_stream) if record["event"] == "chat.failed"
+    )
+    assert failed["model"] == "gpt-test"
 
 
 @pytest.mark.asyncio
@@ -2578,24 +2614,41 @@ async def test_non_streaming_malformed_tool_call_retries_same_session(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_malformed_without_session_logs_not_attempted(
+@pytest.mark.parametrize(
+    ("fixture", "payload", "reason", "expected_status"),
+    [
+        ("retry/malformed-tool.jsonl", _weather_payload(), "malformed_tool_call", 200),
+        ("retry/valid-tool.jsonl", _payload(), "tool_without_catalog", 502),
+        (
+            "retry/invalid-structured-output.jsonl",
+            _integer_answer_payload(),
+            "structured_output",
+            502,
+        ),
+    ],
+)
+async def test_non_streaming_retry_without_session_logs_not_attempted(
     tmp_path: Path,
+    fixture: str,
+    payload: dict[str, object],
+    reason: str,
+    expected_status: int,
 ) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = RetryRunner(
-        ["retry/malformed-tool.jsonl", "retry/valid-tool.jsonl"],
+        [fixture],
         omit_session_started_attempts=frozenset({0}),
     )
 
     async with _client(_app(tmp_path, runner)) as client:
-        response = await client.post("/v1/chat/completions", json=_weather_payload())
+        response = await client.post("/v1/chat/completions", json=payload)
 
-    assert response.status_code == 200
+    assert response.status_code == expected_status
     assert len(runner.requests) == 1
     records = _warning_records(log_stream)
     outcome = _single_retry_outcome(records)
-    assert outcome["reason"] == "malformed_tool_call"
+    assert outcome["reason"] == reason
     assert outcome["outcome"] == "not_attempted"
     assert outcome["attempt"] == 0
     assert not any(record["event"] == "chat.retry" for record in records)
@@ -2856,20 +2909,42 @@ async def test_truncated_phantom_tool_keeps_no_tool_retry_for_structured_output(
 
 @pytest.mark.asyncio
 async def test_non_streaming_tool_without_catalog_retries_same_session(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = RetryRunner(
         [
             "retry/valid-tool.jsonl",
             "retry/plain-answer.jsonl",
         ]
     )
-    async with _client(_app(tmp_path, runner)) as client:
+    app = _app(tmp_path, runner)
+    key = SessionKey(model_id=None, reasoning_effort=None)
+    warm = WarmSession(
+        key=key,
+        client=cast("Any", object()),
+        transport=None,
+        session_id="warm-session",
+        created_at=asyncio.get_running_loop().time() - 1.0,
+    )
+    app.state.pool.note(key)
+    app.state.pool.offer(warm)
+
+    async with _client(app) as client:
         response = await client.post("/v1/chat/completions", json=_payload())
 
     assert response.status_code == 200
     assert response.json()["choices"][0]["message"]["content"] == "Direct answer"
     assert len(runner.requests) == 2
+    assert runner.requests[0].warm_session is warm
     assert runner.requests[1].session_id == "replay-session"
     assert "no tools are available" in runner.requests[1].prompt
+    records = _warning_records(log_stream)
+    retry = next(record for record in records if record["event"] == "chat.retry")
+    assert retry["warm"] is True
+    assert retry["warm_age_ms"] >= 1000.0
+    outcome = _single_retry_outcome(records)
+    assert outcome["reason"] == "tool_without_catalog"
+    assert outcome["outcome"] == "recovered"
 
 
 @pytest.mark.asyncio
@@ -5762,22 +5837,6 @@ def _native_settings(tmp_path: Path) -> Settings:
         workdir=tmp_path,
         timeout_seconds=30.0,
         native_tool_calls=True,
-    )
-
-
-def _weather_payload(**overrides: object) -> dict[str, object]:
-    return _payload(
-        tools=[
-            {
-                "type": "function",
-                "function": {
-                    "name": "weather",
-                    "description": "Read the weather.",
-                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
-                },
-            }
-        ],
-        **overrides,
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -236,6 +236,42 @@ class RetryRunner(FakeRunner):
             self.closed = True
 
 
+class TruncationRetryRunner(FakeRunner):
+    """Serves one truncated attempt, then a configurable second attempt."""
+
+    def __init__(
+        self,
+        *,
+        retry_events: list[RunEvent] | None = None,
+        retry_error: RunnerError | None = None,
+        retry_gate: asyncio.Event | None = None,
+    ) -> None:
+        super().__init__([])
+        self.first = _recorded_events("retry/truncated-tool.jsonl")
+        self.retry_events = retry_events
+        self.retry_error = retry_error
+        self.retry_gate = retry_gate
+
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+        self.requests.append(request)
+        if request.warm_session is not None:
+            request.warm_session.consumed = True
+        try:
+            if len(self.requests) == 1:
+                for event in self.first:
+                    yield event
+            elif self.retry_gate is not None:
+                self.retry_gate.set()
+                await asyncio.Event().wait()
+            elif self.retry_error is not None:
+                raise self.retry_error
+            elif self.retry_events is not None:
+                for event in self.retry_events:
+                    yield event
+        finally:
+            self.closed = True
+
+
 class BlockingRunner(FakeRunner):
     def __init__(self) -> None:
         super().__init__([])
@@ -357,6 +393,72 @@ def _client(app: Any) -> httpx.AsyncClient:
         transport=httpx.ASGITransport(app=app),
         base_url="http://test",
     )
+
+
+def _warning_records(log_stream: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
+
+
+def _weather_payload() -> dict[str, object]:
+    return _payload(
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "weather", "parameters": {}},
+            }
+        ]
+    )
+
+
+def _single_retry_outcome(records: list[dict[str, Any]]) -> dict[str, Any]:
+    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
+    assert len(outcomes) == 1
+    return outcomes[0]
+
+
+def _chat_scope(body: bytes) -> dict[str, Any]:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/chat/completions",
+        "raw_path": b"/v1/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"test"),
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+        "client": ("127.0.0.1", 4242),
+        "server": ("test", 80),
+    }
+
+
+def _request_then_disconnect_receive(body: bytes, gate: asyncio.Event) -> Any:
+    delivered = False
+
+    async def receive() -> Any:
+        nonlocal delivered
+        if not delivered:
+            delivered = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        await gate.wait()
+        return {"type": "http.disconnect"}
+
+    return receive
+
+
+async def _run_chat_request(app: Any, *, body: bytes, receive: Any) -> list[Any]:
+    sent: list[Any] = []
+
+    async def send(message: Any) -> None:
+        sent.append(message)
+
+    await app(_chat_scope(body), receive, send)
+    return sent
 
 
 @pytest.mark.asyncio
@@ -2485,26 +2587,17 @@ async def test_non_streaming_malformed_without_session_logs_not_attempted(
         ["retry/malformed-tool.jsonl", "retry/valid-tool.jsonl"],
         omit_session_started_attempts=frozenset({0}),
     )
-    payload = _payload(
-        tools=[
-            {
-                "type": "function",
-                "function": {"name": "weather", "parameters": {}},
-            }
-        ]
-    )
 
     async with _client(_app(tmp_path, runner)) as client:
-        response = await client.post("/v1/chat/completions", json=payload)
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
 
     assert response.status_code == 200
     assert len(runner.requests) == 1
-    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
-    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
-    assert len(outcomes) == 1
-    assert outcomes[0]["reason"] == "malformed_tool_call"
-    assert outcomes[0]["outcome"] == "not_attempted"
-    assert outcomes[0]["attempt"] == 0
+    records = _warning_records(log_stream)
+    outcome = _single_retry_outcome(records)
+    assert outcome["reason"] == "malformed_tool_call"
+    assert outcome["outcome"] == "not_attempted"
+    assert outcome["attempt"] == 0
     assert not any(record["event"] == "chat.retry" for record in records)
 
 
@@ -2512,158 +2605,56 @@ async def test_non_streaming_malformed_without_session_logs_not_attempted(
 async def test_retry_refailed_when_protocol_error_on_retry(tmp_path: Path) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
-    truncated = _recorded_events("retry/truncated-tool.jsonl")
+    runner = TruncationRetryRunner(retry_events=[TextDelta("\ud800"), RunComplete(Usage())])
 
-    class RetryThenProtocolError(FakeRunner):
-        def __init__(self) -> None:
-            super().__init__([])
-
-        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
-            self.requests.append(request)
-            if request.warm_session is not None:
-                request.warm_session.consumed = True
-            try:
-                if len(self.requests) == 1:
-                    for event in truncated:
-                        yield event
-                else:
-                    yield TextDelta("\ud800")
-                    yield RunComplete(Usage())
-            finally:
-                self.closed = True
-
-    async with _client(_app(tmp_path, RetryThenProtocolError())) as client:
-        response = await client.post(
-            "/v1/chat/completions",
-            json=_payload(
-                tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}]
-            ),
-        )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
 
     assert response.status_code == 502
-    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
-    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
-    assert len(outcomes) == 1
-    assert outcomes[0]["reason"] == "truncated_tool_call"
-    assert outcomes[0]["outcome"] == "refailed"
-    assert outcomes[0]["attempt"] == 1
+    outcome = _single_retry_outcome(_warning_records(log_stream))
+    assert outcome["reason"] == "truncated_tool_call"
+    assert outcome["outcome"] == "refailed"
+    assert outcome["attempt"] == 1
 
 
 @pytest.mark.asyncio
 async def test_retry_refailed_when_runner_error_on_retry(tmp_path: Path) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
-    truncated = _recorded_events("retry/truncated-tool.jsonl")
+    runner = TruncationRetryRunner(
+        retry_error=RunnerError("boom", status_code=503, error_type="factory_droid_sdk_error")
+    )
 
-    class RetryThenRunnerError(FakeRunner):
-        def __init__(self) -> None:
-            super().__init__([])
-
-        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
-            self.requests.append(request)
-            if request.warm_session is not None:
-                request.warm_session.consumed = True
-            try:
-                if len(self.requests) == 1:
-                    for event in truncated:
-                        yield event
-                else:
-                    raise RunnerError("boom", status_code=503, error_type="factory_droid_sdk_error")
-            finally:
-                self.closed = True
-
-    async with _client(_app(tmp_path, RetryThenRunnerError())) as client:
-        response = await client.post(
-            "/v1/chat/completions",
-            json=_payload(
-                tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}]
-            ),
-        )
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=_weather_payload())
 
     assert response.status_code == 503
-    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
-    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
-    assert len(outcomes) == 1
-    assert outcomes[0]["reason"] == "truncated_tool_call"
-    assert outcomes[0]["outcome"] == "refailed"
-    assert outcomes[0]["attempt"] == 1
+    outcome = _single_retry_outcome(_warning_records(log_stream))
+    assert outcome["reason"] == "truncated_tool_call"
+    assert outcome["outcome"] == "refailed"
+    assert outcome["attempt"] == 1
 
 
 @pytest.mark.asyncio
 async def test_retry_refailed_when_client_disconnects_on_retry(tmp_path: Path) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
-    truncated = _recorded_events("retry/truncated-tool.jsonl")
-
-    class RetryThenBlock(FakeRunner):
-        def __init__(self) -> None:
-            super().__init__([])
-            self.retry_started = asyncio.Event()
-
-        async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
-            self.requests.append(request)
-            if request.warm_session is not None:
-                request.warm_session.consumed = True
-            try:
-                if len(self.requests) == 1:
-                    for event in truncated:
-                        yield event
-                else:
-                    self.retry_started.set()
-                    await asyncio.Event().wait()
-            finally:
-                self.closed = True
-
-    runner = RetryThenBlock()
+    retry_gate = asyncio.Event()
+    runner = TruncationRetryRunner(retry_gate=retry_gate)
     app = _app(tmp_path, runner)
-    body = json.dumps(
-        _payload(tools=[{"type": "function", "function": {"name": "weather", "parameters": {}}}])
-    ).encode()
-    delivered = False
+    body = json.dumps(_weather_payload()).encode()
 
-    async def receive() -> Any:
-        nonlocal delivered
-        if not delivered:
-            delivered = True
-            return {"type": "http.request", "body": body, "more_body": False}
-        await runner.retry_started.wait()
-        return {"type": "http.disconnect"}
-
-    sent: list[Any] = []
-
-    async def send(message: Any) -> None:
-        sent.append(message)
-
-    await app(
-        {
-            "type": "http",
-            "asgi": {"version": "3.0", "spec_version": "2.4"},
-            "http_version": "1.1",
-            "method": "POST",
-            "scheme": "http",
-            "path": "/v1/chat/completions",
-            "raw_path": b"/v1/chat/completions",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [
-                (b"host", b"test"),
-                (b"content-type", b"application/json"),
-                (b"content-length", str(len(body)).encode()),
-            ],
-            "client": ("127.0.0.1", 4242),
-            "server": ("test", 80),
-        },
-        receive,
-        send,
+    sent = await _run_chat_request(
+        app,
+        body=body,
+        receive=_request_then_disconnect_receive(body, retry_gate),
     )
 
     assert sent[0]["status"] == 499
-    records = [json.loads(line) for line in log_stream.getvalue().splitlines() if line.strip()]
-    outcomes = [record for record in records if record["event"] == "chat.retry_outcome"]
-    assert len(outcomes) == 1
-    assert outcomes[0]["reason"] == "truncated_tool_call"
-    assert outcomes[0]["outcome"] == "refailed"
-    assert outcomes[0]["attempt"] == 1
+    outcome = _single_retry_outcome(_warning_records(log_stream))
+    assert outcome["reason"] == "truncated_tool_call"
+    assert outcome["outcome"] == "refailed"
+    assert outcome["attempt"] == 1
 
 
 @pytest.mark.asyncio
@@ -5589,42 +5580,11 @@ async def test_non_streaming_request_answers_499_when_the_client_disconnects(
     runner = BlockingRunner()
     app = _app(tmp_path, runner)
     body = json.dumps(_payload()).encode()
-    delivered = False
 
-    async def receive() -> Any:
-        nonlocal delivered
-        if not delivered:
-            delivered = True
-            return {"type": "http.request", "body": body, "more_body": False}
-        await runner.started.wait()
-        return {"type": "http.disconnect"}
-
-    sent: list[Any] = []
-
-    async def send(message: Any) -> None:
-        sent.append(message)
-
-    await app(
-        {
-            "type": "http",
-            "asgi": {"version": "3.0", "spec_version": "2.4"},
-            "http_version": "1.1",
-            "method": "POST",
-            "scheme": "http",
-            "path": "/v1/chat/completions",
-            "raw_path": b"/v1/chat/completions",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [
-                (b"host", b"test"),
-                (b"content-type", b"application/json"),
-                (b"content-length", str(len(body)).encode()),
-            ],
-            "client": ("127.0.0.1", 4242),
-            "server": ("test", 80),
-        },
-        receive,
-        send,
+    sent = await _run_chat_request(
+        app,
+        body=body,
+        receive=_request_then_disconnect_receive(body, runner.started),
     )
 
     assert sent[0]["status"] == 499


### PR DESCRIPTION
## Summary

This closes the measurement half of #112. The census said ~15% of traffic failed or was retried, but it could not say what a retry did. Now every bridge retry logs its result, so we can count recovered against still-failing instead of one big failed bucket.

Three things changed.

`chat.retry_outcome` logs `recovered`, `refailed`, or `not_attempted` with the attempt number, on the same request_id as the trigger. `chat.retry` gains `model`, `warm`, and `warm_age_ms`. `chat.failed` gains `model`.

`not_attempted` matters. On prod some retries never started: same attempt 0, same second, no `chat.retry` between them. That was #119. Without this state those requests fall into `refailed` and fake the statistic, the same blunt-census problem one level down. Now the reason is recorded and we can pair trigger with outcome instead of guessing.

The model breadcrumb is there because the model is the strongest correlator I have: gemini with the same effort and the same schema is clean, luna fails. Without it the census still merges both models into one line.

The #119 double-emit itself was already fixed by #120, this only makes the retry result visible.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` (1837 passed, 100% branch)
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.

The new paths are deterministic and covered with the existing RetryRunner
fixtures, so no new live model captured. Reason it cannot be: the failure
modes are luna-specific and we cannot pin a live luna transcript into the
fixture set. The retry-outcome states are asserted against recorded events
instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded logging documentation for truncation, retries, failures, request correlation, attempt details, session status, tool calls, and model identification.

* **Bug Fixes**
  * Improved retry handling when no session is available.
  * Retry and failure logs now provide clearer outcomes and model context for streaming and non-streaming requests.
  * Added diagnostics for recovered, failed, and not-attempted retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->