### PR TITLE
feat(api): enforce max_tokens and stop capped turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ factory-droid-openai
 | Sampling controls | ❌ | `temperature`, `top_p`, penalties, and `seed` are ignored |
 | Multiple choices | ✅ | `n` runs that many Droid turns sequentially and returns `n` choices |
 | Log probabilities | ❌ | `logprobs` and `top_logprobs` are ignored |
-| Output token limits | ✅ | `max_tokens` and `max_completion_tokens` stop the turn at the limit; the completion ends with `finish_reason="length"` |
+| Output token limits | ✅ | `max_tokens` and `max_completion_tokens` stop the turn at the limit; incomplete output ends with `finish_reason="length"` |
 | Stored completions | ❌ | `store`, `metadata`, listing, retrieval, and deletion are unavailable |
 | Prompt cache controls | ❌ | OpenAI cache keys and retention settings are ignored |
 | Built-in web search | ❌ | `web_search_options` is ignored |
@@ -304,13 +304,15 @@ are not retried because response bytes may already have reached the client.
 `max_tokens` and `max_completion_tokens` stop the Droid turn once the limit is
 reached, and the completion ends with `finish_reason="length"` whether the cap
 fell on text or inside a tool-call argument; a partial call is dropped, never
-executed. The cap watches the output tokens Droid reports for the turn, so a
-pooled or continued session cannot fire it on its earlier turns. Models that
-report no usage mid-turn get a coarse text-length fallback of roughly four
-characters per token instead of running free. A capped completion is never
-retried server-side: the limit ended the turn, so a second attempt would
-regenerate the same capped output, and the client can retry or split the
-request itself.
+executed. A complete call emitted before the cap keeps
+`finish_reason="tool_calls"` so the client can run it. The cap compares Droid's
+session-cumulative output tokens with the counter captured before the turn, so
+a pooled or continued session cannot fire it on earlier output. Once Droid
+reports usage, its counter is authoritative. Until then, a coarse text-length
+fallback of roughly four characters per token prevents unbounded output. A
+capped completion is never retried server-side: the limit ended the turn, so a
+second attempt would regenerate the same capped output, and the client can
+retry or split the request itself.
 Non-final truncations log as `chat.attempt_truncated`. Its `will_retry` field
 distinguishes an actual retry from a dropped trailing partial call after a
 valid call, and `has_tool_calls` makes clear why that partial call cannot be
@@ -1099,7 +1101,7 @@ tool calls through the official `openai` Python client.
 | `factory_droid_reasoning_effort` | Yes | Bridge-specific override, wins over `reasoning_effort` |
 | `timeout` | Yes | Per-request value capped by server timeout |
 | `temperature`, `top_p`, penalties, `seed` | No | Accepted but ignored |
-| `max_tokens`, `max_completion_tokens` | Yes | Stop the Droid turn once the limit is reached; `max_completion_tokens` wins when both are set |
+| `max_tokens`, `max_completion_tokens` | Yes | Stop incomplete output at the limit; a completed call still returns `tool_calls`; `max_completion_tokens` wins when both are set |
 | `response_format` | Yes | `json_schema` and `json_object`; validated again before completion |
 | `functions`, `function_call` | No | Legacy function-calling fields are ignored |
 | `modalities`, `audio` | No | Accepted but ignored |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ factory-droid-openai
 | Sampling controls | ❌ | `temperature`, `top_p`, penalties, and `seed` are ignored |
 | Multiple choices | ✅ | `n` runs that many Droid turns sequentially and returns `n` choices |
 | Log probabilities | ❌ | `logprobs` and `top_logprobs` are ignored |
-| Output token limits | ❌ | `max_tokens` and `max_completion_tokens` are ignored |
+| Output token limits | ✅ | `max_tokens` and `max_completion_tokens` stop the turn at the limit; the completion ends with `finish_reason="length"` |
 | Stored completions | ❌ | `store`, `metadata`, listing, retrieval, and deletion are unavailable |
 | Prompt cache controls | ❌ | OpenAI cache keys and retention settings are ignored |
 | Built-in web search | ❌ | `web_search_options` is ignored |
@@ -301,6 +301,16 @@ do not resend the prompt or attachments. Every retry keeps the original request
 deadline. A repeated malformed call still returns the notice, while a repeated
 truncated call returns `finish_reason="length"` without it. Streaming requests
 are not retried because response bytes may already have reached the client.
+`max_tokens` and `max_completion_tokens` stop the Droid turn once the limit is
+reached, and the completion ends with `finish_reason="length"` whether the cap
+fell on text or inside a tool-call argument; a partial call is dropped, never
+executed. The cap watches the output tokens Droid reports for the turn, so a
+pooled or continued session cannot fire it on its earlier turns. Models that
+report no usage mid-turn get a coarse text-length fallback of roughly four
+characters per token instead of running free. A capped completion is never
+retried server-side: the limit ended the turn, so a second attempt would
+regenerate the same capped output, and the client can retry or split the
+request itself.
 Non-final truncations log as `chat.attempt_truncated`. Its `will_retry` field
 distinguishes an actual retry from a dropped trailing partial call after a
 valid call, and `has_tool_calls` makes clear why that partial call cannot be
@@ -995,8 +1005,8 @@ What VS Code BYOK does not cover, regardless of the bridge:
 - Any feature that requires a Copilot plan or GitHub sign-in
 
 What the bridge accepts but ignores when VS Code sends it:
-`temperature`, `top_p`, `seed`, `max_tokens`, `max_completion_tokens`,
-`logprobs`, and `top_logprobs`. These are documented in the
+`temperature`, `top_p`, `seed`, `logprobs`, and `top_logprobs`. These are
+documented in the
 [API compatibility](#api-compatibility) table. Remote `http(s)` image URLs are
 rejected with `400`; send vision inputs as base64 `data:` URIs instead.
 VSCode does not auto-discover models from a Custom Endpoint, so every Droid
@@ -1089,7 +1099,7 @@ tool calls through the official `openai` Python client.
 | `factory_droid_reasoning_effort` | Yes | Bridge-specific override, wins over `reasoning_effort` |
 | `timeout` | Yes | Per-request value capped by server timeout |
 | `temperature`, `top_p`, penalties, `seed` | No | Accepted but ignored |
-| `max_tokens`, `max_completion_tokens` | No | Accepted but ignored; Droid owns the output budget |
+| `max_tokens`, `max_completion_tokens` | Yes | Stop the Droid turn once the limit is reached; `max_completion_tokens` wins when both are set |
 | `response_format` | Yes | `json_schema` and `json_object`; validated again before completion |
 | `functions`, `function_call` | No | Legacy function-calling fields are ignored |
 | `modalities`, `audio` | No | Accepted but ignored |

--- a/scripts/e2e_matrix.py
+++ b/scripts/e2e_matrix.py
@@ -176,11 +176,13 @@ def _baseline_scenarios() -> list[Scenario]:
             },
         ),
         Scenario(
-            name="ignored_token_limit",
+            name="output_token_limit",
             body={
                 "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
                 "max_tokens": 5,
             },
+            expect_finish=("stop", "length"),
+            expect_content=False,
         ),
     ]
 

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -1813,7 +1813,11 @@ def create_app(
                                 result,
                                 tools_available=bool(plan.allowed_tool_names),
                             )
-                            if retry_reason is None and structured is not None:
+                            if (
+                                retry_reason is None
+                                and structured is not None
+                                and not result.output_capped
+                            ):
                                 try:
                                     _validate_structured_output(result.text, structured)
                                 except ProtocolError as exc:
@@ -1903,6 +1907,7 @@ def create_app(
                         choice_message["content"] is None
                         and not choice_message.get("tool_calls")
                         and not completed_result.stopped
+                        and not completed_result.output_capped
                     ):
                         # A dead Factory key answers with empty 200s before it
                         # answers with errors (issue #122), so an empty body
@@ -2023,17 +2028,21 @@ class _TruncatedToolCall:
 class OutputTokenCap:
     """Turn-local max_tokens enforcement built from Droid usage snapshots.
 
-    Droid reports session-cumulative counters, so the first snapshot of a
-    turn sets the baseline and the cap watches the delta; a pooled or retuned
-    session cannot fire the cap on tokens its earlier turns produced. Models
-    that report no usage mid-turn get a coarse text-length fallback instead
-    of running free (issue #130).
+    Droid reports session-cumulative counters, so SessionStarted carries the
+    pre-turn baseline and the cap watches the delta; a continued session
+    cannot fire the cap on tokens its earlier turns produced. Models that
+    report no usage mid-turn get a coarse text-length fallback instead of
+    running free (issue #130).
     """
 
     def __init__(self, limit: int | None) -> None:
         self._limit = limit
         self._baseline: int | None = None
         self._emitted_chars = 0
+        self._usage_seen = False
+
+    def start_turn(self, output_tokens: int | None) -> None:
+        self._baseline = output_tokens
 
     def record_usage(self, usage: Usage) -> bool:
         """Returns True when reported output tokens reached the limit."""
@@ -2041,11 +2050,13 @@ class OutputTokenCap:
             return False
         if self._baseline is None:
             self._baseline = usage.output_tokens
+            return False
+        self._usage_seen = True
         return usage.output_tokens - self._baseline >= self._limit
 
     def record_text(self, text: str) -> bool:
         """Returns True when emitted text plausibly reached the limit."""
-        if self._limit is None:
+        if self._limit is None or self._usage_seen:
             return False
         self._emitted_chars += len(text)
         return self._emitted_chars >= self._limit * _CHARS_PER_TOKEN_ESTIMATE
@@ -2219,8 +2230,8 @@ def _event_record(event: RunEvent) -> dict[str, Any]:
     if isinstance(event, StatusUpdate):
         return {"kind": "status", "state": event.state}
     # The session id identifies a Factory account session and replay never
