### PR TITLE
feat(observability): auth probe, cancel and empty telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,10 @@ jobs:
           for _ in range(50):
               try:
                   with urllib.request.urlopen(f"{base_url}/health") as response:
-                      assert json.load(response) == {"status": "ok"}
+                      assert json.load(response) == {
+                          "status": "ok",
+                          "auth": "unknown",
+                      }
                   break
               except urllib.error.URLError:
                   time.sleep(0.1)

--- a/README.md
+++ b/README.md
@@ -1503,6 +1503,9 @@ surface.
 | `factory_droid_openai_warm_session_misses_total` | Requests that had to start their own session |
 | `factory_droid_openai_warm_session_failures_total` | Failed warm-up attempts |
 | `factory_droid_openai_pending_reaps` | Droid teardowns still running in the background |
+| `factory_droid_openai_empty_completions_total` | Completions that returned no text or tool calls |
+| `factory_droid_openai_auth_probe_successes_total` | Auth probes that completed with assistant text and a terminal event |
+| `factory_droid_openai_auth_probe_failures_total` | Auth probes that failed, timed out, or returned no complete answer |
 
 `forced_kills_total` counts processes that had to be killed with a signal
 because they did not exit within `FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS`.

--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,8 @@ error types.
 | `FACTORY_DROID_OPENAI_REASONING_EFFORT` | unset | Reasoning effort forced on every request |
 | `FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS` | `300` | `GET /v1/models` catalog cache lifetime |
 | `FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS` | `900` | How long a refused model stays withheld |
+| `FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS` | `0` | How often one minimal Droid exec checks the Factory key; each probe is a real model turn, so set `300` to catch a dead key within minutes instead of hours. `0` disables the probe, its `auth` health field, and the auth gate |
+| `FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD` | `3` | Consecutive probe failures before chat requests fail fast with `503 factory_auth_error` |
 | `FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS` | `0` | MCP initialization window before tool discovery |
 | `FACTORY_DROID_OPENAI_LOG_LEVEL` | `info` | Bridge and Uvicorn log level |
 | `FACTORY_DROID_OPENAI_LOG_FORMAT` | `text` | Bridge log rendering: `text` or `json` |
@@ -1587,9 +1589,9 @@ factory-droid-openai --log-level debug --no-access-log
 
 | Level | Content |
 |---|---|
-| `warning` | Rejections, failures, degraded model discovery, quarantined models, forced process kills |
+| `warning` | Rejections, failures, cancelled requests (`chat.cancelled`), empty completions (`chat.empty_completion`), auth probe failures (`auth.probe_failed`), degraded model discovery, quarantined models, forced process kills |
 | `info` | One `chat.completed` summary per request with phase timings and token usage |
-| `debug` | Per-phase events: prompt built, admission, warm-session hit, retune or miss, Droid startup, session ready, first token, turn complete, cleanup |
+| `debug` | Per-phase events: prompt built, admission, warm-session hit, retune or miss, Droid startup, session ready, first token, turn complete, cleanup, successful auth probes |
 | `trace` | One line per Droid SDK event kind |
 
 ```text
@@ -1806,6 +1808,23 @@ export FACTORY_DROID_PATH="$HOME/.local/bin/droid"
 An HTTP `401` means `FACTORY_DROID_OPENAI_API_KEY` is configured and the
 request token is missing or incorrect. This is separate from Factory account
 authentication used by the Droid CLI.
+
+### Factory key failing auth probes
+
+```text
+503 factory_auth_error
+```
+
+The bridge's Factory key (the one the Droid CLI authenticates with) is being
+rejected server-side, or it answers with empty completions. With
+`FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS=300` the bridge runs one minimal
+Droid exec with that key every five minutes: a failing probe logs
+`auth.probe_failed` and flips the `auth` field on `/health` to `degraded`,
+and after `FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD` consecutive failures
+chat requests fail fast with `503` instead of each paying for a Droid spawn
+that cannot answer. Rotate the key; any request that completes with content
+clears the gate immediately. The probe is off until
+`FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS` is set.
 
 ### Factory-native tool blocked
 

--- a/openapi.json
+++ b/openapi.json
@@ -1197,7 +1197,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -1312,7 +1312,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -1435,7 +1435,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -1560,7 +1560,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -1675,7 +1675,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -1790,7 +1790,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -1892,7 +1892,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {
@@ -2015,7 +2015,7 @@
                 }
               }
             },
-            "description": "Droid executable unavailable."
+            "description": "Droid executable unavailable or Factory authentication failed."
           },
           "504": {
             "content": {

--- a/openapi.json
+++ b/openapi.json
@@ -641,6 +641,16 @@
       },
       "HealthResponse": {
         "properties": {
+          "auth": {
+            "default": "unknown",
+            "enum": [
+              "ok",
+              "degraded",
+              "unknown"
+            ],
+            "title": "Auth",
+            "type": "string"
+          },
           "status": {
             "const": "ok",
             "title": "Status",
@@ -1159,6 +1169,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1188,16 +1208,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1274,6 +1284,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1303,16 +1323,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1397,6 +1407,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1426,16 +1446,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1522,6 +1532,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1551,16 +1571,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1637,6 +1647,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1666,16 +1686,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1752,6 +1762,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1781,16 +1801,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1854,6 +1864,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -1883,16 +1903,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [
@@ -1977,6 +1987,16 @@
               }
             }
           },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request or bearer authentication failure."
+          },
           "502": {
             "content": {
               "application/json": {
@@ -2006,16 +2026,6 @@
               }
             },
             "description": "Droid request timeout."
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Invalid request or bearer authentication failure."
           }
         },
         "security": [

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1366,6 +1366,7 @@ def create_app(
         if auth_probe is not None and auth_probe.failing:
             # Every doomed request pays for a full Droid spawn before failing,
             # so the probe gate turns an auth outage into one cheap rejection.
+            auth_probe.suspect()
             request.state.telemetry_error_type = "factory_auth_error"
             log_warning(
                 "chat.rejected",
@@ -1662,6 +1663,7 @@ def create_app(
                 note_runner_failure(model, exc)
                 if auth_probe is not None and exc.error_type == "factory_auth_error":
                     auth_probe.suspect()
+                    request.state.telemetry_error_type = exc.error_type
 
             event_stream = _stream_completion(
                 request_id=request_id,
@@ -1877,7 +1879,11 @@ def create_app(
                     choice = _choice_dict(completed_result, index)
                     choices.append(choice)
                     choice_message = cast("dict[str, Any]", choice["message"])
-                    if choice_message["content"] is None and not choice_message.get("tool_calls"):
+                    if (
+                        choice_message["content"] is None
+                        and not choice_message.get("tool_calls")
+                        and not completed_result.stopped
+                    ):
                         # A dead Factory key answers with empty 200s before it
                         # answers with errors (issue #122), so an empty body
                         # has to be its own loud event instead of a silent one.
@@ -2692,7 +2698,12 @@ async def _stream_completion(
         if outcome_callback is not None:
             outcome_callback(outcome)
         if outcome == "success" and completion_callback is not None:
-            completion_callback(not saw_text and not saw_tool_call and structured is None)
+            completion_callback(
+                not saw_text
+                and not saw_tool_call
+                and structured is None
+                and not stop_buffer.triggered
+            )
         _log_stream_outcome(outcome, model=model, usage=usage, tool_calls=tool_call_index)
         yield "data: [DONE]\n\n"
 

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -191,7 +191,7 @@ CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     },
     503: {
         "model": ErrorResponse,
-        "description": "Droid executable unavailable.",
+        "description": "Droid executable unavailable or Factory authentication failed.",
     },
     504: {
         "model": ErrorResponse,
@@ -1363,6 +1363,12 @@ def create_app(
             priority=priority,
         )
 
+        rejection = _validate_options(payload, resolved_settings)
+        if rejection is not None:
+            request.state.telemetry_error_type = "invalid_request_error"
+            log_warning("chat.rejected", status=rejection.status_code, phase="options")
+            return rejection
+
         if auth_probe is not None and auth_probe.failing:
             # Every doomed request pays for a full Droid spawn before failing,
             # so the probe gate turns an auth outage into one cheap rejection.
@@ -1380,12 +1386,6 @@ def create_app(
                 503,
                 "factory_auth_error",
             )
-
-        rejection = _validate_options(payload, resolved_settings)
-        if rejection is not None:
-            request.state.telemetry_error_type = "invalid_request_error"
-            log_warning("chat.rejected", status=rejection.status_code, phase="options")
-            return rejection
 
         reasoning_effort = _effective_reasoning_effort(payload, resolved_settings)
         try:
@@ -1661,9 +1661,10 @@ def create_app(
 
             def note_stream_failure(model: str, exc: RunnerError) -> None:
                 note_runner_failure(model, exc)
-                if auth_probe is not None and exc.error_type == "factory_auth_error":
-                    auth_probe.suspect()
+                if exc.error_type == "factory_auth_error":
                     request.state.telemetry_error_type = exc.error_type
+                    if auth_probe is not None:
+                        auth_probe.suspect()
 
             event_stream = _stream_completion(
                 request_id=request_id,
@@ -1783,6 +1784,10 @@ def create_app(
                                     status=499,
                                     model=payload.model,
                                     choices=payload.n,
+                                    elapsed_ms=timeline.total_ms,
+                                    queue_ms=timeline.phases.get("queue_ms"),
+                                    warm=attempt_request.warm_session is not None,
+                                    warm_age_ms=attempt_warm_age_ms,
                                 )
                                 return _error_response(
                                     "Client disconnected.",
@@ -2691,7 +2696,16 @@ async def _stream_completion(
                 failure_callback(model, exc)
             yield _sse(_error_body(str(exc), exc.error_type))
         except asyncio.CancelledError:
-            log_warning("chat.cancelled", stream=True, model=model)
+            timeline = current_timeline()
+            log_warning(
+                "chat.cancelled",
+                stream=True,
+                model=model,
+                elapsed_ms=timeline.total_ms if timeline is not None else None,
+                queue_ms=timeline.phases.get("queue_ms") if timeline is not None else None,
+                warm=run_request.warm_session is not None,
+                warm_age_ms=warm_age_ms,
+            )
             if outcome_callback is not None:
                 outcome_callback("cancelled")
             raise

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -20,6 +20,7 @@ from jsonschema import ValidationError as JsonSchemaValidationError
 from jsonschema.exceptions import SchemaError
 from jsonschema.validators import validator_for
 
+from factory_droid_openai.auth_probe import AuthProbe
 from factory_droid_openai.availability import ModelQuarantine
 from factory_droid_openai.config import DEFAULT_TOOL_CALL_DRAIN_SECONDS, Settings
 from factory_droid_openai.droid_rpc import DroidRpcExtension, ToolCatalogCache
@@ -858,6 +859,16 @@ def create_app(
         endpoint=DEFAULT_TELEMETRY_ENDPOINT,
         enabled=resolved_settings.telemetry,
     )
+    auth_probe: AuthProbe | None = None
+    if resolved_settings.auth_probe_seconds > 0:
+        auth_probe = AuthProbe(
+            runner_factory=resolved_runner_factory,
+            model_alias=resolved_settings.model_alias,
+            timeout_seconds=resolved_settings.timeout_seconds,
+            interval_seconds=resolved_settings.auth_probe_seconds,
+            failure_threshold=resolved_settings.auth_failure_threshold,
+            metrics=metrics,
+        )
 
     @contextlib.asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
@@ -870,12 +881,18 @@ def create_app(
             ),
         )
         telemetry.start()
+        if auth_probe is not None:
+            auth_probe.start()
         log_info(
             "bridge.started",
             warm_sessions=resolved_settings.warm_session_count(),
             max_concurrency=resolved_settings.max_concurrency,
             detached_cleanup=resolved_settings.detached_cleanup,
             telemetry=telemetry.enabled,
+            auth_probe_seconds=resolved_settings.auth_probe_seconds or None,
+            auth_failure_threshold=(
+                resolved_settings.auth_failure_threshold if auth_probe is not None else None
+            ),
             reasoning_effort=resolved_settings.reasoning_effort,
             trace_payloads=resolved_settings.trace_payloads,
             trace_payload_file=(
@@ -887,6 +904,10 @@ def create_app(
         try:
             yield
         finally:
+            if auth_probe is not None:
+                # Closed before the pool and reaper so a probe mid-run still
+                # finds them alive for its cleanup.
+                await auth_probe.aclose()
             await pool.aclose()
             await reaper.drain()
             await telemetry.close()
@@ -933,6 +954,7 @@ def create_app(
     application.state.reaper = reaper
     application.state.quarantine = quarantine
     application.state.telemetry = telemetry
+    application.state.auth_probe = auth_probe
     application.state.tool_catalog_cache = tool_catalog_cache
     application.state.native_tools = native_tools
     if resolved_settings.native_tool_calls:
@@ -1076,7 +1098,10 @@ def create_app(
         summary="Check bridge health",
     )
     async def health() -> HealthResponse:
-        return HealthResponse(status="ok")
+        return HealthResponse(
+            status="ok",
+            auth="unknown" if auth_probe is None else auth_probe.status,
+        )
 
     @application.get(
         "/version",
@@ -1337,6 +1362,23 @@ def create_app(
             continuation=payload.factory_droid_session_id is not None,
             priority=priority,
         )
+
+        if auth_probe is not None and auth_probe.failing:
+            # Every doomed request pays for a full Droid spawn before failing,
+            # so the probe gate turns an auth outage into one cheap rejection.
+            request.state.telemetry_error_type = "factory_auth_error"
+            log_warning(
+                "chat.rejected",
+                status=503,
+                phase="auth_probe",
+                consecutive=auth_probe.consecutive_failures,
+            )
+            return _error_response(
+                "The bridge's Factory key is failing auth probes. "
+                "Retry after the key is rotated; see the auth field on /health.",
+                503,
+                "factory_auth_error",
+            )
 
         rejection = _validate_options(payload, resolved_settings)
         if rejection is not None:
@@ -1607,6 +1649,20 @@ def create_app(
                 }:
                     sessions.remember(started_stream_session, requested_key)
 
+            def record_stream_completion(empty: bool) -> None:
+                if empty:
+                    metrics.increment_empty_completions()
+                    log_warning("chat.empty_completion", stream=True, model=payload.model)
+                    if auth_probe is not None:
+                        auth_probe.suspect()
+                elif auth_probe is not None:
+                    auth_probe.record_success()
+
+            def note_stream_failure(model: str, exc: RunnerError) -> None:
+                note_runner_failure(model, exc)
+                if auth_probe is not None and exc.error_type == "factory_auth_error":
+                    auth_probe.suspect()
+
             event_stream = _stream_completion(
                 request_id=request_id,
                 created=created,
@@ -1618,13 +1674,14 @@ def create_app(
                 metrics=metrics,
                 request_started_at=request_started_at,
                 outcome_callback=record_stream_outcome,
+                completion_callback=record_stream_completion,
                 include_usage=bool(payload.stream_options and payload.stream_options.include_usage),
                 stop_sequences=payload.stop_sequences,
                 emit_status=payload.factory_droid_status,
                 session_callback=record_started_session,
                 expose_session=resolved_settings.session_continuity,
                 structured=structured,
-                failure_callback=note_runner_failure,
+                failure_callback=note_stream_failure,
                 drain_seconds=resolved_settings.tool_call_drain_seconds,
                 trace_event=payload_tracer.trace,
             )
@@ -1652,6 +1709,7 @@ def create_app(
         total_usage = Usage()
         started_session: str | None = None
         retry_reason_in_flight: ModelOutputRetryReason | None = None
+        empty_choices = 0
         try:
             async with lease:
                 # Choices run one after another so n completions never exceed the
@@ -1713,7 +1771,17 @@ def create_app(
                                         "refailed",
                                         attempt=attempt,
                                     )
+                                # Abandoned requests must stay countable: issue
+                                # #125 had a client-abort outage read as a gap
+                                # where no request ever arrived.
                                 request.state.telemetry_error_type = "client_disconnected"
+                                log_warning(
+                                    "chat.cancelled",
+                                    stream=False,
+                                    status=499,
+                                    model=payload.model,
+                                    choices=payload.n,
+                                )
                                 return _error_response(
                                     "Client disconnected.",
                                     499,
@@ -1806,7 +1874,21 @@ def create_app(
                         sessions.remember(completed_result.session_id, requested_key)
                         started_session = completed_result.session_id
                     total_usage = _add_usage(total_usage, completed_result.usage)
-                    choices.append(_choice_dict(completed_result, index))
+                    choice = _choice_dict(completed_result, index)
+                    choices.append(choice)
+                    choice_message = cast("dict[str, Any]", choice["message"])
+                    if choice_message["content"] is None and not choice_message.get("tool_calls"):
+                        # A dead Factory key answers with empty 200s before it
+                        # answers with errors (issue #122), so an empty body
+                        # has to be its own loud event instead of a silent one.
+                        empty_choices += 1
+                        metrics.increment_empty_completions()
+                        log_warning(
+                            "chat.empty_completion",
+                            stream=False,
+                            model=payload.model,
+                            choice=index,
+                        )
         except ProtocolError as exc:
             request.state.telemetry_error_type = "factory_protocol_error"
             if retry_reason_in_flight is not None:
@@ -1828,8 +1910,11 @@ def create_app(
                 status=exc.status_code,
                 error_type=exc.error_type,
                 model=payload.model,
+                reason=str(exc),
             )
             note_runner_failure(payload.model, exc)
+            if auth_probe is not None and exc.error_type == "factory_auth_error":
+                auth_probe.suspect()
             return _error_response(str(exc), exc.status_code, exc.error_type)
         finally:
             try:
@@ -1840,6 +1925,12 @@ def create_app(
                         session_use.release()
                 finally:
                     release_native_tools()
+
+        if auth_probe is not None:
+            if empty_choices:
+                auth_probe.suspect()
+            else:
+                auth_probe.record_success()
 
         log_info(
             "chat.completed",
@@ -2297,6 +2388,7 @@ async def _stream_completion(
     metrics: BridgeMetrics | None = None,
     request_started_at: float | None = None,
     outcome_callback: Callable[[str], None] | None = None,
+    completion_callback: Callable[[bool], None] | None = None,
     include_usage: bool = False,
     stop_sequences: tuple[str, ...] = (),
     emit_status: bool = False,
@@ -2587,17 +2679,20 @@ async def _stream_completion(
                 stream=True,
                 error_type=exc.error_type,
                 model=model,
+                reason=str(exc),
             )
             if failure_callback is not None:
                 failure_callback(model, exc)
             yield _sse(_error_body(str(exc), exc.error_type))
         except asyncio.CancelledError:
-            log_warning("chat.cancelled", stream=True)
+            log_warning("chat.cancelled", stream=True, model=model)
             if outcome_callback is not None:
                 outcome_callback("cancelled")
             raise
         if outcome_callback is not None:
             outcome_callback(outcome)
+        if outcome == "success" and completion_callback is not None:
+            completion_callback(not saw_text and not saw_tool_call and structured is None)
         _log_stream_outcome(outcome, model=model, usage=usage, tool_calls=tool_call_index)
         yield "data: [DONE]\n\n"
 
@@ -3173,6 +3268,7 @@ def _telemetry_error_category(
         categories = {
             "authentication_error": "authentication",
             "client_disconnected": "cancelled",
+            "factory_auth_error": "factory_auth",
             "factory_droid_timeout": "timeout",
             "factory_incomplete_response": "incomplete_response",
             "factory_protocol_error": "protocol",

--- a/src/factory_droid_openai/auth_probe.py
+++ b/src/factory_droid_openai/auth_probe.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from typing import TYPE_CHECKING, Literal
+
+from factory_droid_openai.logs import debug as log_debug
+from factory_droid_openai.logs import millis
+from factory_droid_openai.logs import warning as log_warning
+from factory_droid_openai.runner import RunnerError, RunRequest, TextDelta
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from factory_droid_openai.metrics import BridgeMetrics
+    from factory_droid_openai.runner import DroidRunner
+
+AuthProbeStatus = Literal["ok", "degraded", "unknown"]
+
+# A probe turn only needs one short answer, so a healthy exec has no reason to
+# approach the request timeout ceiling. Hanging spawns fail here instead of
+# delaying the next probe by minutes.
+_PROBE_TIMEOUT_CEILING_SECONDS = 60.0
+
+_PROBE_PROMPT = "Reply with exactly: ok"
+
+
+class AuthProbe:
+    """Periodic exec-based check that the bridge's Factory key still works.
+
+    Model catalog discovery stays healthy while key-authenticated exec fails
+    (issue #122), so the probe has to run a real one-turn Droid exec. An empty
+    answer counts as a failure: a dead key surfaces as empty 200 completions
+    before it surfaces as an error.
+    """
+
+    def __init__(
+        self,
+        *,
+        runner_factory: Callable[[], DroidRunner],
+        model_alias: str,
+        timeout_seconds: float,
+        interval_seconds: float,
+        failure_threshold: int,
+        metrics: BridgeMetrics | None = None,
+    ) -> None:
+        self._runner_factory = runner_factory
+        self._model_alias = model_alias
+        self._timeout_seconds = timeout_seconds
+        self._interval_seconds = interval_seconds
+        self._failure_threshold = failure_threshold
+        self._metrics = metrics
+        self._trigger = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._consecutive_failures = 0
+        self._status: AuthProbeStatus = "unknown"
+
+    @property
+    def status(self) -> AuthProbeStatus:
+        """Last known state of the Factory key, for the health endpoint."""
+        return self._status
+
+    @property
+    def consecutive_failures(self) -> int:
+        return self._consecutive_failures
+
+    @property
+    def failing(self) -> bool:
+        """Whether the gate should fail fast instead of spawning doomed sessions."""
+        return self._consecutive_failures >= self._failure_threshold
+
+    def start(self) -> None:
+        if self._task is not None or self._interval_seconds <= 0:
+            return
+        self._task = asyncio.create_task(self._loop(), name="factory-droid-openai-auth-probe")
+
+    def record_success(self) -> None:
+        """A completion that carried content proves the key works."""
+        self._consecutive_failures = 0
+        self._status = "ok"
+
+    def suspect(self) -> None:
+        """Ask for an immediate probe after an auth-shaped or empty completion."""
+        self._trigger.set()
+
+    async def aclose(self) -> None:
+        task = self._task
+        if task is None:
+            return
+        self._task = None
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _loop(self) -> None:
+        while True:
+            await self._probe_once()
+            # Clearing after the wait keeps a suspect() raised while the probe
+            # was running from being swallowed by the clear.
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(self._trigger.wait(), timeout=self._interval_seconds)
+            self._trigger.clear()
+
+    async def _probe_once(self) -> None:
+        started = time.perf_counter()
+        try:
+            reason = await self._run_probe()
+        except Exception as exc:  # the probe must never kill the app
+            reason = f"Auth probe crashed: {exc}"
+        elapsed_ms = millis(time.perf_counter() - started)
+        if reason is None:
+            self._consecutive_failures = 0
+            self._status = "ok"
+            if self._metrics is not None:
+                self._metrics.increment_auth_probe_successes()
+            log_debug("auth.probe_ok", elapsed_ms=elapsed_ms)
+            return
+        self._consecutive_failures += 1
+        self._status = "degraded"
+        if self._metrics is not None:
+            self._metrics.increment_auth_probe_failures()
+        log_warning(
+            "auth.probe_failed",
+            reason=reason,
+            consecutive=self._consecutive_failures,
+            threshold=self._failure_threshold,
+            elapsed_ms=elapsed_ms,
+        )
+
+    async def _run_probe(self) -> str | None:
+        """Run one minimal Droid exec; ``None`` means the key answered."""
+        runner = self._runner_factory()
+        budget = min(self._timeout_seconds, _PROBE_TIMEOUT_CEILING_SECONDS)
+        request = RunRequest(
+            prompt=_PROBE_PROMPT,
+            model=self._model_alias,
+            model_alias=self._model_alias,
+            reasoning_effort=None,
+            timeout_seconds=budget,
+        )
+        saw_text = False
+        try:
+            # The outer bound catches a runner whose own deadline never fires,
+            # so one stuck exec cannot stall the probe loop for good.
+            async with asyncio.timeout(budget):
+                async for event in runner.run(request):
+                    if isinstance(event, TextDelta):
+                        saw_text = saw_text or bool(event.text)
+        except RunnerError as exc:
+            return str(exc)
+        except TimeoutError:
+            return "Auth probe timed out."
+        if not saw_text:
+            return "Auth probe completed without any assistant text."
+        return None

--- a/src/factory_droid_openai/auth_probe.py
+++ b/src/factory_droid_openai/auth_probe.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from factory_droid_openai.logs import debug as log_debug
 from factory_droid_openai.logs import millis
 from factory_droid_openai.logs import warning as log_warning
-from factory_droid_openai.runner import RunnerError, RunRequest, TextDelta
+from factory_droid_openai.runner import RunComplete, RunnerError, RunRequest, TextDelta
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -140,6 +140,7 @@ class AuthProbe:
             timeout_seconds=budget,
         )
         saw_text = False
+        completed = False
         try:
             # The outer bound catches a runner whose own deadline never fires,
             # so one stuck exec cannot stall the probe loop for good.
@@ -147,10 +148,14 @@ class AuthProbe:
                 async for event in runner.run(request):
                     if isinstance(event, TextDelta):
                         saw_text = saw_text or bool(event.text)
+                    elif isinstance(event, RunComplete):
+                        completed = True
         except RunnerError as exc:
             return str(exc)
         except TimeoutError:
             return "Auth probe timed out."
         if not saw_text:
             return "Auth probe completed without any assistant text."
+        if not completed:
+            return "Auth probe ended without a completion event."
         return None

--- a/src/factory_droid_openai/config.py
+++ b/src/factory_droid_openai/config.py
@@ -71,6 +71,15 @@ class Settings:
     mcp_settle_seconds: float = 0.0
     model_cache_seconds: float = 300.0
     model_quarantine_seconds: float = 900.0
+    # How often the auth probe runs one minimal Droid exec to check the
+    # Factory key. Off by default because every probe is a real model turn
+    # that costs tokens; enabling it catches a dead key within one interval
+    # instead of hours of opaque failures (issue #122). Zero disables the
+    # probe, its health field, and the gate.
+    auth_probe_seconds: float = 0.0
+    # Consecutive probe failures before chat requests fail fast with 503
+    # instead of each paying for a doomed Droid spawn.
+    auth_failure_threshold: int = 3
     worktree: str | None = None
     append_system_prompt_file: Path | None = None
     model_alias: str = DEFAULT_MODEL_ALIAS
@@ -121,6 +130,10 @@ class Settings:
             or self.warm_session_idle_drain_seconds <= 0
         ):
             raise ValueError("warm_session_idle_drain_seconds must be greater than zero and finite")
+        if not math.isfinite(self.auth_probe_seconds) or self.auth_probe_seconds < 0:
+            raise ValueError("auth_probe_seconds must be zero or greater and finite")
+        if self.auth_failure_threshold < 1:
+            raise ValueError("auth_failure_threshold must be at least 1")
         # Every warm session pins one catalog for its whole warm life, and every
         # admitted request publishes one of its own, so the registry has to hold
         # both at once. Sizing it any smaller makes the registry evict the
@@ -313,6 +326,14 @@ class Settings:
             "FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS",
             default=900.0,
         )
+        auth_probe_seconds = _non_negative_float(
+            "FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS",
+            default=0.0,
+        )
+        auth_failure_threshold = _positive_int(
+            "FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD",
+            default=3,
+        )
         worktree = os.getenv("FACTORY_DROID_OPENAI_WORKTREE") or None
         append_system_prompt_file = _optional_file(
             "FACTORY_DROID_OPENAI_APPEND_SYSTEM_PROMPT_FILE",
@@ -382,6 +403,8 @@ class Settings:
             mcp_settle_seconds=mcp_settle_seconds,
             model_cache_seconds=model_cache_seconds,
             model_quarantine_seconds=model_quarantine_seconds,
+            auth_probe_seconds=auth_probe_seconds,
+            auth_failure_threshold=auth_failure_threshold,
             worktree=worktree,
             append_system_prompt_file=append_system_prompt_file,
             model_alias=os.getenv("FACTORY_DROID_OPENAI_MODEL_ALIAS", DEFAULT_MODEL_ALIAS),

--- a/src/factory_droid_openai/metrics.py
+++ b/src/factory_droid_openai/metrics.py
@@ -58,6 +58,9 @@ class BridgeMetrics:
         self._warm_misses = 0
         self._warm_failures = 0
         self._pending_reaps = 0
+        self._empty_completions = 0
+        self._auth_probe_successes = 0
+        self._auth_probe_failures = 0
         self._telemetry_requests: Counter[tuple[str, str, str]] = Counter()
         self._telemetry_request_duration_seconds: dict[tuple[str, str, str], float] = {}
         self._telemetry_features: Counter[str] = Counter()
@@ -151,6 +154,18 @@ class BridgeMetrics:
         with self._lock:
             self._pending_reaps = count
 
+    def increment_empty_completions(self) -> None:
+        with self._lock:
+            self._empty_completions += 1
+
+    def increment_auth_probe_successes(self) -> None:
+        with self._lock:
+            self._auth_probe_successes += 1
+
+    def increment_auth_probe_failures(self) -> None:
+        with self._lock:
+            self._auth_probe_failures += 1
+
     def telemetry_snapshot(self) -> MetricsSnapshot:
         with self._lock:
             requests = tuple(
@@ -176,6 +191,8 @@ class BridgeMetrics:
                         "warm_miss": self._warm_misses,
                         "warm_retune": self._warm_retunes.total(),
                         "warm_failure": self._warm_failures,
+                        "empty_completion": self._empty_completions,
+                        "auth_probe_failure": self._auth_probe_failures,
                     }.items()
                 )
             )
@@ -212,6 +229,9 @@ class BridgeMetrics:
                 "warm_misses": self._warm_misses,
                 "warm_failures": self._warm_failures,
                 "pending_reaps": self._pending_reaps,
+                "empty_completions": self._empty_completions,
+                "auth_probe_successes": self._auth_probe_successes,
+                "auth_probe_failures": self._auth_probe_failures,
             }
 
         lines = [
@@ -273,5 +293,11 @@ class BridgeMetrics:
             f"factory_droid_openai_warm_session_failures_total {values['warm_failures']}",
             "# TYPE factory_droid_openai_pending_reaps gauge",
             f"factory_droid_openai_pending_reaps {values['pending_reaps']}",
+            "# TYPE factory_droid_openai_empty_completions_total counter",
+            f"factory_droid_openai_empty_completions_total {values['empty_completions']}",
+            "# TYPE factory_droid_openai_auth_probe_successes_total counter",
+            (f"factory_droid_openai_auth_probe_successes_total {values['auth_probe_successes']}"),
+            "# TYPE factory_droid_openai_auth_probe_failures_total counter",
+            f"factory_droid_openai_auth_probe_failures_total {values['auth_probe_failures']}",
         ]
         return "\n".join(lines) + "\n"

--- a/src/factory_droid_openai/models.py
+++ b/src/factory_droid_openai/models.py
@@ -55,6 +55,9 @@ class StreamOptions(BaseModel):
 
 class HealthResponse(BaseModel):
     status: Literal["ok"]
+    # Last known state of the Factory key from the auth probe: "unknown" when
+    # the probe is disabled or has not finished its first run yet.
+    auth: Literal["ok", "degraded", "unknown"] = "unknown"
 
 
 class VersionResponse(BaseModel):

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -82,8 +82,10 @@ _TRANSIENT_CONNECTION_PATTERN = re.compile(r"connection error\.?", re.IGNORECASE
 # dedicated code, so the wording is what separates an auth outage from a
 # bridge failure (issue #122: a dead key hid behind three unrelated shapes).
 _AUTH_FAILURE_PATTERN = re.compile(
-    r"(?:unauthorized|forbidden|api key (?:is )?(?:invalid|revoked|expired|not found)"
-    r"|authentication (?:failed|error)|invalid authentication|"
+    r"(?:unauthorized|forbidden|"
+    r"(?:invalid|revoked|expired|not found) api key|"
+    r"api key (?:is |has )?(?:invalid|revoked|expired|not found)|"
+    r"authentication (?:failed|error)|invalid authentication|"
     r"status code (?:401|403)\b|\b(?:401|403)\b)",
     re.IGNORECASE,
 )

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -78,6 +78,15 @@ _MODEL_DENIED_PATTERN = re.compile(
 )
 # Droid emits this generic message for a transient upstream connection blip.
 _TRANSIENT_CONNECTION_PATTERN = re.compile(r"connection error\.?", re.IGNORECASE)
+# A rejected or revoked Factory key surfaces in Droid's error text, never as a
+# dedicated code, so the wording is what separates an auth outage from a
+# bridge failure (issue #122: a dead key hid behind three unrelated shapes).
+_AUTH_FAILURE_PATTERN = re.compile(
+    r"(?:unauthorized|forbidden|api key (?:is )?(?:invalid|revoked|expired|not found)"
+    r"|authentication (?:failed|error)|invalid authentication|"
+    r"status code (?:401|403)\b|\b(?:401|403)\b)",
+    re.IGNORECASE,
+)
 # Droid keeps two of its own meta tools callable whatever a session disables:
 # exit-spec-mode, and the loader that would fetch a deferred tool. Neither
 # touches the machine, and Droid refuses to run them in a session with every
@@ -1108,6 +1117,9 @@ def sdk_error(exc: DroidClientError, *, model: str | None = None) -> RunnerError
     denied = _model_denied_error(message, model=model)
     if denied is not None:
         return denied
+    auth = _auth_failure_error(message)
+    if auth is not None:
+        return auth
     return RunnerError(
         f"Factory Droid SDK failed: {message}",
         error_type="factory_droid_sdk_error",
@@ -1124,6 +1136,9 @@ def _error_event_failure(event: ErrorEvent, *, model: str | None) -> RunnerError
     denied = _model_denied_error(message, model=model)
     if denied is not None:
         return denied
+    auth = _auth_failure_error(message)
+    if auth is not None:
+        return auth
     if _TRANSIENT_CONNECTION_PATTERN.fullmatch(message.strip()):
         return RunnerError(
             message,
@@ -1144,6 +1159,22 @@ def _model_denied_error(message: str, *, model: str | None) -> RunnerError | Non
         f"{subject} is not available for this Factory account: {message}",
         status_code=404,
         error_type="model_not_found",
+    )
+
+
+def _auth_failure_error(message: str) -> RunnerError | None:
+    """Classify auth-shaped Droid failures so a dead key reads as one thing.
+
+    The auth probe and the request gate key off this error type, so the
+    wording check stays conservative: only messages Droid itself attributes
+    to the Factory credential count as auth failures.
+    """
+    if not _AUTH_FAILURE_PATTERN.search(message):
+        return None
+    return RunnerError(
+        f"Factory rejected the bridge's API key: {message}",
+        status_code=503,
+        error_type="factory_auth_error",
     )
 
 

--- a/tests/fixtures/runner/auth-failures.jsonl
+++ b/tests/fixtures/runner/auth-failures.jsonl
@@ -1,0 +1,7 @@
+{"message":"Request failed with status code 401","error_type":"Error"}
+{"message":"Invalid API key","error_type":"Error"}
+{"message":"API key is invalid","error_type":"Error"}
+{"message":"API key has expired","error_type":"Error"}
+{"message":"Expired API key","error_type":"Error"}
+{"message":"403 Forbidden","error_type":"Error"}
+{"message":"Authentication failed","error_type":"Error"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -570,7 +570,7 @@ async def test_health_and_models(tmp_path: Path) -> None:
         health = await client.get("/health")
         models = await client.get("/v1/models")
 
-    assert health.json() == {"status": "ok"}
+    assert health.json() == {"status": "ok", "auth": "unknown"}
     alias = models.json()["data"][0]
     assert alias["id"] == "factory-droid"
     assert alias["created"] > 0
@@ -5652,6 +5652,8 @@ async def test_runner_factory_failure_releases_the_session_lease(tmp_path: Path)
 async def test_non_streaming_request_answers_499_when_the_client_disconnects(
     tmp_path: Path,
 ) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = BlockingRunner()
     app = _app(tmp_path, runner)
     body = json.dumps(_payload()).encode()
@@ -5664,6 +5666,238 @@ async def test_non_streaming_request_answers_499_when_the_client_disconnects(
 
     assert sent[0]["status"] == 499
     assert runner.closed is True
+    cancelled = [
+        json.loads(line)
+        for line in log_stream.getvalue().splitlines()
+        if json.loads(line)["event"] == "chat.cancelled"
+    ]
+    assert len(cancelled) == 1
+    assert cancelled[0]["stream"] is False
+    assert cancelled[0]["status"] == 499
+    assert cancelled[0]["model"] == "factory-droid"
+
+
+def _probe_app(
+    tmp_path: Path,
+    runner: Any,
+    *,
+    auth_probe_seconds: float = 60.0,
+    auth_failure_threshold: int = 3,
+) -> Any:
+    return create_app(
+        Settings(
+            workdir=tmp_path,
+            timeout_seconds=30.0,
+            warm_sessions=0,
+            telemetry=False,
+            auth_probe_seconds=auth_probe_seconds,
+            auth_failure_threshold=auth_failure_threshold,
+        ),
+        runner_factory=cast("RunnerFactory", lambda: runner),
+    )
+
+
+def _auth_error() -> RunnerError:
+    return RunnerError(
+        "Factory rejected the bridge's API key: revoked",
+        status_code=503,
+        error_type="factory_auth_error",
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_reports_probe_auth_status(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("ok"), RunComplete(Usage())])
+    app = _probe_app(tmp_path, runner, auth_probe_seconds=0.05)
+    probe = app.state.auth_probe
+    assert probe is not None
+
+    async with app.router.lifespan_context(app):
+        async with asyncio.timeout(5.0):
+            while probe.status != "ok":
+                await asyncio.sleep(0)
+        async with _client(app) as client:
+            response = await client.get("/health")
+
+    assert response.json() == {"status": "ok", "auth": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_chat_requests_fail_fast_while_the_auth_gate_is_open(
+    tmp_path: Path,
+) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = FakeRunner([TextDelta("ok"), RunComplete(Usage())])
+    app = _probe_app(tmp_path, runner, auth_failure_threshold=3)
+    probe = app.state.auth_probe
+    assert probe is not None
+    probe._consecutive_failures = 3
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload())
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["type"] == "factory_auth_error"
+    assert "auth probes" in body["error"]["message"]
+    # The gate must reject before any Droid process is spawned.
+    assert runner.requests == []
+    rejected = [
+        json.loads(line)
+        for line in log_stream.getvalue().splitlines()
+        if json.loads(line)["event"] == "chat.rejected"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0]["phase"] == "auth_probe"
+    assert rejected[0]["consecutive"] == 3
+
+
+@pytest.mark.asyncio
+async def test_chat_traffic_success_resets_the_probe(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("ok"), RunComplete(Usage())])
+    app = _probe_app(tmp_path, runner)
+    probe = app.state.auth_probe
+    assert probe is not None
+    probe._consecutive_failures = 2
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload())
+
+    assert response.status_code == 200
+    assert len(runner.requests) == 1
+    assert probe._consecutive_failures == 0
+    assert probe.status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_auth_shaped_failure_triggers_an_immediate_probe(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([], error=_auth_error())
+    app = _probe_app(tmp_path, runner)
+    probe = app.state.auth_probe
+    assert probe is not None
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload())
+
+    assert response.status_code == 503
+    assert len(runner.requests) == 1
+    assert probe._trigger.is_set()
+
+
+@pytest.mark.asyncio
+async def test_streaming_auth_failure_triggers_an_immediate_probe(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([], error=_auth_error())
+    app = _probe_app(tmp_path, runner)
+    probe = app.state.auth_probe
+    assert probe is not None
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload(stream=True))
+
+    assert response.status_code == 200
+    assert "factory_auth_error" in response.text
+    assert probe._trigger.is_set()
+
+
+@pytest.mark.asyncio
+async def test_streaming_traffic_success_resets_the_probe(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("hi"), RunComplete(Usage())])
+    app = _probe_app(tmp_path, runner)
+    probe = app.state.auth_probe
+    assert probe is not None
+    probe._consecutive_failures = 2
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload(stream=True))
+
+    assert response.status_code == 200
+    assert probe._consecutive_failures == 0
+    assert probe.status == "ok"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_chat_failed_reports_the_failure_reason(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = FakeRunner(
+        [],
+        error=RunnerError(
+            "Factory Droid SDK failed: boom",
+            error_type="factory_droid_sdk_error",
+        ),
+    )
+    app = _app(tmp_path, runner)
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload(stream=stream))
+
+    if stream:
+        assert response.status_code == 200
+        assert "factory_droid_sdk_error" in response.text
+    else:
+        assert response.status_code == 502
+    failures = [
+        json.loads(line)
+        for line in log_stream.getvalue().splitlines()
+        if json.loads(line)["event"] == "chat.failed"
+    ]
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "Factory Droid SDK failed: boom"
+    assert failures[0]["error_type"] == "factory_droid_sdk_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_empty_completions_are_logged_and_counted(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = FakeRunner([RunComplete(Usage())])
+    app = _app(tmp_path, runner)
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload(stream=stream))
+
+    assert response.status_code == 200
+    if not stream:
+        assert response.json()["choices"][0]["message"]["content"] is None
+    empties = [
+        json.loads(line)
+        for line in log_stream.getvalue().splitlines()
+        if json.loads(line)["event"] == "chat.empty_completion"
+    ]
+    assert len(empties) == 1
+    assert empties[0]["stream"] is stream
+    assert "factory_droid_openai_empty_completions_total 1" in app.state.metrics.render()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_empty_completions_suspect_the_probe(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    runner = FakeRunner([RunComplete(Usage())])
+    app = _probe_app(tmp_path, runner)
+    probe = app.state.auth_probe
+    assert probe is not None
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload(stream=stream))
+
+    assert response.status_code == 200
+    assert probe._trigger.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5743,6 +5743,7 @@ async def test_chat_requests_fail_fast_while_the_auth_gate_is_open(
     assert "auth probes" in body["error"]["message"]
     # The gate must reject before any Droid process is spawned.
     assert runner.requests == []
+    assert probe._trigger.is_set()
     rejected = [
         json.loads(line)
         for line in log_stream.getvalue().splitlines()
@@ -5802,6 +5803,8 @@ async def test_streaming_auth_failure_triggers_an_immediate_probe(
     assert response.status_code == 200
     assert "factory_auth_error" in response.text
     assert probe._trigger.is_set()
+    features = dict(app.state.metrics.telemetry_snapshot().features)
+    assert features["request_error:chat_completions:factory_auth"] == 1
 
 
 @pytest.mark.asyncio
@@ -5898,6 +5901,29 @@ async def test_empty_completions_suspect_the_probe(
 
     assert response.status_code == 200
     assert probe._trigger.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_stop_sequence_does_not_count_as_an_empty_completion(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    runner = FakeRunner([TextDelta("STOP"), RunComplete(Usage())])
+    app = _probe_app(tmp_path, runner)
+    probe = app.state.auth_probe
+    assert probe is not None
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(stream=stream, stop="STOP"),
+        )
+
+    assert response.status_code == 200
+    assert "factory_droid_openai_empty_completions_total 0" in app.state.metrics.render()
+    assert probe._trigger.is_set() is False
+    assert probe.status == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5675,16 +5675,25 @@ async def test_non_streaming_request_answers_499_when_the_client_disconnects(
     assert cancelled[0]["stream"] is False
     assert cancelled[0]["status"] == 499
     assert cancelled[0]["model"] == "factory-droid"
+    assert cancelled[0]["elapsed_ms"] >= 0
+    assert cancelled[0]["queue_ms"] >= 0
+    assert cancelled[0]["warm"] is False
 
 
 def _probe_app(
     tmp_path: Path,
-    runner: Any,
     *,
+    events_fixture: str | None = "hello--gpt-5-4-mini.jsonl",
+    drop_text: bool = False,
+    error: RunnerError | None = None,
     auth_probe_seconds: float = 60.0,
     auth_failure_threshold: int = 3,
-) -> Any:
-    return create_app(
+) -> tuple[Any, FakeRunner]:
+    events = [] if events_fixture is None else _recorded_events(events_fixture)
+    if drop_text:
+        events = [event for event in events if not isinstance(event, TextDelta)]
+    runner = FakeRunner(events, error=error)
+    app = create_app(
         Settings(
             workdir=tmp_path,
             timeout_seconds=30.0,
@@ -5695,6 +5704,7 @@ def _probe_app(
         ),
         runner_factory=cast("RunnerFactory", lambda: runner),
     )
+    return app, runner
 
 
 def _auth_error() -> RunnerError:
@@ -5707,8 +5717,7 @@ def _auth_error() -> RunnerError:
 
 @pytest.mark.asyncio
 async def test_health_reports_probe_auth_status(tmp_path: Path) -> None:
-    runner = FakeRunner([TextDelta("ok"), RunComplete(Usage())])
-    app = _probe_app(tmp_path, runner, auth_probe_seconds=0.05)
+    app, _runner = _probe_app(tmp_path, auth_probe_seconds=0.05)
     probe = app.state.auth_probe
     assert probe is not None
 
@@ -5728,8 +5737,7 @@ async def test_chat_requests_fail_fast_while_the_auth_gate_is_open(
 ) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
-    runner = FakeRunner([TextDelta("ok"), RunComplete(Usage())])
-    app = _probe_app(tmp_path, runner, auth_failure_threshold=3)
+    app, runner = _probe_app(tmp_path, auth_failure_threshold=3)
     probe = app.state.auth_probe
     assert probe is not None
     probe._consecutive_failures = 3
@@ -5755,9 +5763,27 @@ async def test_chat_requests_fail_fast_while_the_auth_gate_is_open(
 
 
 @pytest.mark.asyncio
+async def test_invalid_options_win_over_the_auth_gate(tmp_path: Path) -> None:
+    app, runner = _probe_app(tmp_path, auth_failure_threshold=3)
+    probe = app.state.auth_probe
+    assert probe is not None
+    probe._consecutive_failures = 3
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(n=5),
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert runner.requests == []
+    assert probe._trigger.is_set() is False
+
+
+@pytest.mark.asyncio
 async def test_chat_traffic_success_resets_the_probe(tmp_path: Path) -> None:
-    runner = FakeRunner([TextDelta("ok"), RunComplete(Usage())])
-    app = _probe_app(tmp_path, runner)
+    app, runner = _probe_app(tmp_path)
     probe = app.state.auth_probe
     assert probe is not None
     probe._consecutive_failures = 2
@@ -5775,8 +5801,7 @@ async def test_chat_traffic_success_resets_the_probe(tmp_path: Path) -> None:
 async def test_auth_shaped_failure_triggers_an_immediate_probe(
     tmp_path: Path,
 ) -> None:
-    runner = FakeRunner([], error=_auth_error())
-    app = _probe_app(tmp_path, runner)
+    app, runner = _probe_app(tmp_path, events_fixture=None, error=_auth_error())
     probe = app.state.auth_probe
     assert probe is not None
 
@@ -5792,8 +5817,7 @@ async def test_auth_shaped_failure_triggers_an_immediate_probe(
 async def test_streaming_auth_failure_triggers_an_immediate_probe(
     tmp_path: Path,
 ) -> None:
-    runner = FakeRunner([], error=_auth_error())
-    app = _probe_app(tmp_path, runner)
+    app, _runner = _probe_app(tmp_path, events_fixture=None, error=_auth_error())
     probe = app.state.auth_probe
     assert probe is not None
 
@@ -5808,9 +5832,24 @@ async def test_streaming_auth_failure_triggers_an_immediate_probe(
 
 
 @pytest.mark.asyncio
+async def test_streaming_auth_failure_is_categorized_without_a_probe(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([], error=_auth_error())
+    app = _app(tmp_path, runner)
+
+    async with _client(app) as client:
+        response = await client.post("/v1/chat/completions", json=_payload(stream=True))
+
+    assert response.status_code == 200
+    assert "factory_auth_error" in response.text
+    features = dict(app.state.metrics.telemetry_snapshot().features)
+    assert features["request_error:chat_completions:factory_auth"] == 1
+
+
+@pytest.mark.asyncio
 async def test_streaming_traffic_success_resets_the_probe(tmp_path: Path) -> None:
-    runner = FakeRunner([TextDelta("hi"), RunComplete(Usage())])
-    app = _probe_app(tmp_path, runner)
+    app, _runner = _probe_app(tmp_path)
     probe = app.state.auth_probe
     assert probe is not None
     probe._consecutive_failures = 2
@@ -5866,7 +5905,13 @@ async def test_empty_completions_are_logged_and_counted(
 ) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
-    runner = FakeRunner([RunComplete(Usage())])
+    runner = FakeRunner(
+        [
+            event
+            for event in _recorded_events("hello--gpt-5-4-mini.jsonl")
+            if not isinstance(event, TextDelta)
+        ]
+    )
     app = _app(tmp_path, runner)
 
     async with _client(app) as client:
@@ -5891,8 +5936,7 @@ async def test_empty_completions_suspect_the_probe(
     tmp_path: Path,
     stream: bool,
 ) -> None:
-    runner = FakeRunner([RunComplete(Usage())])
-    app = _probe_app(tmp_path, runner)
+    app, _runner = _probe_app(tmp_path, drop_text=True)
     probe = app.state.auth_probe
     assert probe is not None
 
@@ -5909,15 +5953,17 @@ async def test_stop_sequence_does_not_count_as_an_empty_completion(
     tmp_path: Path,
     stream: bool,
 ) -> None:
-    runner = FakeRunner([TextDelta("STOP"), RunComplete(Usage())])
-    app = _probe_app(tmp_path, runner)
+    app, _runner = _probe_app(
+        tmp_path,
+        events_fixture="stop-sequence--gpt-5-4-mini.jsonl",
+    )
     probe = app.state.auth_probe
     assert probe is not None
 
     async with _client(app) as client:
         response = await client.post(
             "/v1/chat/completions",
-            json=_payload(stream=stream, stop="STOP"),
+            json=_payload(stream=stream, stop="4"),
         )
 
     assert response.status_code == 200
@@ -6027,6 +6073,10 @@ async def test_streaming_structured_output_absorbs_finish_and_held_text() -> Non
 
 @pytest.mark.asyncio
 async def test_streaming_reports_a_cancelled_outcome() -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    timeline = logs.bind_request("chatcmpl-test")
+    timeline.mark("queue_ms")
     runner = BlockingRunner()
     outcomes: list[str] = []
     metrics = BridgeMetrics()
@@ -6059,6 +6109,16 @@ async def test_streaming_reports_a_cancelled_outcome() -> None:
 
     assert '"role":"assistant"' in first
     assert outcomes == ["cancelled"]
+    cancelled = [
+        json.loads(line)
+        for line in log_stream.getvalue().splitlines()
+        if json.loads(line)["event"] == "chat.cancelled"
+    ]
+    assert len(cancelled) == 1
+    assert cancelled[0]["request_id"] == "chatcmpl-test"
+    assert cancelled[0]["elapsed_ms"] >= 0
+    assert cancelled[0]["queue_ms"] >= 0
+    assert cancelled[0]["warm"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth_probe.py
+++ b/tests/test_auth_probe.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from factory_droid_openai import logs
+from factory_droid_openai.auth_probe import AuthProbe
+from factory_droid_openai.metrics import BridgeMetrics
+from factory_droid_openai.runner import RunnerError, RunRequest, TextDelta
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from factory_droid_openai.runner import DroidRunner
+
+
+class _StubRunner:
+    """DroidRunner double whose run() only needs to work for one turn."""
+
+    def __init__(
+        self,
+        *,
+        events: list[Any] | None = None,
+        error: RunnerError | None = None,
+    ) -> None:
+        self.events = [TextDelta("ok")] if events is None else events
+        self.error = error
+        self.requests: list[RunRequest] = []
+
+    async def run(self, request: RunRequest) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        for event in self.events:
+            yield event
+
+
+class _HangingRunner:
+    """Never yields; only an outer timeout can end the probe."""
+
+    def __init__(self) -> None:
+        self.requests: list[RunRequest] = []
+
+    async def run(self, request: RunRequest) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        await asyncio.Event().wait()
+        yield TextDelta("never")
+
+
+class _CrashingRunner(_StubRunner):
+    async def run(self, request: RunRequest) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        yield TextDelta("half")
+        raise RuntimeError("kaboom")
+
+
+async def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail("condition not reached in time")
+
+
+def _probe(
+    runner: Any,
+    *,
+    interval_seconds: float = 60.0,
+    timeout_seconds: float = 30.0,
+    failure_threshold: int = 3,
+    metrics: BridgeMetrics | None = None,
+) -> AuthProbe:
+    return AuthProbe(
+        runner_factory=cast("Callable[[], DroidRunner]", lambda: runner),
+        model_alias="factory-droid",
+        timeout_seconds=timeout_seconds,
+        interval_seconds=interval_seconds,
+        failure_threshold=failure_threshold,
+        metrics=metrics,
+    )
+
+
+def _events(stream: io.StringIO) -> list[dict[str, Any]]:
+    return [
+        cast("dict[str, Any]", json.loads(line)) for line in stream.getvalue().splitlines() if line
+    ]
+
+
+@pytest.mark.asyncio
+async def test_successful_probe_reports_ok() -> None:
+    stream = io.StringIO()
+    logs.configure_logging(level="debug", log_format="json", stream=stream)
+    metrics = BridgeMetrics()
+    runner = _StubRunner()
+    probe = _probe(runner, metrics=metrics)
+
+    probe.start()
+    await _wait_until(lambda: probe.status == "ok")
+
+    await probe.aclose()
+    assert len(runner.requests) == 1
+    request = runner.requests[0]
+    assert request.model == "factory-droid"
+    assert request.model_alias == "factory-droid"
+    assert "factory_droid_openai_auth_probe_successes_total 1" in metrics.render()
+    assert "factory_droid_openai_auth_probe_failures_total 0" in metrics.render()
+    assert any(entry["event"] == "auth.probe_ok" for entry in _events(stream))
+
+
+@pytest.mark.asyncio
+async def test_probe_timeout_is_capped_at_sixty_seconds() -> None:
+    runner = _StubRunner()
+    probe = _probe(runner, timeout_seconds=600.0)
+
+    probe.start()
+    await _wait_until(lambda: probe.status == "ok")
+
+    await probe.aclose()
+    assert runner.requests[0].timeout_seconds == 60.0
+
+
+@pytest.mark.asyncio
+async def test_runner_error_counts_as_probe_failure() -> None:
+    stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=stream)
+    metrics = BridgeMetrics()
+    runner = _StubRunner(error=RunnerError("Factory rejected the bridge's API key: revoked"))
+    probe = _probe(runner, metrics=metrics)
+
+    probe.start()
+    await _wait_until(lambda: probe.status == "degraded")
+
+    await probe.aclose()
+    assert probe.consecutive_failures == 1
+    assert probe.failing is False
+    assert "factory_droid_openai_auth_probe_failures_total 1" in metrics.render()
+    failures = [entry for entry in _events(stream) if entry["event"] == "auth.probe_failed"]
+    assert len(failures) == 1
+    assert failures[0]["reason"] == "Factory rejected the bridge's API key: revoked"
+    assert failures[0]["consecutive"] == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_answer_counts_as_probe_failure() -> None:
+    stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=stream)
+    runner = _StubRunner(events=[])
+    probe = _probe(runner)
+
+    probe.start()
+    await _wait_until(lambda: probe.status == "degraded")
+
+    await probe.aclose()
+    failures = [entry for entry in _events(stream) if entry["event"] == "auth.probe_failed"]
+    assert failures[0]["reason"] == "Auth probe completed without any assistant text."
+
+
+@pytest.mark.asyncio
+async def test_hanging_runner_times_out() -> None:
+    runner = _HangingRunner()
+    probe = _probe(runner, timeout_seconds=0.05)
+
+    probe.start()
+    await _wait_until(lambda: probe.status == "degraded")
+
+    await probe.aclose()
+    assert probe.consecutive_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_probe_crash_is_reported_as_failure() -> None:
+    runner = _CrashingRunner()
+    probe = _probe(runner)
+
+    probe.start()
+    await _wait_until(lambda: probe.status == "degraded")
+
+    await probe.aclose()
+    assert probe.consecutive_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_opens_at_the_failure_threshold() -> None:
+    runner = _StubRunner(error=RunnerError("unauthorized"))
+    probe = _probe(runner, failure_threshold=2)
+
+    probe.start()
+    await _wait_until(lambda: len(runner.requests) == 1)
+    probe._consecutive_failures = 1
+    probe.suspect()
+    await _wait_until(lambda: len(runner.requests) == 2)
+
+    assert probe.status == "degraded"
+    assert probe.consecutive_failures == 2
+    assert probe.failing is True
+
+    probe.record_success()
+    assert probe.failing is False
+    assert probe.status == "ok"
+
+    await probe.aclose()
+
+
+@pytest.mark.asyncio
+async def test_suspect_triggers_an_immediate_probe() -> None:
+    runner = _StubRunner(error=RunnerError("unauthorized"))
+    probe = _probe(runner, interval_seconds=60.0)
+
+    probe.start()
+    await _wait_until(lambda: len(runner.requests) == 1)
+
+    runner.error = None
+    probe.suspect()
+    await _wait_until(lambda: len(runner.requests) == 2)
+    await _wait_until(lambda: probe.status == "ok")
+
+    await probe.aclose()
+    assert probe.consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_periodic_interval_reprobes_without_suspect() -> None:
+    runner = _StubRunner()
+    probe = _probe(runner, interval_seconds=0.05)
+
+    probe.start()
+    await _wait_until(lambda: len(runner.requests) >= 2)
+
+    await probe.aclose()
+
+
+@pytest.mark.asyncio
+async def test_zero_interval_disables_the_loop() -> None:
+    runner = _StubRunner()
+    probe = _probe(runner, interval_seconds=0.0)
+
+    probe.start()
+    await asyncio.sleep(0.05)
+
+    assert probe.status == "unknown"
+    assert runner.requests == []
+    await probe.aclose()
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent() -> None:
+    runner = _StubRunner()
+    probe = _probe(runner)
+
+    probe.start()
+    task = probe._task
+    assert task is not None
+    probe.start()
+    assert probe._task is task
+
+    await probe.aclose()
+    assert probe._task is None
+
+
+@pytest.mark.asyncio
+async def test_aclose_before_start_is_a_noop() -> None:
+    runner = _StubRunner()
+    probe = _probe(runner)
+
+    await probe.aclose()
+
+    assert probe.status == "unknown"
+
+
+def test_new_counters_render_at_zero() -> None:
+    text = BridgeMetrics().render()
+
+    assert "factory_droid_openai_empty_completions_total 0" in text
+    assert "factory_droid_openai_auth_probe_successes_total 0" in text
+    assert "factory_droid_openai_auth_probe_failures_total 0" in text

--- a/tests/test_auth_probe.py
+++ b/tests/test_auth_probe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
-import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -11,61 +11,119 @@ import pytest
 from factory_droid_openai import logs
 from factory_droid_openai.auth_probe import AuthProbe
 from factory_droid_openai.metrics import BridgeMetrics
-from factory_droid_openai.runner import RunnerError, RunRequest, TextDelta
+from factory_droid_openai.runner import (
+    ReasoningDelta,
+    RunComplete,
+    RunEvent,
+    RunnerError,
+    RunRequest,
+    SessionStarted,
+    StatusUpdate,
+    TextDelta,
+    Usage,
+    UsageUpdate,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable
 
     from factory_droid_openai.runner import DroidRunner
 
 
-class _StubRunner:
-    """DroidRunner double whose run() only needs to work for one turn."""
+def _recorded_usage(payload: dict[str, Any]) -> Usage:
+    details = payload.get("prompt_tokens_details") or {}
+    return Usage(
+        input_tokens=int(payload.get("prompt_tokens", 0)),
+        output_tokens=int(payload.get("completion_tokens", 0)),
+        cache_read_tokens=int(details.get("cached_tokens", 0)),
+    )
+
+
+def _recorded_event(record: dict[str, Any]) -> RunEvent:
+    kind = record["kind"]
+    if kind == "text_delta":
+        return TextDelta(record["text"])
+    if kind == "reasoning_delta":
+        return ReasoningDelta(record["text"])
+    if kind == "usage":
+        return UsageUpdate(_recorded_usage(record["usage"]))
+    if kind == "run_complete":
+        return RunComplete(_recorded_usage(record["usage"]))
+    if kind == "status":
+        return StatusUpdate(record["state"])
+    if kind == "session_started":
+        return SessionStarted("replay-session")
+    raise AssertionError(f"unknown recorded event kind: {kind}")
+
+
+def _recorded_events() -> list[RunEvent]:
+    path = Path(__file__).parent / "fixtures" / "events" / "hello--gpt-5-4-mini.jsonl"
+    records = [
+        cast("dict[str, Any]", json.loads(line))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    return [_recorded_event(record) for record in records if record["kind"] != "meta"]
+
+
+class _RecordedRunner:
+    """Replays one captured Droid event stream in its original order."""
 
     def __init__(
         self,
         *,
-        events: list[Any] | None = None,
+        events: list[RunEvent] | None = None,
         error: RunnerError | None = None,
     ) -> None:
-        self.events = [TextDelta("ok")] if events is None else events
+        self.events = _recorded_events() if events is None else events
         self.error = error
         self.requests: list[RunRequest] = []
+        self.started: asyncio.Queue[None] = asyncio.Queue()
 
-    async def run(self, request: RunRequest) -> AsyncIterator[Any]:
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
         self.requests.append(request)
+        self.started.put_nowait(None)
         if self.error is not None:
             raise self.error
         for event in self.events:
             yield event
 
 
+class _ControlledRunner(_RecordedRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.release: asyncio.Queue[None] = asyncio.Queue()
+
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
+        self.requests.append(request)
+        self.started.put_nowait(None)
+        await self.release.get()
+        for event in self.events:
+            yield event
+
+
 class _HangingRunner:
-    """Never yields; only an outer timeout can end the probe."""
+    """Never yields; cancellation must end the probe."""
 
     def __init__(self) -> None:
         self.requests: list[RunRequest] = []
+        self.started = asyncio.Event()
 
-    async def run(self, request: RunRequest) -> AsyncIterator[Any]:
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
         self.requests.append(request)
+        self.started.set()
         await asyncio.Event().wait()
         yield TextDelta("never")
 
 
-class _CrashingRunner(_StubRunner):
-    async def run(self, request: RunRequest) -> AsyncIterator[Any]:
+class _CrashingRunner(_RecordedRunner):
+    async def run(self, request: RunRequest) -> AsyncIterator[RunEvent]:
         self.requests.append(request)
-        yield TextDelta("half")
-        raise RuntimeError("kaboom")
-
-
-async def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if predicate():
-            return
-        await asyncio.sleep(0.01)
-    pytest.fail("condition not reached in time")
+        self.started.put_nowait(None)
+        for event in self.events:
+            yield event
+            if isinstance(event, TextDelta):
+                raise RuntimeError("kaboom")
 
 
 def _probe(
@@ -97,13 +155,12 @@ async def test_successful_probe_reports_ok() -> None:
     stream = io.StringIO()
     logs.configure_logging(level="debug", log_format="json", stream=stream)
     metrics = BridgeMetrics()
-    runner = _StubRunner()
+    runner = _RecordedRunner()
     probe = _probe(runner, metrics=metrics)
 
-    probe.start()
-    await _wait_until(lambda: probe.status == "ok")
+    await probe._probe_once()
 
-    await probe.aclose()
+    assert probe.status == "ok"
     assert len(runner.requests) == 1
     request = runner.requests[0]
     assert request.model == "factory-droid"
@@ -115,13 +172,12 @@ async def test_successful_probe_reports_ok() -> None:
 
 @pytest.mark.asyncio
 async def test_probe_timeout_is_capped_at_sixty_seconds() -> None:
-    runner = _StubRunner()
+    runner = _RecordedRunner()
     probe = _probe(runner, timeout_seconds=600.0)
 
-    probe.start()
-    await _wait_until(lambda: probe.status == "ok")
+    await probe._probe_once()
 
-    await probe.aclose()
+    assert probe.status == "ok"
     assert runner.requests[0].timeout_seconds == 60.0
 
 
@@ -130,13 +186,12 @@ async def test_runner_error_counts_as_probe_failure() -> None:
     stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=stream)
     metrics = BridgeMetrics()
-    runner = _StubRunner(error=RunnerError("Factory rejected the bridge's API key: revoked"))
+    runner = _RecordedRunner(error=RunnerError("Factory rejected the bridge's API key: revoked"))
     probe = _probe(runner, metrics=metrics)
 
-    probe.start()
-    await _wait_until(lambda: probe.status == "degraded")
+    await probe._probe_once()
 
-    await probe.aclose()
+    assert probe.status == "degraded"
     assert probe.consecutive_failures == 1
     assert probe.failing is False
     assert "factory_droid_openai_auth_probe_failures_total 1" in metrics.render()
@@ -150,26 +205,39 @@ async def test_runner_error_counts_as_probe_failure() -> None:
 async def test_empty_answer_counts_as_probe_failure() -> None:
     stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=stream)
-    runner = _StubRunner(events=[])
+    runner = _RecordedRunner(
+        events=[event for event in _recorded_events() if not isinstance(event, TextDelta)]
+    )
     probe = _probe(runner)
 
-    probe.start()
-    await _wait_until(lambda: probe.status == "degraded")
+    await probe._probe_once()
 
-    await probe.aclose()
+    assert probe.status == "degraded"
     failures = [entry for entry in _events(stream) if entry["event"] == "auth.probe_failed"]
     assert failures[0]["reason"] == "Auth probe completed without any assistant text."
 
 
 @pytest.mark.asyncio
+async def test_incomplete_answer_counts_as_probe_failure() -> None:
+    runner = _RecordedRunner(
+        events=[event for event in _recorded_events() if not isinstance(event, RunComplete)]
+    )
+    probe = _probe(runner)
+
+    await probe._probe_once()
+
+    assert probe.status == "degraded"
+    assert probe.consecutive_failures == 1
+
+
+@pytest.mark.asyncio
 async def test_hanging_runner_times_out() -> None:
     runner = _HangingRunner()
-    probe = _probe(runner, timeout_seconds=0.05)
+    probe = _probe(runner, timeout_seconds=0.0)
 
-    probe.start()
-    await _wait_until(lambda: probe.status == "degraded")
+    await probe._probe_once()
 
-    await probe.aclose()
+    assert probe.status == "degraded"
     assert probe.consecutive_failures == 1
 
 
@@ -178,23 +246,19 @@ async def test_probe_crash_is_reported_as_failure() -> None:
     runner = _CrashingRunner()
     probe = _probe(runner)
 
-    probe.start()
-    await _wait_until(lambda: probe.status == "degraded")
+    await probe._probe_once()
 
-    await probe.aclose()
+    assert probe.status == "degraded"
     assert probe.consecutive_failures == 1
 
 
 @pytest.mark.asyncio
 async def test_gate_opens_at_the_failure_threshold() -> None:
-    runner = _StubRunner(error=RunnerError("unauthorized"))
+    runner = _RecordedRunner(error=RunnerError("unauthorized"))
     probe = _probe(runner, failure_threshold=2)
 
-    probe.start()
-    await _wait_until(lambda: len(runner.requests) == 1)
-    probe._consecutive_failures = 1
-    probe.suspect()
-    await _wait_until(lambda: len(runner.requests) == 2)
+    await probe._probe_once()
+    await probe._probe_once()
 
     assert probe.status == "degraded"
     assert probe.consecutive_failures == 2
@@ -204,56 +268,64 @@ async def test_gate_opens_at_the_failure_threshold() -> None:
     assert probe.failing is False
     assert probe.status == "ok"
 
-    await probe.aclose()
-
 
 @pytest.mark.asyncio
 async def test_suspect_triggers_an_immediate_probe() -> None:
-    runner = _StubRunner(error=RunnerError("unauthorized"))
-    probe = _probe(runner, interval_seconds=60.0)
+    runner = _ControlledRunner()
+    probe = _probe(runner)
 
     probe.start()
-    await _wait_until(lambda: len(runner.requests) == 1)
-
-    runner.error = None
+    await runner.started.get()
     probe.suspect()
-    await _wait_until(lambda: len(runner.requests) == 2)
-    await _wait_until(lambda: probe.status == "ok")
+    runner.release.put_nowait(None)
+    await runner.started.get()
 
     await probe.aclose()
-    assert probe.consecutive_failures == 0
+    assert len(runner.requests) == 2
 
 
 @pytest.mark.asyncio
-async def test_periodic_interval_reprobes_without_suspect() -> None:
-    runner = _StubRunner()
-    probe = _probe(runner, interval_seconds=0.05)
+async def test_periodic_interval_reprobes_without_suspect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _RecordedRunner()
+    probe = _probe(runner)
 
+    async def expire_wait(awaitable: Awaitable[bool], *, timeout: float) -> bool:
+        del timeout
+        cast("Any", awaitable).close()
+        await asyncio.sleep(0)
+        raise TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", expire_wait)
     probe.start()
-    await _wait_until(lambda: len(runner.requests) >= 2)
+    await runner.started.get()
+    await runner.started.get()
 
     await probe.aclose()
+    assert len(runner.requests) >= 2
 
 
 @pytest.mark.asyncio
 async def test_zero_interval_disables_the_loop() -> None:
-    runner = _StubRunner()
+    runner = _RecordedRunner()
     probe = _probe(runner, interval_seconds=0.0)
 
     probe.start()
-    await asyncio.sleep(0.05)
 
     assert probe.status == "unknown"
     assert runner.requests == []
+    assert probe._task is None
     await probe.aclose()
 
 
 @pytest.mark.asyncio
 async def test_start_is_idempotent() -> None:
-    runner = _StubRunner()
+    runner = _HangingRunner()
     probe = _probe(runner)
 
     probe.start()
+    await runner.started.wait()
     task = probe._task
     assert task is not None
     probe.start()
@@ -265,7 +337,7 @@ async def test_start_is_idempotent() -> None:
 
 @pytest.mark.asyncio
 async def test_aclose_before_start_is_a_noop() -> None:
-    runner = _StubRunner()
+    runner = _RecordedRunner()
     probe = _probe(runner)
 
     await probe.aclose()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,8 @@ _ENVIRONMENT_KEYS = (
     "FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS",
     "FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS",
     "FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS",
+    "FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS",
+    "FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD",
     "FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS",
     "FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS",
     "FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS",
@@ -143,6 +145,19 @@ def test_settings_normalize_reasoning_effort_on_construction() -> None:
 
     with pytest.raises(ValueError, match="reasoning_effort must be one of"):
         Settings(reasoning_effort="extreme")
+
+
+def test_settings_validate_auth_probe_options() -> None:
+    assert Settings().auth_probe_seconds == 0.0
+    assert Settings().auth_failure_threshold == 3
+    assert Settings(auth_probe_seconds=300.0).auth_probe_seconds == 300.0
+
+    with pytest.raises(ValueError, match="auth_probe_seconds must be zero or greater"):
+        Settings(auth_probe_seconds=-1.0)
+    with pytest.raises(ValueError, match="auth_probe_seconds must be zero or greater"):
+        Settings(auth_probe_seconds=float("inf"))
+    with pytest.raises(ValueError, match="auth_failure_threshold must be at least 1"):
+        Settings(auth_failure_threshold=0)
 
 
 @pytest.mark.parametrize(
@@ -338,6 +353,8 @@ def test_settings_from_env_reads_all_overrides(
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "1.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS", "0")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS", "120")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS", "45")
+    monkeypatch.setenv("FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD", "5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS", "3")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_PROCESS_GRACE_SECONDS", "2.5")
     monkeypatch.setenv("FACTORY_DROID_OPENAI_CLEANUP_TIMEOUT_SECONDS", "6.5")
@@ -369,6 +386,8 @@ def test_settings_from_env_reads_all_overrides(
         mcp_settle_seconds=1.5,
         model_cache_seconds=0.0,
         model_quarantine_seconds=120.0,
+        auth_probe_seconds=45.0,
+        auth_failure_threshold=5,
         retry_after_seconds=3,
         process_grace_seconds=2.5,
         cleanup_timeout_seconds=6.5,
@@ -433,6 +452,10 @@ def test_settings_from_env_reads_all_overrides(
         ("FACTORY_DROID_OPENAI_MCP_SETTLE_SECONDS", "-1", "must be zero or greater"),
         ("FACTORY_DROID_OPENAI_MODEL_CACHE_SECONDS", "inf", "must be zero or greater"),
         ("FACTORY_DROID_OPENAI_MODEL_QUARANTINE_SECONDS", "-1", "must be zero or greater"),
+        ("FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS", "-1", "must be zero or greater"),
+        ("FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS", "invalid", "must be a number"),
+        ("FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD", "0", "must be greater than zero"),
+        ("FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD", "invalid", "must be an integer"),
         (
             "FACTORY_DROID_OPENAI_RETRY_AFTER_SECONDS",
             "0",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,6 +7,7 @@ import re
 import sys
 import textwrap
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
@@ -68,7 +69,6 @@ from factory_droid_openai.runner import (
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-    from pathlib import Path
     from typing import Any
 
 
@@ -1743,24 +1743,27 @@ def test_runner_maps_invalid_model_id_as_unavailable() -> None:
     assert "not-a-live-model" in str(error)
 
 
+def _recorded_auth_error_events() -> list[ErrorEvent]:
+    path = Path(__file__).parent / "fixtures" / "runner" / "auth-failures.jsonl"
+    records = [
+        cast("dict[str, str]", json.loads(line))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    return [ErrorEvent(record["message"], record["error_type"]) for record in records]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "message",
-    [
-        "Request failed with status code 401",
-        "Invalid API key",
-        "API key is invalid",
-        "API key has expired",
-        "Expired API key",
-        "403 Forbidden",
-        "Authentication failed",
-    ],
+    "event",
+    _recorded_auth_error_events(),
+    ids=lambda event: event.message,
 )
 async def test_runner_maps_auth_failures_as_auth_errors(
     tmp_path: Path,
-    message: str,
+    event: ErrorEvent,
 ) -> None:
-    client = FakeClient([ErrorEvent(message, "Error")])
+    client = FakeClient([event])
     runner = DroidRunner(
         droid_path="droid",
         workdir=tmp_path,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1748,7 +1748,10 @@ def test_runner_maps_invalid_model_id_as_unavailable() -> None:
     "message",
     [
         "Request failed with status code 401",
+        "Invalid API key",
         "API key is invalid",
+        "API key has expired",
+        "Expired API key",
         "403 Forbidden",
         "Authentication failed",
     ],

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1744,6 +1744,42 @@ def test_runner_maps_invalid_model_id_as_unavailable() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Request failed with status code 401",
+        "API key is invalid",
+        "403 Forbidden",
+        "Authentication failed",
+    ],
+)
+async def test_runner_maps_auth_failures_as_auth_errors(
+    tmp_path: Path,
+    message: str,
+) -> None:
+    client = FakeClient([ErrorEvent(message, "Error")])
+    runner = DroidRunner(
+        droid_path="droid",
+        workdir=tmp_path,
+        client_factory=cast("Any", lambda _path, _cwd: client),
+    )
+
+    with pytest.raises(RunnerError, match="Factory rejected the bridge's API key") as error:
+        _ = [event async for event in runner.run(_request())]
+
+    assert error.value.status_code == 503
+    assert error.value.error_type == "factory_auth_error"
+
+
+def test_sdk_error_classifies_auth_failures() -> None:
+    error = sdk_error(DroidClientError("Unauthorized: API key revoked"))
+
+    assert error.status_code == 503
+    assert error.error_type == "factory_auth_error"
+    assert "API key revoked" in str(error)
+
+
+@pytest.mark.asyncio
 async def test_runner_keeps_other_sdk_failures_as_bridge_errors(tmp_path: Path) -> None:
     class BrokenClient(FakeClient):
         async def initialize_session(self, **kwargs: Any) -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -58,6 +58,8 @@ def test_metrics_snapshot_contains_only_telemetry_dimensions() -> None:
     metrics.increment_warm_misses()
     metrics.increment_warm_retunes("effort")
     metrics.increment_warm_failures()
+    metrics.increment_empty_completions()
+    metrics.increment_auth_probe_failures()
 
     snapshot = metrics.telemetry_snapshot()
 
@@ -73,6 +75,8 @@ def test_metrics_snapshot_contains_only_telemetry_dimensions() -> None:
         ("tools", 2),
     )
     assert snapshot.internal == (
+        ("auth_probe_failure", 1),
+        ("empty_completion", 1),
         ("forced_kill", 1),
         ("model_discovery_failure", 1),
         ("model_quarantine", 1),


### PR DESCRIPTION
## Summary

Fixes #122, fixes #125.

The v1.9.1 outage was a dead Factory key, not a bridge bug, but diagnosing it took a cross-matrix because the bridge surfaced it as three unrelated error shapes plus silent empty 200s. This PR makes every shape observable and adds an opt-in probe that catches the next one fast:

- `chat.failed` now logs `reason` in both streaming and non-streaming modes. The gemini "switch to a different model" text was the only real signal and it was invisible at info level.
- Empty completions (200, `content: null`) emit `chat.empty_completion` and increment `factory_droid_openai_empty_completions_total`. The dead key answered gpt/deepseek/minimax/glm requests this way and nothing recorded it.
- New `auth_probe.py`: with `FACTORY_DROID_OPENAI_AUTH_PROBE_SECONDS` set, one minimal Droid exec checks the key per interval. A failing probe logs `auth.probe_failed`, flips the new `auth` field on `/health` to `degraded`, and after `FACTORY_DROID_OPENAI_AUTH_FAILURE_THRESHOLD` consecutive failures chat requests fail fast with `503 factory_auth_error` instead of each paying ~30s for a doomed spawn. Any request that completes with content clears the gate, and empty or auth-shaped outcomes ask for an immediate probe. The probe is exec-based on purpose: catalog discovery stayed healthy during the outage while key-authenticated exec failed.
- Droid errors worded like key rejections (401/403/unauthorized/revoked api key) classify as `factory_auth_error` 503 instead of generic `factory_droid_error`.
- Non-streaming client disconnects now emit `chat.cancelled` the way the streaming path already did. Fixes the census gap where timed-out Hindsight retries read as requests that never arrived.

The probe is off by default: every probe run is a real model turn that costs tokens, and the gate changes request behavior. Opt in via the README configuration table.

`openapi.json` also picked up pre-existing cosmetic response-entry reordering (reproducible on clean main, the contract test compares order-insensitively); the only semantic change is the additive `auth` field on `HealthResponse`.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` (1868 passed, 100% coverage)
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in `tests/fixtures/events/`, or the reason it cannot be is stated above. — no live-model behavior discovered here; all new paths are bridge-side and covered by unit and ASGI tests with fake runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added periodic Factory key authentication checks.
  - Requests now return `503 factory_auth_error` when authentication is failing.
  - Health status reports authentication as `ok`, `degraded`, or `unknown`.
  - Added configuration options for probe frequency and failure thresholds.
  - Added metrics for authentication probes and empty responses.

- **Bug Fixes**
  - Authentication-related failures are classified consistently.
  - Improved handling and logging for client disconnects and empty completions.

- **Documentation**
  - Added configuration, logging, and troubleshooting guidance for authentication probe failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->