-    # needs it, so SessionStarted is recorded without its payload.
-    return {"kind": "session_started"}
+    # needs it, but the pre-turn counter is required to reproduce cap behavior.
+    return {"kind": "session_started", "output_tokens": event.output_tokens}
 
 
 async def _run_events(
@@ -2363,6 +2374,7 @@ async def _collect_completion(
                     break
             elif isinstance(event, SessionStarted):
                 result.session_id = event.session_id
+                token_cap.start_turn(event.output_tokens)
                 if session_callback is not None:
                     session_callback(event.session_id)
             elif isinstance(event, UsageUpdate):
@@ -2393,6 +2405,8 @@ async def _collect_completion(
             # A failed parse already settled the turn; asking the parser to
             # finish would re-raise on the same garbage.
             try:
+                if result.output_capped:
+                    parser.discard_partial_call()
                 _apply_emissions(result, parser.finish(), stop_buffer)
             except MalformedToolCallError as exc:
                 record_malformed(exc)
@@ -2512,6 +2526,7 @@ async def _stream_completion(
     capped = False
     saw_tool_call = False
     saw_text = False
+    saw_output = False
     observed_ttft = False
     outcome = "success"
     stop_buffer = StopSequenceBuffer(stop_sequences)
@@ -2581,6 +2596,7 @@ async def _stream_completion(
                                 chunk_payload = text_chunk(text)
                                 if chunk_payload is not None:
                                     saw_text = True
+                                    saw_output = True
                                     yield chunk_payload
                         if stop_buffer.triggered:
                             # Closing the runner generator interrupts the Droid
@@ -2595,6 +2611,7 @@ async def _stream_completion(
                             completed = True
                             break
                     elif isinstance(event, SessionStarted):
+                        token_cap.start_turn(event.output_tokens)
                         if session_callback is not None:
                             session_callback(event.session_id)
                         if expose_session:
@@ -2636,6 +2653,7 @@ async def _stream_completion(
                                 include_usage=include_usage,
                             )
                         )
+                        saw_output = saw_output or bool(event.text)
                         if token_cap.record_text(event.text):
                             capped = True
                             completed = True
@@ -2667,6 +2685,8 @@ async def _stream_completion(
                 )
             if not stop_buffer.triggered:
                 try:
+                    if capped:
+                        parser.discard_partial_call()
                     for emission in parser.finish():
                         if isinstance(emission, ToolCallEmission):
                             saw_tool_call = True
@@ -2687,6 +2707,7 @@ async def _stream_completion(
                             chunk_payload = text_chunk(text)
                             if chunk_payload is not None:
                                 saw_text = True
+                                saw_output = True
                                 yield chunk_payload
                 except ProtocolError:
                     # A capped turn already ends with finish_reason="length";
@@ -2700,10 +2721,12 @@ async def _stream_completion(
                     chunk_payload = text_chunk(held)
                     if chunk_payload is not None:
                         saw_text = True
+                        saw_output = True
                         yield chunk_payload
             if structured is not None and structured_buffer is not None:
                 structured_text = structured_buffer.text()
-                _validate_structured_output(structured_text, structured)
+                if not capped:
+                    _validate_structured_output(structured_text, structured)
                 yield _sse(
                     _chunk_for_emission(
                         request_id,
@@ -2713,6 +2736,7 @@ async def _stream_completion(
                         include_usage=include_usage,
                     )
                 )
+                saw_output = saw_output or bool(structured_text)
             if capped:
                 if not saw_tool_call:
                     outcome = "truncated"
@@ -2857,13 +2881,16 @@ async def _stream_completion(
             raise
         if outcome_callback is not None:
             outcome_callback(outcome)
-        if outcome == "success" and completion_callback is not None:
-            completion_callback(
-                not saw_text
-                and not saw_tool_call
-                and structured is None
-                and not stop_buffer.triggered
-            )
+        if completion_callback is not None:
+            if outcome == "success":
+                completion_callback(
+                    not saw_text
+                    and not saw_tool_call
+                    and structured is None
+                    and not stop_buffer.triggered
+                )
+            elif capped and saw_output:
+                completion_callback(False)
         _log_stream_outcome(outcome, model=model, usage=usage, tool_calls=tool_call_index)
         yield "data: [DONE]\n\n"
 

--- a/src/factory_droid_openai/app.py
+++ b/src/factory_droid_openai/app.py
@@ -147,6 +147,11 @@ _MODEL_OUTPUT_RETRY_PROMPTS: dict[ModelOutputRetryReason, str] = {
     ),
 }
 _TOOL_WITHOUT_CATALOG_ERROR = "the model requested a tool when none are available"
+# The bridge ships no tokenizer, so the text-length fallback in OutputTokenCap
+# counts roughly 4 characters per output token; Droid's own usage snapshots
+# stay authoritative whenever they arrive mid-turn.
+_CHARS_PER_TOKEN_ESTIMATE = 4
+_OUTPUT_LIMIT_TRUNCATION = "output token limit reached"
 
 CHAT_COMPLETION_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
@@ -1633,6 +1638,14 @@ def create_app(
                 record_repair=record_repair,
             )
 
+        # max_completion_tokens wins when both are set, matching the OpenAI
+        # field that supersedes the deprecated max_tokens.
+        output_token_limit = (
+            payload.max_completion_tokens
+            if payload.max_completion_tokens is not None
+            else payload.max_tokens
+        )
+
         if payload.stream:
             request.state.stream_outcome = "pending"
             started_stream_session: str | None = None
@@ -1687,6 +1700,7 @@ def create_app(
                 failure_callback=note_stream_failure,
                 drain_seconds=resolved_settings.tool_call_drain_seconds,
                 trace_event=payload_tracer.trace,
+                output_token_limit=output_token_limit,
             )
             return FinalizingStreamingResponse(
                 event_stream,
@@ -1753,6 +1767,7 @@ def create_app(
                                 observe_ttft=attempt == 0,
                                 trace_attempt=attempt,
                                 trace_choice=index,
+                                output_token_limit=output_token_limit,
                             )
                         except ProtocolError as exc:
                             if attempt == 0 and str(exc) == _TOOL_WITHOUT_CATALOG_ERROR:
@@ -1996,8 +2011,44 @@ class _TruncatedToolCall:
     payload_bytes: int
 
     @classmethod
-    def from_error(cls, exc: IncompleteToolCallError) -> _TruncatedToolCall:
-        return cls(str(exc), exc.tool_name, exc.payload_bytes)
+    def from_error(
+        cls,
+        exc: IncompleteToolCallError,
+        *,
+        reason: str | None = None,
+    ) -> _TruncatedToolCall:
+        return cls(reason if reason is not None else str(exc), exc.tool_name, exc.payload_bytes)
+
+
+class OutputTokenCap:
+    """Turn-local max_tokens enforcement built from Droid usage snapshots.
+
+    Droid reports session-cumulative counters, so the first snapshot of a
+    turn sets the baseline and the cap watches the delta; a pooled or retuned
+    session cannot fire the cap on tokens its earlier turns produced. Models
+    that report no usage mid-turn get a coarse text-length fallback instead
+    of running free (issue #130).
+    """
+
+    def __init__(self, limit: int | None) -> None:
+        self._limit = limit
+        self._baseline: int | None = None
+        self._emitted_chars = 0
+
+    def record_usage(self, usage: Usage) -> bool:
+        """Returns True when reported output tokens reached the limit."""
+        if self._limit is None:
+            return False
+        if self._baseline is None:
+            self._baseline = usage.output_tokens
+        return usage.output_tokens - self._baseline >= self._limit
+
+    def record_text(self, text: str) -> bool:
+        """Returns True when emitted text plausibly reached the limit."""
+        if self._limit is None:
+            return False
+        self._emitted_chars += len(text)
+        return self._emitted_chars >= self._limit * _CHARS_PER_TOKEN_ESTIMATE
 
 
 class CollectedCompletion:
@@ -2012,6 +2063,7 @@ class CollectedCompletion:
         self.truncation: _TruncatedToolCall | None = None
         self.warm_age_ms: float | None = None
         self.malformed_note: str | None = None
+        self.output_capped = False
 
     @property
     def text(self) -> str:
@@ -2032,6 +2084,10 @@ def _completion_retry_reason(
     tools_available: bool,
 ) -> ModelOutputRetryReason | None:
     if result.tool_calls:
+        return None
+    if result.output_capped:
+        # The requested limit, not model misbehavior, ended the turn, so a
+        # retry would regenerate the same capped output (issue #130).
         return None
     if result.malformed_note is not None:
         return "malformed_tool_call" if tools_available else "tool_without_catalog"
@@ -2233,10 +2289,12 @@ async def _collect_completion(
     observe_ttft: bool = True,
     trace_attempt: int = 0,
     trace_choice: int = 0,
+    output_token_limit: int | None = None,
 ) -> CollectedCompletion:
     result = CollectedCompletion()
     result.warm_age_ms = _warm_session_age_ms(run_request)
     stop_buffer = StopSequenceBuffer(stop_sequences)
+    token_cap = OutputTokenCap(output_token_limit)
     observed_ttft = not observe_ttft
 
     def record_malformed(exc: MalformedToolCallError) -> None:
@@ -2285,6 +2343,13 @@ async def _collect_completion(
                     result.stopped = True
                     result.completed = True
                     break
+                if token_cap.record_text(event.text):
+                    # Same interruption as a stop sequence: reading past the
+                    # requested output limit only burns tokens nobody asked
+                    # for (issue #130).
+                    result.output_capped = True
+                    result.completed = True
+                    break
             elif isinstance(event, ReasoningDelta):
                 observed_ttft = _observe_ttft(
                     observed_ttft,
@@ -2292,14 +2357,26 @@ async def _collect_completion(
                     request_started_at,
                 )
                 result.reasoning_parts.append(event.text)
+                if token_cap.record_text(event.text):
+                    result.output_capped = True
+                    result.completed = True
+                    break
             elif isinstance(event, SessionStarted):
                 result.session_id = event.session_id
                 if session_callback is not None:
                     session_callback(event.session_id)
             elif isinstance(event, UsageUpdate):
                 result.usage = event.usage
+                if token_cap.record_usage(event.usage):
+                    result.output_capped = True
+                    result.completed = True
+                    break
             elif isinstance(event, RunComplete):
                 result.usage = event.usage
+                if token_cap.record_usage(event.usage):
+                    # The turn ended on its own past the limit; the completion
+                    # still reports length so the client can see the cap hit.
+                    result.output_capped = True
                 result.completed = True
                 break
     if result.tool_calls:
@@ -2324,7 +2401,23 @@ async def _collect_completion(
                 # a tool-call payload returns completed output with
                 # finish_reason="length" instead of a 502. The partial call is
                 # dropped, never executed.
-                result.truncation = _TruncatedToolCall.from_error(exc)
+                result.truncation = _TruncatedToolCall.from_error(
+                    exc,
+                    reason=_OUTPUT_LIMIT_TRUNCATION if result.output_capped else None,
+                )
+            except ProtocolError:
+                # A capped turn already ends with finish_reason="length"; a
+                # required-call or trailing-prose complaint would turn a
+                # limit-cut completion into a 502 even though the limit, not
+                # the model, ended it.
+                if not result.output_capped:
+                    raise
+            if result.output_capped and result.truncation is None:
+                result.truncation = _TruncatedToolCall(
+                    reason=_OUTPUT_LIMIT_TRUNCATION,
+                    tool_name=None,
+                    payload_bytes=0,
+                )
         held = stop_buffer.flush()
         if held:
             result.text_parts.append(held)
@@ -2346,6 +2439,7 @@ async def _collect_completion_or_disconnect(
     observe_ttft: bool = True,
     trace_attempt: int = 0,
     trace_choice: int = 0,
+    output_token_limit: int | None = None,
 ) -> CollectedCompletion | None:
     completion_task = asyncio.create_task(
         _collect_completion(
@@ -2361,6 +2455,7 @@ async def _collect_completion_or_disconnect(
             observe_ttft=observe_ttft,
             trace_attempt=trace_attempt,
             trace_choice=trace_choice,
+            output_token_limit=output_token_limit,
         )
     )
     disconnect_task = asyncio.create_task(_wait_for_disconnect(request))
@@ -2409,15 +2504,18 @@ async def _stream_completion(
     failure_callback: Callable[[str, RunnerError], None] | None = None,
     drain_seconds: float = DEFAULT_TOOL_CALL_DRAIN_SECONDS,
     trace_event: Callable[..., None] | None = None,
+    output_token_limit: int | None = None,
 ) -> AsyncIterator[str]:
     usage = Usage()
     warm_age_ms = _warm_session_age_ms(run_request)
     completed = False
+    capped = False
     saw_tool_call = False
     saw_text = False
     observed_ttft = False
     outcome = "success"
     stop_buffer = StopSequenceBuffer(stop_sequences)
+    token_cap = OutputTokenCap(output_token_limit)
     tool_call_index = 0
     structured_buffer = (
         StructuredOutputBuffer(structured.max_bytes) if structured is not None else None
@@ -2489,6 +2587,13 @@ async def _stream_completion(
                             # turn instead of draining output nobody will read.
                             completed = True
                             break
+                        if token_cap.record_text(event.text):
+                            # Same interruption as a stop sequence: reading
+                            # past the requested output limit only burns
+                            # tokens nobody asked for (issue #130).
+                            capped = True
+                            completed = True
+                            break
                     elif isinstance(event, SessionStarted):
                         if session_callback is not None:
                             session_callback(event.session_id)
@@ -2531,10 +2636,23 @@ async def _stream_completion(
                                 include_usage=include_usage,
                             )
                         )
+                        if token_cap.record_text(event.text):
+                            capped = True
+                            completed = True
+                            break
                     elif isinstance(event, UsageUpdate):
                         usage = event.usage
+                        if token_cap.record_usage(event.usage):
+                            capped = True
+                            completed = True
+                            break
                     elif isinstance(event, RunComplete):
                         usage = event.usage
+                        if token_cap.record_usage(event.usage):
+                            # The turn ended on its own past the limit; the
+                            # stream still finishes with length so the client
+                            # can see the cap hit.
+                            capped = True
                         completed = True
                         break
 
@@ -2548,27 +2666,35 @@ async def _stream_completion(
                     error_type="factory_incomplete_response",
                 )
             if not stop_buffer.triggered:
-                for emission in parser.finish():
-                    if isinstance(emission, ToolCallEmission):
-                        saw_tool_call = True
-                        yield _sse(
-                            _chunk_for_emission(
-                                request_id,
-                                created,
-                                model,
-                                emission,
-                                include_usage=include_usage,
-                                tool_call_index=tool_call_index,
+                try:
+                    for emission in parser.finish():
+                        if isinstance(emission, ToolCallEmission):
+                            saw_tool_call = True
+                            yield _sse(
+                                _chunk_for_emission(
+                                    request_id,
+                                    created,
+                                    model,
+                                    emission,
+                                    include_usage=include_usage,
+                                    tool_call_index=tool_call_index,
+                                )
                             )
-                        )
-                        tool_call_index += 1
-                        continue
-                    text = stop_buffer.feed(emission.text)
-                    if text:
-                        chunk_payload = text_chunk(text)
-                        if chunk_payload is not None:
-                            saw_text = True
-                            yield chunk_payload
+                            tool_call_index += 1
+                            continue
+                        text = stop_buffer.feed(emission.text)
+                        if text:
+                            chunk_payload = text_chunk(text)
+                            if chunk_payload is not None:
+                                saw_text = True
+                                yield chunk_payload
+                except ProtocolError:
+                    # A capped turn already ends with finish_reason="length";
+                    # a required-call complaint would turn a limit-cut stream
+                    # into an error event. An uncapped turn keeps its existing
+                    # truncation or error handling.
+                    if not capped:
+                        raise
                 held = stop_buffer.flush()
                 if held:
                     chunk_payload = text_chunk(held)
@@ -2587,13 +2713,33 @@ async def _stream_completion(
                         include_usage=include_usage,
                     )
                 )
+            if capped:
+                if not saw_tool_call:
+                    outcome = "truncated"
+                _log_truncated_tool_call(
+                    _TruncatedToolCall(
+                        reason=_OUTPUT_LIMIT_TRUNCATION,
+                        tool_name=None,
+                        payload_bytes=0,
+                    ),
+                    stream=True,
+                    run_request=run_request,
+                    usage=usage,
+                    attempt=0,
+                    choice=0,
+                    warm_age_ms=warm_age_ms,
+                    will_retry=False,
+                    has_tool_calls=saw_tool_call,
+                )
             yield _sse(
                 _chunk(
                     request_id,
                     created,
                     model,
                     delta={},
-                    finish_reason="tool_calls" if saw_tool_call else "stop",
+                    finish_reason=(
+                        "tool_calls" if saw_tool_call else "length" if capped else "stop"
+                    ),
                     include_usage=include_usage,
                 )
             )

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -475,6 +475,13 @@ class ToolCallStreamParser:
             raise ProtocolError("the model did not produce the required tool call")
         return emissions
 
+    def discard_partial_call(self) -> None:
+        """Drop a call whose framing was incomplete when the turn was stopped."""
+        if self._capturing:
+            self._reset_tool_payload()
+        if self._capturing_message_json:
+            self._reset_message_json()
+
     def _consume_text(
         self,
         chunk: str,

--- a/src/factory_droid_openai/protocol.py
+++ b/src/factory_droid_openai/protocol.py
@@ -477,6 +477,7 @@ class ToolCallStreamParser:
 
     def discard_partial_call(self) -> None:
         """Drop a call whose framing was incomplete when the turn was stopped."""
+        self._pending_transcript_error = None
         if self._capturing:
             self._reset_tool_payload()
         if self._capturing_message_json:

--- a/src/factory_droid_openai/runner.py
+++ b/src/factory_droid_openai/runner.py
@@ -283,6 +283,7 @@ class RunComplete:
 @dataclass(frozen=True, slots=True)
 class SessionStarted:
     session_id: str
+    output_tokens: int | None = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -573,13 +574,14 @@ class DroidRunner:
         native_tool_calls = 0
         unmapped_event_kind: str | None = None
         usage = Usage()
+        output_token_baseline: int | None = 0
 
         try:
             async with asyncio.timeout_at(deadline) as request_timeout:
                 if warm is None:
 
                     async def initialize() -> None:
-                        nonlocal initialized
+                        nonlocal initialized, output_token_baseline
                         startup_started = time.perf_counter()
                         try:
                             await client.connect()
@@ -601,9 +603,13 @@ class DroidRunner:
                         if request.session_id is not None:
                             # Continuation: reuse the stored Droid session so only
                             # the new turn is sent instead of the full transcript.
-                            await client.load_session(
+                            loaded = await client.load_session(
                                 session_id=request.session_id,
                                 mcp_servers=mcp_servers,
+                            )
+                            loaded_usage = getattr(loaded, "token_usage", None)
+                            output_token_baseline = (
+                                None if loaded_usage is None else max(0, loaded_usage.output_tokens)
                             )
                         else:
                             await client.initialize_session(
@@ -652,7 +658,7 @@ class DroidRunner:
                     ),
                 )
                 if client.session_id is not None:
-                    yield SessionStarted(client.session_id)
+                    yield SessionStarted(client.session_id, output_token_baseline)
                 if request.output_format is None:
                     await client.add_user_message(
                         text=request.prompt,

--- a/tests/fixtures/events/output-token-limit--claude-haiku-4-5-20251001-stream.jsonl
+++ b/tests/fixtures/events/output-token-limit--claude-haiku-4-5-20251001-stream.jsonl
@@ -1,7 +1,8 @@
-{"kind": "meta", "scenario": "ignored_token_limit", "stream": true, "recorded_model": "kimi-k3", "expect_verdict": "pass"}
+{"kind": "meta", "scenario": "output_token_limit", "stream": true, "recorded_model": "claude-haiku-4-5-20251001", "expect_verdict": "pass"}
 {"kind": "session_started"}
 {"kind": "status", "state": "streaming_assistant_message"}
 {"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}
 {"kind": "text_delta", "text": "OK"}
+{"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}
 {"kind": "status", "state": "idle"}
 {"kind": "run_complete", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/output-token-limit--claude-haiku-4-5-20251001.jsonl
+++ b/tests/fixtures/events/output-token-limit--claude-haiku-4-5-20251001.jsonl
@@ -1,4 +1,4 @@
-{"kind": "meta", "scenario": "ignored_token_limit", "stream": false, "recorded_model": "claude-haiku-4-5-20251001", "expect_verdict": "pass"}
+{"kind": "meta", "scenario": "output_token_limit", "stream": false, "recorded_model": "claude-haiku-4-5-20251001", "expect_verdict": "pass"}
 {"kind": "session_started"}
 {"kind": "status", "state": "streaming_assistant_message"}
 {"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 10, "total_tokens": 470, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/output-token-limit--gpt-5-4-mini-stream.jsonl
+++ b/tests/fixtures/events/output-token-limit--gpt-5-4-mini-stream.jsonl
@@ -1,8 +1,7 @@
-{"kind": "meta", "scenario": "ignored_token_limit", "stream": true, "recorded_model": "claude-haiku-4-5-20251001", "expect_verdict": "pass"}
+{"kind": "meta", "scenario": "output_token_limit", "stream": true, "recorded_model": "gpt-5.4-mini", "expect_verdict": "pass"}
 {"kind": "session_started"}
 {"kind": "status", "state": "streaming_assistant_message"}
 {"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}
 {"kind": "text_delta", "text": "OK"}
-{"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}
 {"kind": "status", "state": "idle"}
 {"kind": "run_complete", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/output-token-limit--gpt-5-4-mini.jsonl
+++ b/tests/fixtures/events/output-token-limit--gpt-5-4-mini.jsonl
@@ -1,4 +1,4 @@
-{"kind": "meta", "scenario": "ignored_token_limit", "stream": false, "recorded_model": "gpt-5.4-mini", "expect_verdict": "pass"}
+{"kind": "meta", "scenario": "output_token_limit", "stream": false, "recorded_model": "gpt-5.4-mini", "expect_verdict": "pass"}
 {"kind": "session_started"}
 {"kind": "status", "state": "streaming_assistant_message"}
 {"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 4, "total_tokens": 464, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/output-token-limit--kimi-k3-stream.jsonl
+++ b/tests/fixtures/events/output-token-limit--kimi-k3-stream.jsonl
@@ -1,4 +1,4 @@
-{"kind": "meta", "scenario": "ignored_token_limit", "stream": true, "recorded_model": "gpt-5.4-mini", "expect_verdict": "pass"}
+{"kind": "meta", "scenario": "output_token_limit", "stream": true, "recorded_model": "kimi-k3", "expect_verdict": "pass"}
 {"kind": "session_started"}
 {"kind": "status", "state": "streaming_assistant_message"}
 {"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 11, "total_tokens": 471, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/fixtures/events/output-token-limit--kimi-k3.jsonl
+++ b/tests/fixtures/events/output-token-limit--kimi-k3.jsonl
@@ -1,4 +1,4 @@
-{"kind": "meta", "scenario": "ignored_token_limit", "stream": false, "recorded_model": "kimi-k3", "expect_verdict": "pass"}
+{"kind": "meta", "scenario": "output_token_limit", "stream": false, "recorded_model": "kimi-k3", "expect_verdict": "pass"}
 {"kind": "session_started"}
 {"kind": "status", "state": "streaming_assistant_message"}
 {"kind": "usage", "usage": {"prompt_tokens": 460, "completion_tokens": 10, "total_tokens": 470, "prompt_tokens_details": {"cached_tokens": 0}}}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,7 +105,11 @@ def _recorded_event(record: dict[str, Any]) -> RunEvent:
     if kind == "status":
         return StatusUpdate(record["state"])
     if kind == "session_started":
-        return SessionStarted("replay-session")
+        output_tokens = record.get("output_tokens", 0)
+        return SessionStarted(
+            "replay-session",
+            None if output_tokens is None else int(output_tokens),
+        )
     raise AssertionError(f"unknown recorded event kind: {kind}")
 
 
@@ -558,6 +562,7 @@ async def test_payload_tracing_records_sdk_events_for_replay(tmp_path: Path) -> 
         "usage",
         "run_complete",
     ]
+    assert events[0]["output_tokens"] == 0
     assert events[3]["text"] == "hello"
     assert events[5]["usage"]["completion_tokens"] == 2
     assert "session-secret" not in trace_path.read_text(encoding="utf-8")
@@ -2047,12 +2052,10 @@ async def test_invalid_tool_name_is_rejected_before_runner(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("field", ["max_tokens", "max_completion_tokens"])
-async def test_token_limit_fields_are_accepted_and_ignored(
+async def test_token_limit_fields_accept_short_completions(
     tmp_path: Path,
     field: str,
 ) -> None:
-    # Copilot, litellm and LangChain send these by default; rejecting them
-    # would break every one of those clients.
     runner = FakeRunner([TextDelta("Hi"), RunComplete(Usage())])
     payload = _payload(**{field: 5})
 
@@ -2982,16 +2985,20 @@ def _output_cap_runaway_argument() -> TextDelta:
     return TextDelta(f"{TOOL_CALL_OPEN}{head}{'x' * 60}")
 
 
+def _output_cap_events(*events: RunEvent, baseline: int | None = 0) -> list[RunEvent]:
+    return [SessionStarted("replay-session", baseline), *events]
+
+
 @pytest.mark.asyncio
 async def test_output_limit_caps_a_runaway_tool_argument(tmp_path: Path) -> None:
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = FakeRunner(
-        [
+        _output_cap_events(
             _output_cap_runaway_argument(),
             UsageUpdate(Usage(output_tokens=10)),
             UsageUpdate(Usage(output_tokens=45)),
-        ]
+        )
     )
     payload = _weather_payload(max_tokens=32)
 
@@ -3010,6 +3017,7 @@ async def test_output_limit_caps_a_runaway_tool_argument(tmp_path: Path) -> None
     assert truncated["reason"] == "output token limit reached"
     assert truncated["will_retry"] is False
     assert truncated["has_tool_calls"] is False
+    assert not any(record["event"] == "chat.empty_completion" for record in records)
     assert not any(record["event"] == "chat.retry" for record in records)
     assert not any(record["event"] == "chat.attempt_truncated" for record in records)
 
@@ -3032,6 +3040,28 @@ async def test_output_limit_text_fallback_caps_without_usage_events(
 
 
 @pytest.mark.asyncio
+async def test_output_limit_keeps_fallback_until_the_baseline_is_known(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner(
+        _output_cap_events(
+            UsageUpdate(Usage(output_tokens=5000)),
+            TextDelta("x" * 200),
+            baseline=None,
+        )
+    )
+    payload = _payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"] == "x" * 200
+
+
+@pytest.mark.asyncio
 async def test_output_limit_caps_reasoning_output(tmp_path: Path) -> None:
     runner = FakeRunner([ReasoningDelta("r" * 200)])
     payload = _payload(max_tokens=32)
@@ -3049,13 +3079,7 @@ async def test_output_limit_caps_reasoning_output(tmp_path: Path) -> None:
 async def test_output_limit_marks_a_turn_completed_past_the_limit(
     tmp_path: Path,
 ) -> None:
-    runner = FakeRunner(
-        [
-            TextDelta("Short answer"),
-            UsageUpdate(Usage(output_tokens=10)),
-            RunComplete(Usage(output_tokens=45)),
-        ]
-    )
+    runner = FakeRunner(_recorded_events("hello--gpt-5-4-mini.jsonl"))
     payload = _payload(max_tokens=32)
 
     async with _client(_app(tmp_path, runner)) as client:
@@ -3064,7 +3088,7 @@ async def test_output_limit_marks_a_turn_completed_past_the_limit(
     assert response.status_code == 200
     choice = response.json()["choices"][0]
     assert choice["finish_reason"] == "length"
-    assert choice["message"]["content"] == "Short answer"
+    assert choice["message"]["content"] == "OK"
 
 
 @pytest.mark.asyncio
@@ -3072,12 +3096,12 @@ async def test_output_limit_counts_turn_tokens_not_session_totals(
     tmp_path: Path,
 ) -> None:
     runner = FakeRunner(
-        [
-            UsageUpdate(Usage(output_tokens=5000)),
+        _output_cap_events(
             UsageUpdate(Usage(output_tokens=5008)),
             TextDelta("Direct answer"),
             RunComplete(Usage(output_tokens=5008)),
-        ]
+            baseline=5000,
+        )
     )
     payload = _payload(max_tokens=32)
 
@@ -3105,16 +3129,130 @@ async def test_output_limit_honors_max_completion_tokens(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_output_limit_prefers_max_completion_tokens(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("y" * 40), RunComplete(Usage())])
+    payload = _payload(max_tokens=8, max_completion_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"] == "y" * 40
+
+
+@pytest.mark.asyncio
+async def test_output_limit_real_usage_disables_text_fallback(tmp_path: Path) -> None:
+    runner = FakeRunner(_recorded_events("tool-result-followup--gpt-5-2.jsonl"))
+    payload = _payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert len(choice["message"]["content"]) == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_output_limit_uses_recorded_final_usage_without_updates(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    events: list[RunEvent] = [
+        event
+        for event in _recorded_events("hello--gpt-5-4-mini.jsonl")
+        if not isinstance(event, UsageUpdate)
+    ]
+    runner = FakeRunner(events)
+    payload = _payload(stream=stream, max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        assert '"finish_reason":"length"' in response.text
+        assert "factory_protocol_error" not in response.text
+    else:
+        choice = response.json()["choices"][0]
+        assert choice["finish_reason"] == "length"
+        assert choice["message"]["content"] == "OK"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_output_limit_drops_an_unclosed_complete_payload(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    partial = f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}'
+    runner = FakeRunner([TextDelta(partial)])
+    payload = _weather_payload(stream=stream, max_tokens=8)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        assert '"tool_calls"' not in response.text
+        assert '"finish_reason":"length"' in response.text
+    else:
+        choice = response.json()["choices"][0]
+        assert "tool_calls" not in choice["message"]
+        assert choice["finish_reason"] == "length"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_output_limit_skips_partial_structured_output_validation(
+    tmp_path: Path,
+    stream: bool,
+) -> None:
+    partial = '{"answer":"' + ("x" * 40)
+    runner = FakeRunner([TextDelta(partial)])
+    payload = _payload(
+        stream=stream,
+        max_tokens=8,
+        response_format={"type": "json_object"},
+    )
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    if stream:
+        chunks = [
+            json.loads(line.removeprefix("data: "))
+            for line in response.text.splitlines()
+            if line.startswith("data: {")
+        ]
+        content = "".join(
+            choice["delta"].get("content", "") for chunk in chunks for choice in chunk["choices"]
+        )
+        assert content == partial
+        assert '"finish_reason":"length"' in response.text
+        assert "factory_protocol_error" not in response.text
+    else:
+        choice = response.json()["choices"][0]
+        assert choice["message"]["content"] == partial
+        assert choice["finish_reason"] == "length"
+
+
+@pytest.mark.asyncio
 async def test_output_limit_after_a_complete_call_keeps_the_call(
     tmp_path: Path,
 ) -> None:
     call = f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}{TOOL_CALL_CLOSE}'
     runner = FakeRunner(
-        [
+        _output_cap_events(
             TextDelta(call),
             UsageUpdate(Usage(output_tokens=10)),
             UsageUpdate(Usage(output_tokens=50)),
-        ]
+        )
     )
     payload = _weather_payload(max_tokens=32)
 
@@ -3130,18 +3268,24 @@ async def test_output_limit_after_a_complete_call_keeps_the_call(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
 async def test_output_limit_required_tool_call_finishes_length(
     tmp_path: Path,
+    stream: bool,
 ) -> None:
     runner = FakeRunner([TextDelta("x" * 200)])
-    payload = _weather_payload(max_tokens=32, tool_choice="required")
+    payload = _weather_payload(stream=stream, max_tokens=32, tool_choice="required")
 
     async with _client(_app(tmp_path, runner)) as client:
         response = await client.post("/v1/chat/completions", json=payload)
 
     assert response.status_code == 200
-    choice = response.json()["choices"][0]
-    assert choice["finish_reason"] == "length"
+    if stream:
+        assert '"finish_reason":"length"' in response.text
+        assert "factory_protocol_error" not in response.text
+    else:
+        choice = response.json()["choices"][0]
+        assert choice["finish_reason"] == "length"
 
 
 @pytest.mark.asyncio
@@ -3151,11 +3295,11 @@ async def test_streaming_output_limit_caps_a_runaway_tool_argument(
     log_stream = io.StringIO()
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     runner = FakeRunner(
-        [
+        _output_cap_events(
             _output_cap_runaway_argument(),
             UsageUpdate(Usage(output_tokens=10)),
             UsageUpdate(Usage(output_tokens=45)),
-        ]
+        )
     )
     payload = _weather_payload(stream=True, max_tokens=32)
 
@@ -3192,13 +3336,7 @@ async def test_streaming_output_limit_text_fallback_finishes_length(
 async def test_streaming_output_limit_marks_a_turn_completed_past_the_limit(
     tmp_path: Path,
 ) -> None:
-    runner = FakeRunner(
-        [
-            TextDelta("Short answer"),
-            UsageUpdate(Usage(output_tokens=10)),
-            RunComplete(Usage(output_tokens=45)),
-        ]
-    )
+    runner = FakeRunner(_recorded_events("hello--gpt-5-4-mini.jsonl"))
     payload = _weather_payload(stream=True, max_tokens=32)
 
     async with _client(_app(tmp_path, runner)) as client:
@@ -3231,11 +3369,11 @@ async def test_streaming_output_limit_after_a_complete_call_keeps_the_call(
     logs.configure_logging(level="warning", log_format="json", stream=log_stream)
     call = f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}{TOOL_CALL_CLOSE}'
     runner = FakeRunner(
-        [
+        _output_cap_events(
             TextDelta(call),
             UsageUpdate(Usage(output_tokens=10)),
             UsageUpdate(Usage(output_tokens=50)),
-        ]
+        )
     )
     payload = _weather_payload(stream=True, max_tokens=32)
 
@@ -6146,6 +6284,28 @@ async def test_streaming_traffic_success_resets_the_probe(tmp_path: Path) -> Non
         response = await client.post("/v1/chat/completions", json=_payload(stream=True))
 
     assert response.status_code == 200
+    assert probe._consecutive_failures == 0
+    assert probe.status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_streaming_capped_content_resets_the_probe(tmp_path: Path) -> None:
+    app, _runner = _probe_app(
+        tmp_path,
+        events_fixture="hello--gpt-5-4-mini.jsonl",
+    )
+    probe = app.state.auth_probe
+    assert probe is not None
+    probe._consecutive_failures = 2
+
+    async with _client(app) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json=_payload(stream=True, max_tokens=32),
+        )
+
+    assert response.status_code == 200
+    assert '"finish_reason":"length"' in response.text
     assert probe._consecutive_failures == 0
     assert probe.status == "ok"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3207,6 +3207,25 @@ async def test_output_limit_drops_an_unclosed_complete_payload(
 
 
 @pytest.mark.asyncio
+async def test_output_limit_discards_a_deferred_transcript_error(tmp_path: Path) -> None:
+    prefix = 'safe answer (reset|", '
+    mangled = (
+        '"tool_calls":"id":"call_1","type":"function","function":'
+        '("name":"weather","arguments":("city":"Gdansk"))'
+    )
+    runner = FakeRunner([TextDelta(prefix + mangled)])
+    payload = _weather_payload(max_tokens=8)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["message"]["content"] == prefix
+    assert choice["finish_reason"] == "length"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("stream", [False, True])
 async def test_output_limit_skips_partial_structured_output_validation(
     tmp_path: Path,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2975,6 +2975,294 @@ async def test_non_streaming_retry_stays_bounded_when_tool_call_is_still_malform
     assert len(runner.requests) == 2
 
 
+def _output_cap_runaway_argument() -> TextDelta:
+    # Stays under the 4-chars-per-token text fallback so only the usage
+    # snapshots decide the cap.
+    head = '{"name":"weather","arguments":{"city":"'
+    return TextDelta(f"{TOOL_CALL_OPEN}{head}{'x' * 60}")
+
+
+@pytest.mark.asyncio
+async def test_output_limit_caps_a_runaway_tool_argument(tmp_path: Path) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = FakeRunner(
+        [
+            _output_cap_runaway_argument(),
+            UsageUpdate(Usage(output_tokens=10)),
+            UsageUpdate(Usage(output_tokens=45)),
+        ]
+    )
+    payload = _weather_payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert "tool_calls" not in choice["message"]
+    # The limit, not model misbehavior, ended the turn, so no retry burns a
+    # second capped attempt.
+    assert len(runner.requests) == 1
+    records = _warning_records(log_stream)
+    truncated = next(record for record in records if record["event"] == "chat.truncated")
+    assert truncated["reason"] == "output token limit reached"
+    assert truncated["will_retry"] is False
+    assert truncated["has_tool_calls"] is False
+    assert not any(record["event"] == "chat.retry" for record in records)
+    assert not any(record["event"] == "chat.attempt_truncated" for record in records)
+
+
+@pytest.mark.asyncio
+async def test_output_limit_text_fallback_caps_without_usage_events(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta("x" * 200)])
+    payload = _weather_payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"] == "x" * 200
+    assert len(runner.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_output_limit_caps_reasoning_output(tmp_path: Path) -> None:
+    runner = FakeRunner([ReasoningDelta("r" * 200)])
+    payload = _payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["reasoning"] == "r" * 200
+
+
+@pytest.mark.asyncio
+async def test_output_limit_marks_a_turn_completed_past_the_limit(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("Short answer"),
+            UsageUpdate(Usage(output_tokens=10)),
+            RunComplete(Usage(output_tokens=45)),
+        ]
+    )
+    payload = _payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"] == "Short answer"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_counts_turn_tokens_not_session_totals(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner(
+        [
+            UsageUpdate(Usage(output_tokens=5000)),
+            UsageUpdate(Usage(output_tokens=5008)),
+            TextDelta("Direct answer"),
+            RunComplete(Usage(output_tokens=5008)),
+        ]
+    )
+    payload = _payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"] == "Direct answer"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_honors_max_completion_tokens(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("y" * 200)])
+    payload = _payload(max_completion_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert choice["message"]["content"] == "y" * 200
+
+
+@pytest.mark.asyncio
+async def test_output_limit_after_a_complete_call_keeps_the_call(
+    tmp_path: Path,
+) -> None:
+    call = f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}{TOOL_CALL_CLOSE}'
+    runner = FakeRunner(
+        [
+            TextDelta(call),
+            UsageUpdate(Usage(output_tokens=10)),
+            UsageUpdate(Usage(output_tokens=50)),
+        ]
+    )
+    payload = _weather_payload(max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_calls = choice["message"]["tool_calls"]
+    assert tool_calls is not None
+    assert tool_calls[0]["function"]["name"] == "weather"
+
+
+@pytest.mark.asyncio
+async def test_output_limit_required_tool_call_finishes_length(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta("x" * 200)])
+    payload = _weather_payload(max_tokens=32, tool_choice="required")
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    choice = response.json()["choices"][0]
+    assert choice["finish_reason"] == "length"
+
+
+@pytest.mark.asyncio
+async def test_streaming_output_limit_caps_a_runaway_tool_argument(
+    tmp_path: Path,
+) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    runner = FakeRunner(
+        [
+            _output_cap_runaway_argument(),
+            UsageUpdate(Usage(output_tokens=10)),
+            UsageUpdate(Usage(output_tokens=45)),
+        ]
+    )
+    payload = _weather_payload(stream=True, max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert '"finish_reason":"length"' in response.text
+    assert "factory_protocol_error" not in response.text
+    # A capped stream is a truncated outcome, not an empty completion.
+    records = _warning_records(log_stream)
+    assert not any(record["event"] == "chat.empty_completion" for record in records)
+    truncated = next(record for record in records if record["event"] == "chat.truncated")
+    assert truncated["reason"] == "output token limit reached"
+
+
+@pytest.mark.asyncio
+async def test_streaming_output_limit_text_fallback_finishes_length(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner([TextDelta("z" * 200)])
+    payload = _weather_payload(stream=True, max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert "z" * 200 in response.text
+    assert '"finish_reason":"length"' in response.text
+    assert "factory_protocol_error" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_streaming_output_limit_marks_a_turn_completed_past_the_limit(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner(
+        [
+            TextDelta("Short answer"),
+            UsageUpdate(Usage(output_tokens=10)),
+            RunComplete(Usage(output_tokens=45)),
+        ]
+    )
+    payload = _weather_payload(stream=True, max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert '"finish_reason":"length"' in response.text
+    assert "factory_protocol_error" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_streaming_output_limit_caps_reasoning_output(tmp_path: Path) -> None:
+    runner = FakeRunner([ReasoningDelta("r" * 200)])
+    payload = _payload(stream=True, max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert "r" * 200 in response.text
+    assert '"finish_reason":"length"' in response.text
+    assert "factory_protocol_error" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_streaming_output_limit_after_a_complete_call_keeps_the_call(
+    tmp_path: Path,
+) -> None:
+    log_stream = io.StringIO()
+    logs.configure_logging(level="warning", log_format="json", stream=log_stream)
+    call = f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{}}}}{TOOL_CALL_CLOSE}'
+    runner = FakeRunner(
+        [
+            TextDelta(call),
+            UsageUpdate(Usage(output_tokens=10)),
+            UsageUpdate(Usage(output_tokens=50)),
+        ]
+    )
+    payload = _weather_payload(stream=True, max_tokens=32)
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 200
+    assert '"finish_reason":"tool_calls"' in response.text
+    assert "factory_protocol_error" not in response.text
+    records = _warning_records(log_stream)
+    truncated = next(record for record in records if record["event"] == "chat.attempt_truncated")
+    assert truncated["reason"] == "output token limit reached"
+    assert truncated["has_tool_calls"] is True
+
+
+@pytest.mark.asyncio
+async def test_required_tool_call_missing_at_finish_fails_closed(tmp_path: Path) -> None:
+    runner = FakeRunner([TextDelta("no call here"), RunComplete(Usage())])
+    payload = _weather_payload(tool_choice="required")
+
+    async with _client(_app(tmp_path, runner)) as client:
+        response = await client.post("/v1/chat/completions", json=payload)
+
+    assert response.status_code == 502
+    assert response.json()["error"]["type"] == "factory_protocol_error"
+
+
 @pytest.mark.asyncio
 async def test_retry_cleanup_wait_respects_expired_deadline() -> None:
     reaper = BackgroundReaper()

--- a/tests/test_auth_probe.py
+++ b/tests/test_auth_probe.py
@@ -52,7 +52,11 @@ def _recorded_event(record: dict[str, Any]) -> RunEvent:
     if kind == "status":
         return StatusUpdate(record["state"])
     if kind == "session_started":
-        return SessionStarted("replay-session")
+        output_tokens = record.get("output_tokens", 0)
+        return SessionStarted(
+            "replay-session",
+            None if output_tokens is None else int(output_tokens),
+        )
     raise AssertionError(f"unknown recorded event kind: {kind}")
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -949,6 +949,15 @@ def test_stream_parser_rejects_incomplete_transcript_message() -> None:
         parser.finish()
 
 
+def test_stream_parser_can_discard_an_incomplete_transcript_message() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    parser.feed('{"role":"assistant","tool_calls":')
+    parser.discard_partial_call()
+
+    assert parser.finish() == []
+
+
 def test_stream_parser_rejects_an_oversized_transcript_message() -> None:
     parser = ToolCallStreamParser(frozenset({"weather"}))
 
@@ -3309,6 +3318,15 @@ def test_stream_parser_recovers_tool_call_without_close_marker() -> None:
     assert len(emissions) == 1
     assert isinstance(emissions[0], ToolCallEmission)
     assert json.loads(emissions[0].arguments) == {"city": "Hel"}
+
+
+def test_stream_parser_can_discard_an_unclosed_call() -> None:
+    parser = ToolCallStreamParser(frozenset({"weather"}))
+
+    parser.feed(f'{TOOL_CALL_OPEN}{{"name":"weather","arguments":{{"city":"Hel"}}}}')
+    parser.discard_partial_call()
+
+    assert parser.finish() == []
 
 
 def test_stream_parser_recovers_tool_call_with_partial_close_marker() -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -92,7 +92,11 @@ def _event(record: dict[str, Any]) -> RunEvent:
     if kind == "status":
         return StatusUpdate(record["state"])
     if kind == "session_started":
-        return SessionStarted("replay-session")
+        output_tokens = record.get("output_tokens", 0)
+        return SessionStarted(
+            "replay-session",
+            None if output_tokens is None else int(output_tokens),
+        )
     raise AssertionError(f"unknown recorded event kind: {kind}")
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -82,6 +82,7 @@ class FakeClient:
         self.session_id = session_id
         self.loaded_session_id: str | None = None
         self.loaded_mcp_servers: list[dict[str, Any]] | None = None
+        self.loaded_token_usage: Any = None
         self.images: Any = None
         self.files: Any = None
         self.init_kwargs: dict[str, Any] = {}
@@ -109,10 +110,11 @@ class FakeClient:
         *,
         session_id: str,
         mcp_servers: list[dict[str, Any]] | None = None,
-    ) -> None:
+    ) -> Any:
         self.loaded_mcp_servers = mcp_servers
         self.loaded_session_id = session_id
         self.session_id = session_id
+        return SimpleNamespace(token_usage=self.loaded_token_usage)
 
     async def add_user_message(
         self,
@@ -927,6 +929,7 @@ async def test_runner_loads_existing_session_instead_of_initializing(
         cache_write_tokens=0,
     )
     client = FakeClient([TurnComplete(usage)])
+    client.loaded_token_usage = SimpleNamespace(output_tokens=41)
     runner = DroidRunner(
         droid_path="droid",
         workdir=tmp_path,
@@ -937,7 +940,7 @@ async def test_runner_loads_existing_session_instead_of_initializing(
 
     assert client.loaded_session_id == "session-42"
     assert client.init_kwargs == {}
-    assert events[0] == SessionStarted("session-42")
+    assert events[0] == SessionStarted("session-42", output_tokens=41)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #130.

`max_tokens` / `max_completion_tokens` were accepted but ignored, so a native-dialect turn asked for 32 output tokens could generate a 16k-token tool-call argument: the bridge kept reading until the stream died mid-argument, the fresh-session retry regenerated the same monster, and 78 of 81 capped-then-retried operations died for good, burning up to 850s each.

Now `OutputTokenCap` enforces the limit on both transports. Droid reports session-cumulative usage counters, so the first snapshot of a turn sets the baseline and the cap watches the delta, which keeps pooled or continued sessions from firing on their earlier turns. Models that report no usage mid-turn get a coarse text-length fallback of roughly four characters per token instead of running free. When the cap hits, the bridge stops reading the session stream (closing the runner generator interrupts the Droid turn, same as a stop sequence) and returns the completion with `finish_reason="length"`; a partial tool call is dropped, never executed.

A capped turn is never retried server-side, because the limit, not model misbehavior, ended the turn, so a second attempt would just regenerate the same capped output. The client can retry or split the request itself. A capped stream counts as a truncated outcome, not an empty completion, and a required-tool-call complaint no longer turns a limit-cut stream or completion into a 502. `max_completion_tokens` wins when both fields are set, matching the OpenAI field that supersedes the deprecated `max_tokens`.

`openapi.json` is unchanged because both request fields were already part of the schema; only their runtime handling changed. README moved output token limits from the ignored table to enforced and documents the counting semantics.

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run openapi-spec-validator openapi.json`
- [x] `uv run pytest --cov=factory_droid_openai --cov-report=term-missing` (1896 passed, 100% branch coverage)
- [x] `uv build`
- [x] `prs validate && prs diff --all --no-color && prs check`

## Security and compatibility

- [x] No credentials, private prompt data, or generated build artifacts committed.
- [x] OpenAI response shapes remain compatible in streaming and non-streaming modes.
- [x] Factory-native tools remain blocked.
- [x] Documentation and tests cover user-visible behavior changes.
- [x] Behavior found against a live model is frozen as a replay fixture in
      `tests/fixtures/events/`, or the reason it cannot be is stated above.
      Not frozen here: the #130 evidence is a log excerpt, not a `droid.event`
      capture, and the cap behavior is deterministic given synthetic event
      sequences, so the regression tests use FakeRunner events with usage
      snapshots instead of a recorded runaway payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced `max_tokens` and `max_completion_tokens` for streaming and non-streaming completions.
  * Capped responses end with `finish_reason="length"`, including during tool calls.
  * Complete tool calls are preserved when output limits are reached.
  * Usage-based limits now account for cumulative session usage and safely handle unavailable usage data.

* **Bug Fixes**
  * Prevented capped completions from being retried or reported as protocol errors.
  * Discarded incomplete tool-call data when output is capped.
  * Updated documentation to clarify token-limit behavior and supported options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->